### PR TITLE
feat: agent description editing, session soft-delete, and invocation detail improvements

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -91,6 +91,8 @@ def _migrate_add_columns(eng) -> None:
         ("invocations", "cost_source", "VARCHAR"),
         ("invocations", "request_id", "VARCHAR"),
         ("invocation_sessions", "user_id", "VARCHAR"),
+        ("invocation_sessions", "hidden_at", "DATETIME"),
+        ("agents", "description", "TEXT"),
     ]
 
     for table, column, col_type in migrations:

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -42,6 +42,7 @@ class Agent(Base):
     protocol = Column(String, nullable=True)  # HTTP, MCP, A2A
     network_mode = Column(String, nullable=True)  # PUBLIC or VPC
     authorizer_config = Column(Text, nullable=True)  # JSON: {type, pool_id, discovery_url, client_id, client_secret}
+    description = Column(Text, nullable=True)  # Human-readable description of the agent
     tags = Column(Text, nullable=True)  # JSON dict of resolved tags
     deployed_at = Column(DateTime, nullable=True)
     registered_at = Column(DateTime, nullable=False, default=datetime.utcnow)
@@ -112,6 +113,7 @@ class Agent(Base):
             "arn": self.arn,
             "runtime_id": self.runtime_id,
             "name": self.name,
+            "description": self.description,
             "status": self.status,
             "region": self.region,
             "account_id": self.account_id,

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -19,6 +19,7 @@ class InvocationSession(Base):
     status = Column(String, nullable=False, default="pending")  # pending, streaming, complete, error
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow, index=True)
     user_id = Column(String, nullable=True, index=True)
+    hidden_at = Column(DateTime, nullable=True)  # Set when user hides the session from their view
 
     # Relationships
     agent = relationship("Agent", back_populates="sessions")
@@ -33,5 +34,6 @@ class InvocationSession(Base):
             "status": self.status,
             "created_at": (self.created_at.isoformat() + "Z") if self.created_at else None,
             "user_id": self.user_id,
+            "hidden_at": (self.hidden_at.isoformat() + "Z") if self.hidden_at else None,
             "invocations": [inv.to_dict() for inv in self.invocations] if self.invocations else [],
         }

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -151,6 +151,7 @@ class AgentResponse(BaseModel):
     arn: str
     runtime_id: str
     name: str | None
+    description: str | None = None
     status: str | None
     region: str
     account_id: str
@@ -193,6 +194,11 @@ class ConfigEntryResponse(BaseModel):
 class ConfigUpdateRequest(BaseModel):
     """Request body for updating agent config entries."""
     config: dict[str, str] = Field(..., description="Key-value pairs to set")
+
+
+class AgentUpdateRequest(BaseModel):
+    """Request body for patching editable agent fields."""
+    description: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -717,6 +723,7 @@ def _deploy_agent(request: AgentCreateRequest, db: Session, background_tasks: Ba
         arn=placeholder_arn,
         runtime_id="",
         name=request.name,
+        description=request.description or None,
         status="CREATING",
         region=region,
         account_id=account_id,
@@ -1509,6 +1516,22 @@ def get_agent_config(agent_id: int, user: UserInfo = Depends(require_scopes("age
             d["value"] = "********"
         result.append(ConfigEntryResponse(**d))
     return result
+
+
+@router.patch("/{agent_id}", response_model=AgentResponse)
+def patch_agent(
+    agent_id: int,
+    request: AgentUpdateRequest,
+    user: UserInfo = Depends(require_scopes("agent:write")),
+    db: Session = Depends(get_db),
+) -> AgentResponse:
+    """Update editable fields on an agent (e.g. description)."""
+    agent = get_agent_or_404(agent_id, db)
+    if "description" in request.model_fields_set:
+        agent.description = request.description
+    db.commit()
+    db.refresh(agent)
+    return _agent_response(agent, db)
 
 
 @router.put("/{agent_id}/config", response_model=list[ConfigEntryResponse])

--- a/backend/app/routers/invocations.py
+++ b/backend/app/routers/invocations.py
@@ -94,6 +94,7 @@ class SessionResponse(BaseModel):
     live_status: str
     created_at: str | None
     user_id: str | None = None
+    hidden_at: str | None = None
     invocations: List[InvocationResponse]
 
 
@@ -973,7 +974,8 @@ def list_sessions(
         )
 
     sessions = db.query(InvocationSession).filter(
-        InvocationSession.agent_id == agent_id
+        InvocationSession.agent_id == agent_id,
+        InvocationSession.hidden_at.is_(None),
     ).order_by(InvocationSession.created_at.desc()).all()
 
     from app.routers.settings import get_cpu_io_wait_discount
@@ -1015,6 +1017,39 @@ def get_session(
     sdict = session.to_dict()
     sdict["invocations"] = [_apply_view_time_costs(inv, io_discount) for inv in sdict.get("invocations", [])]
     return SessionResponse(**sdict, live_status=live_status)
+
+
+@router.delete("/{agent_id}/sessions/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+def hide_session(
+    agent_id: int,
+    session_id: str,
+    user: UserInfo = Depends(require_scopes("invoke")),
+    db: Session = Depends(get_db),
+) -> None:
+    """Hide a session from the user's conversation history (soft delete).
+
+    Sets hidden_at on the session record — no data is removed. The session
+    remains visible to admins and continues to contribute to cost reporting.
+    Only the session owner may hide their own sessions.
+    """
+    session = db.query(InvocationSession).filter(
+        InvocationSession.agent_id == agent_id,
+        InvocationSession.session_id == session_id,
+    ).first()
+
+    if not session:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Session not found")
+
+    # Ownership check — users may only hide their own sessions
+    if session.user_id != (user.username or user.sub):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You can only remove your own conversations")
+
+    # Only allow hiding completed sessions
+    if session.status in ("pending", "streaming"):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Cannot remove an active session")
+
+    session.hidden_at = datetime.utcnow()
+    db.commit()
 
 
 @router.get("/{agent_id}/sessions/{session_id}/invocations/{invocation_id}", response_model=InvocationResponse)

--- a/backend/app/routers/memories.py
+++ b/backend/app/routers/memories.py
@@ -24,6 +24,7 @@ from app.services.memory import (
     get_memory as svc_get_memory,
     list_memories as svc_list_memories,
     delete_memory as svc_delete_memory,
+    list_memory_records as svc_list_memory_records,
 )
 
 logger = logging.getLogger(__name__)
@@ -67,6 +68,22 @@ class MemoryCreateRequest(BaseModel):
 class MemoryImportRequest(BaseModel):
     """Request body for importing an existing memory resource by its AWS memory ID."""
     memory_id: str = Field(..., description="AWS memory ID (e.g. my_memory-zYcvlyGXsK)")
+
+
+class MemoryRecordItem(BaseModel):
+    """A single stored memory record for a user."""
+    memoryRecordId: str
+    text: str
+    memoryStrategyId: str
+    createdAt: str
+    updatedAt: str
+
+
+class MemoryRecordsResponse(BaseModel):
+    """Response model for a user's memory records within a memory resource."""
+    memory_id: str
+    actor_id: str
+    records: list[MemoryRecordItem]
 
 
 class MemoryResponse(BaseModel):
@@ -585,3 +602,54 @@ def purge_memory(memory_id: int, user: UserInfo = Depends(require_scopes("memory
         )
     db.delete(memory)
     db.commit()
+
+
+@router.get("/{memory_id}/records", response_model=MemoryRecordsResponse)
+def get_memory_records(
+    memory_id: int,
+    user: UserInfo = Depends(require_scopes("memory:read")),
+    db: Session = Depends(get_db),
+) -> MemoryRecordsResponse:
+    """
+    Retrieve stored memory records for the authenticated user within a memory resource.
+
+    Records are scoped to the requesting user's username (from JWT) as the actorId.
+    Users cannot access records belonging to other actors.
+    """
+    memory = db.query(Memory).filter(Memory.id == memory_id).first()
+    if not memory:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Memory with id {memory_id} not found",
+        )
+    if not memory.memory_id:
+        return MemoryRecordsResponse(memory_id="", actor_id=user.username, records=[])
+
+    actor_id = user.username
+    try:
+        raw_records = svc_list_memory_records(
+            memory_id=memory.memory_id,
+            actor_id=actor_id,
+            region=memory.region,
+        )
+    except Exception as e:
+        logger.warning("Failed to list memory records for memory_id=%s actor=%s: %s", memory.memory_id, actor_id, e)
+        return MemoryRecordsResponse(memory_id=memory.memory_id, actor_id=actor_id, records=[])
+
+    records = [
+        MemoryRecordItem(
+            memoryRecordId=r["memoryRecordId"],
+            text=r["text"],
+            memoryStrategyId=r["memoryStrategyId"],
+            createdAt=str(r["createdAt"]),
+            updatedAt=str(r["updatedAt"]),
+        )
+        for r in raw_records
+        if r.get("text")
+    ]
+
+    return MemoryRecordsResponse(
+        memory_id=memory.memory_id,
+        actor_id=actor_id,
+        records=records,
+    )

--- a/backend/app/services/memory.py
+++ b/backend/app/services/memory.py
@@ -102,6 +102,63 @@ def list_memories(region: str = "us-east-1") -> dict[str, Any]:
     return response
 
 
+def list_memory_records(
+    memory_id: str,
+    actor_id: str,
+    max_records: int = 100,
+    region: str = "us-east-1",
+) -> list[dict[str, Any]]:
+    """
+    List stored memory records for a specific actor (user) within a memory resource.
+
+    Paginates automatically and returns up to max_records results.
+
+    Args:
+        memory_id: The AWS memory resource ID (e.g. my_memory-zYcvlyGXsK)
+        actor_id: The actor identifier to scope the query (Cognito username)
+        max_records: Maximum total records to return across all pages
+        region: AWS region name
+
+    Returns:
+        List of memory record dicts with keys:
+        memoryRecordId, content (text), memoryStrategyId, createdAt, updatedAt
+    """
+    import boto3
+
+    client = boto3.client("bedrock-agentcore-control", region_name=region)
+
+    records: list[dict[str, Any]] = []
+    next_token: str | None = None
+
+    while len(records) < max_records:
+        params: dict[str, Any] = {
+            "memoryId": memory_id,
+            "actorId": actor_id,
+            "maxResults": min(max_records - len(records), 50),
+        }
+        if next_token:
+            params["nextToken"] = next_token
+
+        response = client.list_memory_records(**params)
+
+        for raw in response.get("memoryRecords", []):
+            content = raw.get("content", {})
+            text = content.get("text", "") if isinstance(content, dict) else str(content)
+            records.append({
+                "memoryRecordId": raw.get("memoryRecordId", ""),
+                "text": text,
+                "memoryStrategyId": raw.get("memoryStrategyId", ""),
+                "createdAt": raw.get("createdAt", ""),
+                "updatedAt": raw.get("updatedAt", ""),
+            })
+
+        next_token = response.get("nextToken")
+        if not next_token:
+            break
+
+    return records
+
+
 def delete_memory(memory_id: str, region: str = "us-east-1") -> dict[str, Any]:
     """
     Delete an AgentCore Memory resource.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -258,7 +258,7 @@ function AppContent() {
       ? `demo-user-${_demoAdminMatch[1]}`
       : undefined;
 
-  const { agents, loading, deleteStartTimes, fetchAgents, registerAgent, deployAgent, redeployAgent, refreshAgent, deleteAgent } = useAgents();
+  const { agents, loading, deleteStartTimes, fetchAgents, registerAgent, deployAgent, redeployAgent, refreshAgent, patchAgent, deleteAgent } = useAgents();
 
   // Re-fetch agents after authentication completes and when navigating to agent tabs
   useEffect(() => {
@@ -649,6 +649,7 @@ function AppContent() {
                     if (user && browserSessionId) trackAction(user.username ?? user.sub, browserSessionId, 'agent', 'redeploy', agentName);
                     await redeployAgent(id);
                   }}
+                  onPatchAgent={patchAgent}
                   canInvoke={effectiveHasScope("invoke")}
                   userGroups={viewAsUser ? (USER_GROUPS[viewAsUser] ?? []) : (user?.groups ?? [])}
                 />

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -79,6 +79,16 @@ export function updateAgentConfig(
   });
 }
 
+export function patchAgent(
+  id: number,
+  updates: { description?: string | null },
+): Promise<AgentResponse> {
+  return apiFetch<AgentResponse>(`/api/agents/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(updates),
+  });
+}
+
 export function fetchRoles(): Promise<IamRole[]> {
   return apiFetch<IamRole[]>("/api/agents/roles");
 }

--- a/frontend/src/api/invocations.ts
+++ b/frontend/src/api/invocations.ts
@@ -32,6 +32,12 @@ export function getSession(
   );
 }
 
+export function hideSession(agentId: number, sessionId: string): Promise<void> {
+  return apiFetch<void>(`/api/agents/${agentId}/sessions/${sessionId}`, {
+    method: "DELETE",
+  });
+}
+
 export interface StreamCallbacks {
   onSessionStart?: (data: SSESessionStart) => void;
   onChunk?: (data: SSEChunk) => void;

--- a/frontend/src/api/memories.ts
+++ b/frontend/src/api/memories.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from "./client";
-import type { MemoryCreateRequest, MemoryResponse } from "./types";
+import type { MemoryCreateRequest, MemoryResponse, MemoryRecordsResponse } from "./types";
 
 export function createMemory(request: MemoryCreateRequest): Promise<MemoryResponse> {
   return apiFetch<MemoryResponse>("/api/memories", {
@@ -41,4 +41,8 @@ export function purgeMemory(id: number): Promise<void> {
   return apiFetch<void>(`/api/memories/${id}/purge`, {
     method: "DELETE",
   });
+}
+
+export function getMemoryRecords(id: number): Promise<MemoryRecordsResponse> {
+  return apiFetch<MemoryRecordsResponse>(`/api/memories/${id}/records`);
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -4,6 +4,7 @@ export interface AgentResponse {
   arn: string;
   runtime_id: string;
   name: string | null;
+  description: string | null;
   status: string | null;
   region: string;
   account_id: string;
@@ -210,6 +211,7 @@ export interface SessionResponse {
   live_status: string;
   created_at: string | null;
   user_id: string | null;
+  hidden_at: string | null;
   invocations: InvocationResponse[];
 }
 
@@ -447,6 +449,20 @@ export interface MemoryResponse {
     total_retrievals: number;
     total_events_sent: number;
   } | null;
+}
+
+export interface MemoryRecordItem {
+  memoryRecordId: string;
+  text: string;
+  memoryStrategyId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MemoryRecordsResponse {
+  memory_id: string;
+  actor_id: string;
+  records: MemoryRecordItem[];
 }
 
 // SSE event types

--- a/frontend/src/hooks/useAgents.ts
+++ b/frontend/src/hooks/useAgents.ts
@@ -157,6 +157,15 @@ export function useAgents() {
     [fetchAgents],
   );
 
+  const patchAgent = useCallback(
+    async (id: number, updates: { description?: string | null }) => {
+      const agent = await agentsApi.patchAgent(id, updates);
+      setAgents((prev) => prev.map((a) => (a.id === id ? agent : a)));
+      return agent;
+    },
+    [],
+  );
+
   const deleteAgent = useCallback(
     async (id: number, cleanupAws: boolean = false) => {
       const updated = await agentsApi.deleteAgent(id, cleanupAws);
@@ -174,5 +183,5 @@ export function useAgents() {
     [],
   );
 
-  return { agents, loading, error, deleteStartTimes, fetchAgents, registerAgent, deployAgent, redeployAgent, refreshAgent, deleteAgent };
+  return { agents, loading, error, deleteStartTimes, fetchAgents, registerAgent, deployAgent, redeployAgent, refreshAgent, patchAgent, deleteAgent };
 }

--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -33,6 +33,8 @@ import {
   trackAction,
 } from "@/api/audit";
 import { useAuth } from "@/contexts/AuthContext";
+import { useTimezone } from "@/contexts/TimezoneContext";
+import { formatTimestamp as fmtTs } from "@/lib/format";
 import type {
   AuditSummary,
   AuditSession,
@@ -43,19 +45,21 @@ import type {
 
 type TimeRange = "today" | "7d" | "30d" | "all";
 
-function getDateRange(range: TimeRange): { start?: string; end?: string } {
+function getDateRange(range: TimeRange, useUtc: boolean): { start?: string; end?: string } {
   if (range === "all") return {};
   const now = new Date();
-  const todayDate = now.toISOString().slice(0, 10);
+  // "sv" locale produces ISO-style "YYYY-MM-DD" in the requested timezone
+  const todayDate = useUtc
+    ? now.toISOString().slice(0, 10)
+    : now.toLocaleDateString("sv");
   const end = `${todayDate}T23:59:59`;
   if (range === "today") return { start: todayDate, end };
   const days = range === "7d" ? 7 : 30;
   const startDate = new Date(now.getTime() - days * 86400000);
-  return { start: startDate.toISOString().slice(0, 10), end };
-}
-
-function formatTimestamp(ts: string): string {
-  return new Date(ts).toLocaleString();
+  const startStr = useUtc
+    ? startDate.toISOString().slice(0, 10)
+    : startDate.toLocaleDateString("sv");
+  return { start: startStr, end };
 }
 
 function formatDuration(seconds: number | null): string {
@@ -76,6 +80,8 @@ function getPageNumbers(current: number, total: number): (number | null)[] {
 
 export function AdminDashboardPage() {
   const { user, browserSessionId } = useAuth();
+  const { timezone } = useTimezone();
+  const useUtc = timezone === "UTC";
   const [timeRange, setTimeRange] = useState<TimeRange>("7d");
   const [summary, setSummary] = useState<AuditSummary | null>(null);
   const [sessions, setSessions] = useState<AuditSession[]>([]);
@@ -109,7 +115,7 @@ export function AdminDashboardPage() {
 
   const loadData = useCallback(async () => {
     setLoading(true);
-    const params = getDateRange(timeRange);
+    const params = getDateRange(timeRange, useUtc);
     try {
       const [s, sess, act, pv] = await Promise.all([
         fetchAuditSummary(params),
@@ -129,7 +135,7 @@ export function AdminDashboardPage() {
     } finally {
       setLoading(false);
     }
-  }, [timeRange]);
+  }, [timeRange, useUtc]);
 
   useEffect(() => {
     void loadData();
@@ -477,7 +483,7 @@ export function AdminDashboardPage() {
                             Session {selectedSession.browser_session_id}
                           </h3>
                           <p className="text-xs text-muted-foreground">
-                            User: {selectedSession.user_id} | Login: {formatTimestamp(selectedSession.logged_in_at)}
+                            User: {selectedSession.user_id} | Login: {fmtTs(selectedSession.logged_in_at, timezone)}
                           </p>
                         </div>
                         <button
@@ -528,9 +534,9 @@ export function AdminDashboardPage() {
                                           ? String(evt.detail.page_name ?? "")
                                           : "Logged in"}
                                     </TableCell>
-                                    <TableCell className="text-xs font-mono">{formatTimestamp(evt.timestamp)}</TableCell>
+                                    <TableCell className="text-xs font-mono">{fmtTs(evt.timestamp, timezone)}</TableCell>
                                     <TableCell className="text-xs font-mono">
-                                      {exitedAt ? formatTimestamp(exitedAt) : "-"}
+                                      {exitedAt ? fmtTs(exitedAt, timezone) : "-"}
                                     </TableCell>
                                     <TableCell className="text-xs font-mono">
                                       {evt.type === "page_view" && evt.detail.duration_seconds != null
@@ -583,9 +589,9 @@ export function AdminDashboardPage() {
                             >
                               <TableCell className="text-xs font-mono">{s.browser_session_id}</TableCell>
                               <TableCell className="text-xs">{s.user_id}</TableCell>
-                              <TableCell className="text-xs font-mono">{formatTimestamp(s.logged_in_at)}</TableCell>
+                              <TableCell className="text-xs font-mono">{fmtTs(s.logged_in_at, timezone)}</TableCell>
                               <TableCell className="text-xs font-mono">
-                                {s.last_activity_at ? formatTimestamp(s.last_activity_at) : "-"}
+                                {s.last_activity_at ? fmtTs(s.last_activity_at, timezone) : "-"}
                               </TableCell>
                               <TableCell className="text-xs text-right font-mono">{s.page_view_count}</TableCell>
                               <TableCell className="text-xs text-right font-mono">{s.action_count}</TableCell>
@@ -685,7 +691,7 @@ export function AdminDashboardPage() {
                               <TableCell className="text-xs">{a.action_type}</TableCell>
                               <TableCell className="text-xs">{a.user_id}</TableCell>
                               <TableCell className="text-xs text-muted-foreground">{a.resource_name ?? "-"}</TableCell>
-                              <TableCell className="text-xs font-mono">{formatTimestamp(a.performed_at)}</TableCell>
+                              <TableCell className="text-xs font-mono">{fmtTs(a.performed_at, timezone)}</TableCell>
                             </TableRow>
                           ))}
                         </TableBody>
@@ -764,10 +770,10 @@ export function AdminDashboardPage() {
                               <TableCell className="text-xs font-mono">{p.browser_session_id}</TableCell>
                               <TableCell className="text-xs">{p.page_name}</TableCell>
                               <TableCell className="text-xs">{p.user_id}</TableCell>
-                              <TableCell className="text-xs font-mono">{formatTimestamp(p.entered_at)}</TableCell>
+                              <TableCell className="text-xs font-mono">{fmtTs(p.entered_at, timezone)}</TableCell>
                               <TableCell className="text-xs font-mono">
                                 {p.duration_seconds != null
-                                  ? formatTimestamp(new Date(new Date(p.entered_at).getTime() + p.duration_seconds * 1000).toISOString())
+                                  ? fmtTs(new Date(new Date(p.entered_at).getTime() + p.duration_seconds * 1000).toISOString(), timezone)
                                   : "-"}
                               </TableCell>
                               <TableCell className="text-xs font-mono">{formatDuration(p.duration_seconds)}</TableCell>

--- a/frontend/src/pages/AgentDetailPage.tsx
+++ b/frontend/src/pages/AgentDetailPage.tsx
@@ -1,7 +1,13 @@
+import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { Key } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Key, Pencil, Check, X } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import { CollapsibleJsonBlock } from "@/components/CollapsibleJsonBlock";
+import remarkGfm from "remark-gfm";
 import { InvokePanel } from "@/components/InvokePanel";
 import { LatencySummary } from "@/components/LatencySummary";
 import { SessionTable } from "@/components/SessionTable";
@@ -18,6 +24,7 @@ interface AgentDetailPageProps {
   onSelectSession: (sessionId: string) => void;
   onSessionsRefresh: () => void;
   onRedeploy?: (id: number) => Promise<void>;
+  onPatchAgent?: (id: number, updates: { description?: string | null }) => Promise<AgentResponse>;
   canInvoke?: boolean;
   userGroups?: string[];
 }
@@ -29,9 +36,34 @@ export function AgentDetailPage({
   onSelectSession,
   onSessionsRefresh,
   onRedeploy,
+  onPatchAgent,
   canInvoke = true,
   userGroups = [],
 }: AgentDetailPageProps) {
+  const [editingDescription, setEditingDescription] = useState(false);
+  const [descriptionDraft, setDescriptionDraft] = useState("");
+  const [savingDescription, setSavingDescription] = useState(false);
+
+  const handleEditDescription = () => {
+    setDescriptionDraft(agent.description ?? "");
+    setEditingDescription(true);
+  };
+
+  const handleSaveDescription = async () => {
+    if (!onPatchAgent) return;
+    setSavingDescription(true);
+    try {
+      await onPatchAgent(agent.id, { description: descriptionDraft.trim() || null });
+      setEditingDescription(false);
+    } finally {
+      setSavingDescription(false);
+    }
+  };
+
+  const handleCancelDescription = () => {
+    setEditingDescription(false);
+  };
+
   // Check if user can invoke this specific agent based on group tags
   const agentGroup = agent.tags?.["loom:group"] || "";
   const isSuperAdmin = userGroups.includes("g-admins-super");
@@ -68,6 +100,47 @@ export function AgentDetailPage({
 
   return (
     <div className="space-y-4">
+      {/* Description */}
+      <Card>
+        <CardHeader className="pb-0">
+          <div className="flex items-center gap-2">
+            <CardTitle className="text-sm font-medium">Description</CardTitle>
+            {!editingDescription && onPatchAgent && (
+              <Button variant="ghost" size="icon" className="h-6 w-6" onClick={handleEditDescription}>
+                <Pencil className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent className="pt-2">
+          {editingDescription ? (
+            <div className="space-y-2">
+              <Textarea
+                value={descriptionDraft}
+                onChange={(e) => setDescriptionDraft(e.target.value)}
+                placeholder="Describe what this agent does..."
+                className="text-sm resize-none"
+                rows={3}
+              />
+              <div className="flex gap-2">
+                <Button size="sm" onClick={() => void handleSaveDescription()} disabled={savingDescription}>
+                  <Check className="h-3.5 w-3.5 mr-1" />
+                  Save
+                </Button>
+                <Button size="sm" variant="ghost" onClick={handleCancelDescription} disabled={savingDescription}>
+                  <X className="h-3.5 w-3.5 mr-1" />
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {agent.description ?? <span className="italic">No description set.</span>}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
       {/* Sessions — full width across top */}
       <section>
         <SessionTable
@@ -157,8 +230,57 @@ export function AgentDetailPage({
             </div>
           </CardHeader>
           <CardContent>
-            <div className="rounded border bg-input-bg p-4 whitespace-pre-wrap text-sm font-mono">
-              {streamedText}
+            <div className="rounded border bg-input-bg p-4 text-sm">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+                  h1: ({ children }) => <h1 className="text-base font-bold mb-2 mt-3 first:mt-0">{children}</h1>,
+                  h2: ({ children }) => <h2 className="text-sm font-bold mb-2 mt-3 first:mt-0">{children}</h2>,
+                  h3: ({ children }) => <h3 className="text-sm font-semibold mb-1 mt-2 first:mt-0">{children}</h3>,
+                  ul: ({ children }) => <ul className="list-disc pl-4 mb-2 space-y-0.5">{children}</ul>,
+                  ol: ({ children }) => <ol className="list-decimal pl-4 mb-2 space-y-0.5">{children}</ol>,
+                  li: ({ children }) => <li className="leading-snug">{children}</li>,
+                  pre: ({ children }) => {
+                    const codeClass = (children as { props?: { className?: string } } | null)?.props?.className ?? '';
+                    if (codeClass.includes('language-json')) {
+                      return <CollapsibleJsonBlock>{children}</CollapsibleJsonBlock>;
+                    }
+                    return (
+                      <pre className="mb-2 overflow-x-auto rounded bg-black/10 dark:bg-white/10 p-3 text-xs font-mono">{children}</pre>
+                    );
+                  },
+                  code: ({ className, children }) =>
+                    className?.startsWith("language-") ? (
+                      <code className={className}>{children}</code>
+                    ) : (
+                      <code className="rounded bg-black/10 dark:bg-white/10 px-1 py-0.5 text-xs font-mono">{children}</code>
+                    ),
+                  blockquote: ({ children }) => (
+                    <blockquote className="border-l-2 border-muted-foreground/30 pl-3 italic text-muted-foreground mb-2">{children}</blockquote>
+                  ),
+                  table: ({ children }) => (
+                    <div className="overflow-x-auto mb-2">
+                      <table className="border-collapse text-xs w-full">{children}</table>
+                    </div>
+                  ),
+                  thead: ({ children }) => <thead>{children}</thead>,
+                  tbody: ({ children }) => <tbody>{children}</tbody>,
+                  tr: ({ children }) => <tr>{children}</tr>,
+                  th: ({ children }) => (
+                    <th className="border border-border px-2 py-1 text-left font-semibold bg-muted/50">{children}</th>
+                  ),
+                  td: ({ children }) => (
+                    <td className="border border-border px-2 py-1">{children}</td>
+                  ),
+                  strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+                  a: ({ href, children }) => (
+                    <a href={href} className="underline underline-offset-2 hover:opacity-80" target="_blank" rel="noopener noreferrer">{children}</a>
+                  ),
+                }}
+              >
+                {streamedText}
+              </ReactMarkdown>
               {isStreaming && (
                 <span className="inline-block w-1.5 h-4 bg-foreground/70 animate-pulse ml-0.5 align-text-bottom" />
               )}

--- a/frontend/src/pages/InvocationDetailPage.tsx
+++ b/frontend/src/pages/InvocationDetailPage.tsx
@@ -3,6 +3,9 @@ import { Badge } from "@/components/ui/badge";
 import { useTimezone } from "@/contexts/TimezoneContext";
 import { formatTimestamp, formatMs } from "@/lib/format";
 import type { AgentResponse, SessionResponse, InvocationResponse } from "@/api/types";
+import ReactMarkdown from "react-markdown";
+import { CollapsibleJsonBlock } from "@/components/CollapsibleJsonBlock";
+import remarkGfm from "remark-gfm";
 
 interface InvocationDetailPageProps {
   agent: AgentResponse;
@@ -44,7 +47,7 @@ function CostRow({ label, value }: { label: string; value: string }) {
   );
 }
 
-export function InvocationDetailPage({ agent, session, invocation }: InvocationDetailPageProps) {
+export function InvocationDetailPage({ invocation }: InvocationDetailPageProps) {
   const { timezone } = useTimezone();
 
   const rtCpu = invocation.compute_cpu_cost ?? 0;
@@ -95,9 +98,64 @@ export function InvocationDetailPage({ agent, session, invocation }: InvocationD
               <CardTitle className="text-sm font-medium">Prompt</CardTitle>
             </CardHeader>
             <CardContent>
-              <pre className="bg-input-bg rounded-md p-4 text-sm font-mono whitespace-pre-wrap overflow-x-auto">
-                {invocation.prompt_text ?? "Not captured"}
-              </pre>
+              {invocation.prompt_text ? (
+                <div className="rounded border bg-input-bg p-4 text-sm">
+                  <ReactMarkdown
+                    remarkPlugins={[remarkGfm]}
+                    components={{
+                      p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+                      h1: ({ children }) => <h1 className="text-base font-bold mb-2 mt-3 first:mt-0">{children}</h1>,
+                      h2: ({ children }) => <h2 className="text-sm font-bold mb-2 mt-3 first:mt-0">{children}</h2>,
+                      h3: ({ children }) => <h3 className="text-sm font-semibold mb-1 mt-2 first:mt-0">{children}</h3>,
+                      ul: ({ children }) => <ul className="list-disc pl-4 mb-2 space-y-0.5">{children}</ul>,
+                      ol: ({ children }) => <ol className="list-decimal pl-4 mb-2 space-y-0.5">{children}</ol>,
+                      li: ({ children }) => <li className="leading-snug">{children}</li>,
+                      pre: ({ children }) => {
+                        const codeClass = (children as { props?: { className?: string } } | null)?.props?.className ?? '';
+                        if (codeClass.includes('language-json')) {
+                          return <CollapsibleJsonBlock>{children}</CollapsibleJsonBlock>;
+                        }
+                        return (
+                          <pre className="mb-2 overflow-x-auto rounded bg-black/10 dark:bg-white/10 p-3 text-xs font-mono">{children}</pre>
+                        );
+                      },
+                      code: ({ className, children }) =>
+                        className?.startsWith("language-") ? (
+                          <code className={className}>{children}</code>
+                        ) : (
+                          <code className="rounded bg-black/10 dark:bg-white/10 px-1 py-0.5 text-xs font-mono">{children}</code>
+                        ),
+                      blockquote: ({ children }) => (
+                        <blockquote className="border-l-2 border-muted-foreground/30 pl-3 italic text-muted-foreground mb-2">{children}</blockquote>
+                      ),
+                      table: ({ children }) => (
+                        <div className="overflow-x-auto mb-2">
+                          <table className="border-collapse text-xs w-full">{children}</table>
+                        </div>
+                      ),
+                      thead: ({ children }) => <thead>{children}</thead>,
+                      tbody: ({ children }) => <tbody>{children}</tbody>,
+                      tr: ({ children }) => <tr>{children}</tr>,
+                      th: ({ children }) => (
+                        <th className="border border-border px-2 py-1 text-left font-semibold bg-muted/50">{children}</th>
+                      ),
+                      td: ({ children }) => (
+                        <td className="border border-border px-2 py-1">{children}</td>
+                      ),
+                      strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+                      a: ({ href, children }) => (
+                        <a href={href} className="underline underline-offset-2 hover:opacity-80" target="_blank" rel="noopener noreferrer">{children}</a>
+                      ),
+                    }}
+                  >
+                    {invocation.prompt_text}
+                  </ReactMarkdown>
+                </div>
+              ) : (
+                <pre className="bg-input-bg rounded-md p-4 text-sm font-mono whitespace-pre-wrap overflow-x-auto text-muted-foreground">
+                  Not captured
+                </pre>
+              )}
             </CardContent>
           </Card>
         </div>
@@ -163,9 +221,58 @@ export function InvocationDetailPage({ agent, session, invocation }: InvocationD
           <CardTitle className="text-sm font-medium">Response</CardTitle>
         </CardHeader>
         <CardContent>
-          <pre className="bg-input-bg rounded-md p-4 text-sm font-mono whitespace-pre-wrap overflow-x-auto">
-            {invocation.response_text ?? "Not captured"}
-          </pre>
+          {invocation.response_text ? (
+            <div className="rounded border bg-input-bg p-4 text-sm">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+                  h1: ({ children }) => <h1 className="text-base font-bold mb-2 mt-3 first:mt-0">{children}</h1>,
+                  h2: ({ children }) => <h2 className="text-sm font-bold mb-2 mt-3 first:mt-0">{children}</h2>,
+                  h3: ({ children }) => <h3 className="text-sm font-semibold mb-1 mt-2 first:mt-0">{children}</h3>,
+                  ul: ({ children }) => <ul className="list-disc pl-4 mb-2 space-y-0.5">{children}</ul>,
+                  ol: ({ children }) => <ol className="list-decimal pl-4 mb-2 space-y-0.5">{children}</ol>,
+                  li: ({ children }) => <li className="leading-snug">{children}</li>,
+                  pre: ({ children }) => (
+                    <pre className="mb-2 overflow-x-auto rounded bg-black/10 dark:bg-white/10 p-3 text-xs font-mono">{children}</pre>
+                  ),
+                  code: ({ className, children }) =>
+                    className?.startsWith("language-") ? (
+                      <code className={className}>{children}</code>
+                    ) : (
+                      <code className="rounded bg-black/10 dark:bg-white/10 px-1 py-0.5 text-xs font-mono">{children}</code>
+                    ),
+                  blockquote: ({ children }) => (
+                    <blockquote className="border-l-2 border-muted-foreground/30 pl-3 italic text-muted-foreground mb-2">{children}</blockquote>
+                  ),
+                  table: ({ children }) => (
+                    <div className="overflow-x-auto mb-2">
+                      <table className="border-collapse text-xs w-full">{children}</table>
+                    </div>
+                  ),
+                  thead: ({ children }) => <thead>{children}</thead>,
+                  tbody: ({ children }) => <tbody>{children}</tbody>,
+                  tr: ({ children }) => <tr>{children}</tr>,
+                  th: ({ children }) => (
+                    <th className="border border-border px-2 py-1 text-left font-semibold bg-muted/50">{children}</th>
+                  ),
+                  td: ({ children }) => (
+                    <td className="border border-border px-2 py-1">{children}</td>
+                  ),
+                  strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+                  a: ({ href, children }) => (
+                    <a href={href} className="underline underline-offset-2 hover:opacity-80" target="_blank" rel="noopener noreferrer">{children}</a>
+                  ),
+                }}
+              >
+                {invocation.response_text}
+              </ReactMarkdown>
+            </div>
+          ) : (
+            <pre className="bg-input-bg rounded-md p-4 text-sm font-mono whitespace-pre-wrap overflow-x-auto text-muted-foreground">
+              Not captured
+            </pre>
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary

These are the remaining uncommitted changes from the end-user chat interface work that were not included in PR #46.

- Backend: agent `description` field, session soft-delete (`hidden_at`), memory service improvements
- Frontend: inline description editing in `AgentDetailPage`, improved `InvocationDetailPage`, admin dashboard improvements, wired `patchAgent` through to the detail page

## Changes

### Backend
- `description` column on `agents` table, exposed via `PATCH /api/agents/{id}`
- `hidden_at` column on `invocation_sessions` for soft-delete — `DELETE /api/agents/{id}/sessions/{session_id}` sets this field; `list_sessions` excludes hidden sessions
- Memory service improvements
- DB migrations for both new columns

### Frontend
- `AgentDetailPage`: inline description editing (Pencil/Check/X buttons), markdown rendering for response pane (`react-markdown` + `remark-gfm` + `CollapsibleJsonBlock`)
- `InvocationDetailPage`: display improvements
- `AdminDashboardPage`: display improvements
- `useAgents`: `patchAgent` action
- `App.tsx`: wire `patchAgent` to `AgentDetailPage`
- Updated types for `description`, `hidden_at`, and related fields

## Test plan

- [x] Agent detail page shows description; clicking pencil opens inline textarea; Save/Cancel work
- [x] Removing a conversation (DELETE session) hides it from the list without deleting data
- [x] Backend migrations run cleanly on existing DB
- [x] Invocation detail page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)