### PR TITLE
feat: add third-party connectors with API key auth and Salesforce A2A

### DIFF
--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -548,7 +548,20 @@ Agents support runtime model selection, allowing users to choose from a set of a
 - **Agent detail response pane refactor:** Markdown rendering extracted to standalone `MarkdownBlock` component. Response pane renders `segments` array with `ToolUseBlock` and `MarkdownBlock` blocks. Thinking indicator shown when streaming with no segments. `StreamingBubble` component in ChatPage for segment-based rendering during active streams.
 - 12 backend tests in `test_model_selection.py` covering Agent model helpers, registration with `allowed_model_ids`, response inclusion, PATCH validation, and invoke model validation.
 
-### Phase 24 — Advanced Operations
+### Phase 24 — Third-Party Connectors *(Complete)*
+- **API key authentication for MCP servers:** New `api_key` auth type alongside `none` and `oauth2`. Admin API keys stored in Loom-managed AWS Secrets Manager (`loom/mcp/{name}/admin-api-key`), never in the database. Per-user API keys stored at `loom/mcp/{name}/api-key/{user_sub}`. Backend resolves keys from Secrets Manager with 5-minute in-memory cache. `_ApiKeyAuth` httpx handler in agent runtime resolves key once at session init (not per-request) to avoid throttling.
+- **Dynamic MCP connectors in ChatPage:** "Connectors" button in the input area footer (left of model picker). Dropdown lists MCP servers available to the user with per-server toggle switches. Enabled connector state persisted to `localStorage` per agent (`loom:enabledConnectors:{agentId}`). API key connectors prompt for key entry on first enable; disconnect action deletes the stored key. Connector IDs passed through invoke request to agent runtime as `dynamic_mcp_servers`.
+- **Agent runtime model override:** `AGENT_MODEL_ID` environment variable and `model_id` field in invoke payload. Agent handler caches `BedrockModel` instances per model ID and swaps `agent.model` per invocation. Default model restored when no override specified.
+- **Agent runtime dynamic MCP attachment:** Handler accepts `dynamic_mcp_servers` in invoke payload. Maintains connection pool keyed by `(server_name, actor_id)`. Previously-connected servers are reused across invocations. Supports `api_key`, `oauth2`, and unauthenticated transports.
+- **Salesforce Agentforce A2A integration:** Salesforce uses `/v1/card` instead of `/.well-known/agent.json` for Agent Card endpoint. `_AuthenticatedA2AAgent` detects Salesforce URLs and trusts the card's declared RPC URL (does not override with endpoint). Agent card `capabilities.streaming` check — skip `message/stream` and go directly to `message/send` for agents that don't advertise streaming support.
+- **A2A agent card UX improvements:** Skill list restyled from Card-based layout to compact expandable rows matching MCP tool list style. Capabilities (streaming, push notifications, state history) and default I/O modes displayed inline with label prefixes. Empty default modes show "none" indicator.
+- **Registry lifecycle improvements:** MCP server deletion cleans up associated registry records. Tool refresh propagates updated descriptors to the registry. Registry status badges shown across catalog and list views.
+- **Catalog navigation improvements:** Clicking an item in the CatalogPage navigates to the corresponding admin page with the item pre-selected.
+- **AgentCard overflow fix:** `overflow-hidden` on flex container prevents long agent names from overflowing card boundaries.
+- **ChatPage model picker grouped by vendor:** Model dropdown uses `groupModels()` utility for alphabetical vendor grouping with section headers, matching the admin deploy form pattern.
+- **SQLite absolute path default:** `DATABASE_URL` defaults to an absolute path based on the backend directory to avoid data loss when CWD differs between invocations.
+
+### Phase 25 — Advanced Operations
 - Real-time metrics auto-refresh.
 - Multi-agent comparison views.
 - Alert configuration.

--- a/agents/strands_agent/README.md
+++ b/agents/strands_agent/README.md
@@ -101,6 +101,7 @@ This allows the frontend to pass the user-configured prompt as a deploy-time par
 | `AGENT_CONFIG_PATH` | Path to configuration JSON file | — |
 | `AGENT_CONFIG_JSON` | Inline configuration JSON string | — |
 | `MEMORY_STORE_ID` | AgentCore Memory store identifier | — |
+| `AGENT_MODEL_ID` | Runtime model override (overrides config) | — |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OTEL collector endpoint | `http://localhost:4317` |
 | `OTEL_SERVICE_NAME` | Service name for telemetry | `loom-agent` |
 | `AWS_REGION` | AWS region | `us-east-1` |
@@ -141,6 +142,13 @@ Produces `build/agent.zip` — a self-contained zip deployable to AgentCore Runt
 
 MCP (Model Context Protocol) tool servers are dynamically loaded from configuration. The agent creates MCP clients at startup for each enabled server. Currently supports `streamable_http` transport.
 
+**Authentication types:**
+- `oauth2` — Uses `_OAuth2Auth` httpx handler to exchange workload tokens for downstream access tokens via AgentCore Identity credential providers.
+- `api_key` — Uses `_ApiKeyAuth` httpx handler. Resolves the API key once from AWS Secrets Manager at initialization (not per-request) to avoid throttling. Header injection follows `api_key_header_name` — `Authorization` headers use `Bearer` prefix; all others set the raw key.
+- Unauthenticated — no auth handler.
+
+**Dynamic MCP connectors:** The handler accepts `dynamic_mcp_servers` in the invocation payload for per-invocation MCP server attachment. A connection pool keyed by `(server_name, actor_id)` reuses previously-connected servers across invocations. For API key connectors, the `{actor_id}` placeholder in `credentials_secret_arn` is resolved to the invoking user's identity.
+
 ### A2A Agent Clients
 
 Agent-to-agent (A2A) communication uses the Strands SDK `A2AAgent` class. Each enabled A2A agent in the configuration is wrapped as a `@tool` function that the orchestrating agent can invoke during conversation.
@@ -148,9 +156,10 @@ Agent-to-agent (A2A) communication uses the Strands SDK `A2AAgent` class. Each e
 **`_AuthenticatedA2AAgent`** — Subclass of `A2AAgent` for OAuth2-protected A2A endpoints. Injects OAuth2 Bearer tokens via the AgentCore Identity service M2M flow (using the workload token from `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`). Handles:
 
 - **Agent Card fetching** with authentication, backfilling required fields that older agent cards may omit, and overriding the card's internal URL with the external AgentCore Runtime endpoint.
-- **Message sending** via `message/stream` (SSE) with automatic fallback to `message/send` when the server returns "Method not found".
+- **Message sending** with capability-aware method selection. Checks `agent_card.capabilities.streaming` — uses `message/stream` (SSE) only when streaming is supported, otherwise goes directly to `message/send`. Falls back from `message/stream` to `message/send` when the server returns "Method not found".
 - **SSE response parsing** — handles both `text/event-stream` (standard A2A streaming) and `application/json` (AgentCore proxy-collapsed) content types. Buffers `Message` events and yields them after `Task` events so that `stream_async` picks the content-bearing `Message` as the `last_complete_event`.
 - **Manual task tracking** instead of `ClientTaskManager` to handle duplicate `Task` events emitted by some A2A servers.
+- **Salesforce Agentforce support** — detects Salesforce URLs and uses `/v1/card` for Agent Card endpoint instead of `/.well-known/agent.json`. Trusts the card's declared RPC URL (does not override with the configured endpoint) since Salesforce RPC URLs differ from base URLs.
 
 **Authentication flow:** The `_OAuth2Auth` httpx handler (shared with MCP clients) exchanges the ephemeral container workload token for a downstream OAuth2 access token via the AgentCore Identity service credential provider.
 

--- a/agents/strands_agent/src/agent.py
+++ b/agents/strands_agent/src/agent.py
@@ -42,11 +42,11 @@ def build_agent(config: AgentConfig, defer_mcp: bool = False) -> Agent:
     tools: list = []
     hooks: list = []
 
-    # MCP tool clients (R3) — may be deferred for OAuth2 servers
+    # MCP tool clients (R3) — may be deferred for authenticated servers
     if not defer_mcp and config.integrations.mcp_servers:
         enabled_servers = [s for s in config.integrations.mcp_servers if s.enabled]
         if enabled_servers:
-            mcp_clients = create_mcp_clients(config.integrations.mcp_servers)
+            mcp_clients = build_mcp_clients(config.integrations.mcp_servers)
             tools.extend(mcp_clients)
             logger.info("Loaded %d MCP tool client(s)", len(mcp_clients))
 

--- a/agents/strands_agent/src/config.py
+++ b/agents/strands_agent/src/config.py
@@ -15,6 +15,7 @@ class AuthConfig:
     credentials_secret_arn: str = ""
     credential_provider_name: str = ""
     scopes: str = ""
+    api_key_header_name: str = "x-api-key"
 
 
 @dataclass
@@ -84,6 +85,7 @@ def _parse_auth(data: Optional[dict]) -> Optional[AuthConfig]:
         credentials_secret_arn=data.get("credentials_secret_arn", ""),
         credential_provider_name=data.get("credential_provider_name", ""),
         scopes=data.get("scopes", ""),
+        api_key_header_name=data.get("api_key_header_name", "x-api-key"),
     )
 
 

--- a/agents/strands_agent/src/handler.py
+++ b/agents/strands_agent/src/handler.py
@@ -20,9 +20,11 @@ from typing import Any, AsyncGenerator
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from strands.types.exceptions import MaxTokensReachedException
 
-from src.config import AgentConfig, load_config
+from strands.models.bedrock import BedrockModel
+
+from src.config import AgentConfig, MCPServerConfig, AuthConfig, load_config
 from src.agent import attach_mcp_tools, build_agent
-from src.integrations.mcp_client import has_oauth2_servers
+from src.integrations.mcp_client import has_deferred_auth_servers, _build_transport_callable
 from src.telemetry import trace_invocation
 
 # Configure the root Python logger so all modules (agent, mcp_client, etc.)
@@ -42,6 +44,9 @@ logger = app.logger
 _agent = None
 _config: AgentConfig | None = None
 _mcp_attached = False
+_dynamic_mcp_clients: dict[str, Any] = {}  # keyed by (server_name, actor_id)
+_default_model: BedrockModel | None = None
+_model_cache: dict[str, BedrockModel] = {}  # keyed by model_id
 
 
 def _get_agent():
@@ -51,18 +56,19 @@ def _get_agent():
     MCP client initialization is deferred until the first invocation
     when the workload access token is available in the request context.
     """
-    global _agent, _config
+    global _agent, _config, _default_model
     if _agent is None:
         _config = load_config()
-        defer_mcp = has_oauth2_servers(_config.integrations.mcp_servers)
+        defer_mcp = has_deferred_auth_servers(_config.integrations.mcp_servers)
         if defer_mcp:
-            logger.info("Deferring MCP client init — OAuth2 servers require invocation context")
+            logger.info("Deferring MCP client init — authenticated servers require invocation context")
         _agent = build_agent(_config, defer_mcp=defer_mcp)
+        _default_model = _agent.model
         logger.info("Agent initialized successfully")
     return _agent
 
 
-def _ensure_mcp_tools():
+def _ensure_mcp_tools(actor_id: str = ""):
     """Attach MCP tools on the first invocation when context is available."""
     global _mcp_attached
     if _mcp_attached or _config is None:
@@ -73,11 +79,66 @@ def _ensure_mcp_tools():
     if not enabled_servers:
         return
 
+    if actor_id:
+        for server in _config.integrations.mcp_servers:
+            if server.auth and server.auth.type == "api_key" and "{actor_id}" in server.auth.credentials_secret_arn:
+                server.auth.credentials_secret_arn = server.auth.credentials_secret_arn.replace("{actor_id}", actor_id)
+
     logger.info("Attaching MCP tools (first invocation with context)")
     try:
         attach_mcp_tools(_agent, _config.integrations.mcp_servers)
     except Exception as e:
         logger.warning("Failed to attach MCP tools: %s. Agent will continue without MCP tools.", e)
+
+
+def _attach_dynamic_mcp_servers(agent_instance, dynamic_servers: list[dict[str, Any]], actor_id: str) -> None:
+    """Attach dynamically-requested MCP servers for this invocation.
+
+    Maintains a pool keyed by (server_name, actor_id). New servers are
+    started and registered; previously-connected servers are reused.
+    """
+    from strands.tools.mcp import MCPClient
+
+    for server_data in dynamic_servers:
+        name = server_data.get("name", "")
+        pool_key = f"{name}:{actor_id}"
+
+        if pool_key in _dynamic_mcp_clients:
+            logger.debug("Reusing cached dynamic MCP client for '%s'", name)
+            continue
+
+        auth_data = server_data.get("auth")
+        auth_config = None
+        if auth_data:
+            auth_config = AuthConfig(
+                type=auth_data.get("type", ""),
+                credentials_secret_arn=auth_data.get("credentials_secret_arn", ""),
+                api_key_header_name=auth_data.get("api_key_header_name", "x-api-key"),
+                well_known_endpoint=auth_data.get("well_known_endpoint", ""),
+                credential_provider_name=auth_data.get("credential_provider_name", ""),
+                scopes=auth_data.get("scopes", ""),
+            )
+
+        config = MCPServerConfig(
+            name=name,
+            enabled=True,
+            transport=server_data.get("transport", "streamable_http"),
+            endpoint_url=server_data.get("endpoint_url", ""),
+            auth=auth_config,
+        )
+
+        transport_callable = _build_transport_callable(config)
+        client = MCPClient(transport_callable)
+        try:
+            agent_instance.tool_registry.process_tools([client])
+            _dynamic_mcp_clients[pool_key] = client
+            logger.info("Attached dynamic MCP server '%s' for actor '%s'", name, actor_id)
+        except BaseException as e:
+            logger.warning("Failed to attach dynamic MCP server '%s' for actor '%s': %s", name, actor_id, e)
+            try:
+                client.stop()
+            except BaseException:
+                pass
 
 
 @app.entrypoint
@@ -98,13 +159,32 @@ async def invoke(payload: dict[str, Any]) -> AsyncGenerator[Any, None]:
         Streaming events produced by the agent.
     """
     agent = _get_agent()
-    _ensure_mcp_tools()
 
     prompt = payload.get("prompt", "")
     session_id = payload.get("session_id", "")
     actor_id = payload.get("actor_id") or "loom-agent"
 
-    logger.info("Processing invocation session_id=%s actor_id=%s", session_id, actor_id)
+    _ensure_mcp_tools(actor_id)
+
+    dynamic_servers = payload.get("dynamic_mcp_servers")
+    if dynamic_servers:
+        _attach_dynamic_mcp_servers(agent, dynamic_servers, actor_id)
+
+    # Runtime model override
+    runtime_model_id = payload.get("model_id")
+    if runtime_model_id and _config:
+        if runtime_model_id not in _model_cache:
+            _model_cache[runtime_model_id] = BedrockModel(
+                model_id=runtime_model_id,
+                max_tokens=_config.max_tokens,
+                streaming=True,
+            )
+            logger.info("Created cached BedrockModel for runtime override: %s", runtime_model_id)
+        agent.model = _model_cache[runtime_model_id]
+    elif _default_model:
+        agent.model = _default_model
+
+    logger.info("Processing invocation session_id=%s actor_id=%s model=%s", session_id, actor_id, runtime_model_id or _config.model_id if _config else "unknown")
 
     with trace_invocation(invocation_id=session_id) as span:
         span.set_attribute("agent.session_id", session_id)

--- a/agents/strands_agent/src/integrations/a2a_client.py
+++ b/agents/strands_agent/src/integrations/a2a_client.py
@@ -89,14 +89,17 @@ class _AuthenticatedA2AAgent(A2AAgent):
         # Fetch the raw card JSON and apply defaults for fields that older
         # A2A agents may omit but the current SDK requires, then validate.
         base_url = self.endpoint.rstrip("/")
-        card_url = f"{base_url}/{AGENT_CARD_WELL_KNOWN_PATH.lstrip('/')}"
+        if "salesforce.com/einstein/ai-agent" in base_url:
+            card_url = f"{base_url}/v1/card"
+        else:
+            card_url = f"{base_url}/{AGENT_CARD_WELL_KNOWN_PATH.lstrip('/')}"
 
         async with httpx.AsyncClient(timeout=self.timeout, auth=self._http_auth) as client:
             response = await client.get(card_url)
             response.raise_for_status()
             card_data: dict = response.json()
 
-        logger.info("Fetched agent card JSON from %s", card_url)
+        logger.info("Fetched agent card JSON from %s: %s", card_url, _json.dumps(card_data, indent=2, default=str))
 
         # Backfill required fields that older agent cards may omit
         card_data.setdefault("defaultInputModes", ["application/json"])
@@ -106,18 +109,26 @@ class _AuthenticatedA2AAgent(A2AAgent):
 
         self._agent_card = AgentCard.model_validate(card_data)
 
-        # Replace the card's internal URL with the external endpoint so
-        # that message sending targets the AgentCore Runtime URL.
-        # Ensure a trailing slash so the POST routes through the proxy
-        # to the A2A server's root (/) rather than the entrypoint handler.
-        external_url = self.endpoint.rstrip("/") + "/"
-        logger.info(
-            "Overriding agent card url '%s' → '%s' (endpoint='%s')",
-            self._agent_card.url,
-            external_url,
-            self.endpoint,
-        )
-        self._agent_card.url = external_url
+        # AgentCore-hosted agents report an internal URL (e.g.
+        # http://localhost:8081) that is not reachable externally.
+        # Override with the configured endpoint for those agents.
+        # For non-AgentCore agents (e.g. Salesforce), trust the card's URL
+        # since the RPC endpoint may differ from the base URL.
+        if "salesforce.com/einstein/ai-agent" not in self.endpoint:
+            external_url = self.endpoint.rstrip("/") + "/"
+            logger.info(
+                "Overriding agent card url '%s' → '%s' (endpoint='%s')",
+                self._agent_card.url,
+                external_url,
+                self.endpoint,
+            )
+            self._agent_card.url = external_url
+        else:
+            logger.info(
+                "Using agent card url '%s' as-is (endpoint='%s')",
+                self._agent_card.url,
+                self.endpoint,
+            )
 
         if self.name is None and self._agent_card.name:
             self.name = self._agent_card.name
@@ -131,16 +142,15 @@ class _AuthenticatedA2AAgent(A2AAgent):
         return self._agent_card
 
     async def _send_message(self, prompt) -> AsyncIterator[Any]:
-        """Send message to remote A2A agent via ``message/stream``.
+        """Send message to remote A2A agent.
 
-        The response may arrive as either:
-        - **SSE** (``text/event-stream``) — the standard A2A streaming
-          format, where each SSE event carries a JSON-RPC response.
-        - **Plain JSON** (``application/json``) — when the AgentCore
-          proxy collapses the SSE stream into a single JSON body.
-
-        This method handles both transparently.  If ``message/stream``
-        returns *Method not found*, it retries with ``message/send``.
+        Checks ``agent_card.capabilities.streaming`` to decide whether
+        to use ``message/stream`` or ``message/send``.  The response
+        may arrive as either:
+        - **SSE** (``text/event-stream``) — streaming format where
+          each SSE event carries a JSON-RPC response.
+        - **Plain JSON** (``application/json``) — when the proxy
+          collapses the stream or the agent only supports send.
 
         Yields the same event shapes as the SDK's ``BaseClient.send_message``:
         - ``Message`` for direct message responses
@@ -156,11 +166,26 @@ class _AuthenticatedA2AAgent(A2AAgent):
             configuration=MessageSendConfiguration(blocking=True),
         )
 
-        # Try message/stream first, fall back to message/send on Method-not-found.
-        for rpc_request_cls, method_label in [
-            (SendStreamingMessageRequest, "message/stream"),
-            (SendMessageRequest, "message/send"),
-        ]:
+        # Use message/stream only if the agent advertises streaming support;
+        # otherwise go directly to message/send.
+        supports_streaming = getattr(
+            getattr(agent_card, "capabilities", None), "streaming", False,
+        )
+        if supports_streaming:
+            methods = [
+                (SendStreamingMessageRequest, "message/stream"),
+                (SendMessageRequest, "message/send"),
+            ]
+        else:
+            methods = [
+                (SendMessageRequest, "message/send"),
+            ]
+        logger.info(
+            "Agent '%s' streaming=%s, methods=%s",
+            self.name, supports_streaming, [m for _, m in methods],
+        )
+
+        for rpc_request_cls, method_label in methods:
             rpc_request = rpc_request_cls(params=params, id=str(uuid4()))
             payload = rpc_request.model_dump(mode="json", exclude_none=True)
 

--- a/agents/strands_agent/src/integrations/mcp_client.py
+++ b/agents/strands_agent/src/integrations/mcp_client.py
@@ -5,6 +5,7 @@ import os
 from functools import partial
 from typing import Any, Generator
 
+import boto3
 import httpx
 from mcp.client.streamable_http import streamablehttp_client
 from strands.tools.mcp import MCPClient
@@ -63,6 +64,35 @@ class _OAuth2Auth(httpx.Auth):
         yield request
 
 
+class _ApiKeyAuth(httpx.Auth):
+    """httpx Auth that injects an API key header on each request.
+
+    The API key is resolved once from AWS Secrets Manager at initialization
+    (not per-request) to avoid throttling.
+    """
+
+    def __init__(self, secret_name: str, header_name: str = "x-api-key") -> None:
+        self._header_name = header_name
+        self._api_key = self._resolve_key(secret_name)
+
+    @staticmethod
+    def _resolve_key(secret_name: str) -> str:
+        region = os.environ.get("AWS_REGION", "us-east-1")
+        client = boto3.client("secretsmanager", region_name=region)
+        resp = client.get_secret_value(SecretId=secret_name)
+        return resp["SecretString"]
+
+    def auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
+        if self._api_key:
+            if self._header_name.lower() == "authorization":
+                request.headers["Authorization"] = f"Bearer {self._api_key}"
+            else:
+                request.headers[self._header_name] = self._api_key
+        else:
+            logger.warning("No API key resolved; sending unauthenticated request")
+        yield request
+
+
 def _build_transport_callable(config: MCPServerConfig) -> Any:
     """Build a transport callable for the given MCP server configuration.
 
@@ -89,6 +119,26 @@ def _build_transport_callable(config: MCPServerConfig) -> Any:
             scope_list,
         )
         return partial(streamablehttp_client, url=config.endpoint_url, auth=auth)
+
+    if config.auth and config.auth.type == "api_key" and config.auth.credentials_secret_arn:
+        try:
+            auth = _ApiKeyAuth(
+                secret_name=config.auth.credentials_secret_arn,
+                header_name=config.auth.api_key_header_name or "x-api-key",
+            )
+            logger.info(
+                "MCP server '%s' configured with API key auth (secret=%s, header=%s)",
+                config.name,
+                config.auth.credentials_secret_arn,
+                config.auth.api_key_header_name,
+            )
+            return partial(streamablehttp_client, url=config.endpoint_url, auth=auth)
+        except Exception as e:
+            logger.warning(
+                "Failed to resolve API key for server '%s': %s. Falling back to unauthenticated.",
+                config.name,
+                e,
+            )
 
     return partial(streamablehttp_client, url=config.endpoint_url)
 
@@ -205,5 +255,13 @@ def has_oauth2_servers(servers: list[MCPServerConfig]) -> bool:
     """Check if any enabled MCP servers require OAuth2 authentication."""
     return any(
         s.enabled and s.auth and s.auth.type == "oauth2" and s.auth.credential_provider_name
+        for s in servers
+    )
+
+
+def has_deferred_auth_servers(servers: list[MCPServerConfig]) -> bool:
+    """Check if any enabled MCP servers require deferred auth (OAuth2 or API key)."""
+    return any(
+        s.enabled and s.auth and s.auth.type in ("oauth2", "api_key")
         for s in servers
     )

--- a/backend/SPECIFICATIONS.md
+++ b/backend/SPECIFICATIONS.md
@@ -352,6 +352,8 @@ Tag profiles are named presets of tag values that satisfy required tag policies.
 | `oauth2_client_id` | TEXT | OAuth2 client ID (required when auth_type is `oauth2`) |
 | `oauth2_client_secret` | TEXT | OAuth2 client secret (write-only, never returned in GET responses) |
 | `oauth2_scopes` | TEXT | Space-separated OAuth2 scopes |
+| `api_key_header_name` | TEXT | HTTP header name for API key auth (e.g. `x-api-key`, `Authorization`) (nullable) |
+| `has_admin_api_key` | TEXT | `"true"` or `"false"` — whether an admin API key is stored in Secrets Manager (nullable) |
 | `created_at` | DATETIME | Creation timestamp |
 | `registry_record_id` | TEXT | AWS Agent Registry record ID (nullable) |
 | `registry_status` | TEXT | Registry lifecycle status: DRAFT, PENDING_APPROVAL, APPROVED, REJECTED, DEPRECATED (nullable) |
@@ -791,6 +793,10 @@ Retrieves stored long-term memory records for the authenticated user within a me
 | `POST` | `/api/mcp/servers/{server_id}/tools/refresh` | Refresh tool list from the MCP server. |
 | `GET` | `/api/mcp/servers/{server_id}/access` | Get access control rules for a server. |
 | `PUT` | `/api/mcp/servers/{server_id}/access` | Replace all access control rules for a server. |
+| `GET` | `/api/mcp/connectors` | List MCP servers available as connectors with per-user API key status. |
+| `PUT` | `/api/mcp/servers/{server_id}/api-key` | Store the user's personal API key in Secrets Manager. |
+| `GET` | `/api/mcp/servers/{server_id}/api-key/status` | Check whether the user has a personal API key set. |
+| `DELETE` | `/api/mcp/servers/{server_id}/api-key` | Remove the user's personal API key from Secrets Manager. |
 
 **`POST /api/mcp/servers` request body:**
 ```json
@@ -807,9 +813,17 @@ Retrieves stored long-term memory records for the authenticated user within a me
 }
 ```
 
-When `auth_type` is `oauth2`, `oauth2_well_known_url` and `oauth2_client_id` are required (validated via Pydantic model validator).
+When `auth_type` is `oauth2`, `oauth2_well_known_url` and `oauth2_client_id` are required (validated via Pydantic model validator). When `auth_type` is `api_key`, `api_key_header_name` is required.
 
-**Security:** `oauth2_client_secret` is write-only — it is never included in GET responses. The response includes `has_oauth2_secret: bool` instead.
+**Security:** `oauth2_client_secret` is write-only — it is never included in GET responses. The response includes `has_oauth2_secret: bool` instead. API keys are stored in Loom-managed AWS Secrets Manager — admin keys at `loom/mcp/{name}/admin-api-key`, per-user keys at `loom/mcp/{name}/api-key/{user_sub}`. The response includes `has_admin_api_key: bool` instead of the key value.
+
+**API key authentication model:**
+- **Admin key:** Used by the Loom backend for test connection, refresh tools, and invoke from admin console. Stored in Secrets Manager on create/update.
+- **Per-user key:** Each user supplies their own key via the ChatPage connector UI or API. Required for runtime invocations. Admin key is for admin console operations only — no fallback between them.
+- **Header injection:** When `api_key_header_name` is `Authorization`, the key is sent as `Bearer {key}`. For all other headers (e.g. `x-api-key`), the raw key is set directly.
+
+**`GET /api/mcp/connectors` response:**
+Returns MCP servers available as connectors with per-user API key status. End-users (`t-user`) see only APPROVED or unregistered servers. Each entry includes `id`, `name`, `description`, `auth_type`, and `has_user_api_key` (whether the current user has a stored API key).
 
 **`PUT /api/mcp/servers/{server_id}/access` request body:**
 ```json
@@ -851,7 +865,7 @@ Replaces all existing access rules for the server. Personas not listed have no a
 }
 ```
 
-On registration, the backend fetches `<base_url>/.well-known/agent.json` to retrieve the Agent Card. All agent metadata (name, description, version, capabilities, skills) is populated from the card. If the fetch fails, registration is rejected with a descriptive error.
+On registration, the backend fetches the Agent Card from the well-known endpoint. Standard A2A agents use `/.well-known/agent.json`; AgentCore agents try `/.well-known/agent-card.json` first; Salesforce Agentforce agents use `/v1/card`. All agent metadata (name, description, version, capabilities, skills) is populated from the card. If the fetch fails, registration is rejected with a descriptive error.
 
 When `auth_type` is `oauth2`, `oauth2_well_known_url` and `oauth2_client_id` are required (validated via Pydantic model validator).
 
@@ -923,7 +937,9 @@ Replaces all existing access rules for the agent. Personas not listed have no ac
 
 The optional `credential_id` references an authorizer credential. When provided, the backend fetches the client secret from Secrets Manager and generates an OAuth token for authenticated invocation. The optional `bearer_token` allows passing a raw bearer token directly — it takes highest priority (Priority 0) in the token selection chain, above user tokens and credential-based tokens.
 
-The optional `model_id` specifies a runtime model override. When provided, it is validated against the agent's `allowed_model_ids`. If the model is not in the allowed list, the endpoint returns HTTP 400. If valid, the override is passed to `invoke_agent_stream()` which uses it instead of the agent's default model for that invocation.
+The optional `model_id` specifies a runtime model override. When provided, it is validated against the agent's `allowed_model_ids`. If the model is not in the allowed list, the endpoint returns HTTP 400. If valid, the override is passed to `invoke_agent_stream()` which uses it instead of the agent's default model for that invocation. At the agent runtime level, model override uses a cached `BedrockModel` pool — models are created once and reused across invocations.
+
+The optional `connector_ids` field is a list of MCP server IDs to dynamically attach for this invocation. The backend resolves each connector's configuration (endpoint URL, transport type, auth settings) and passes them to the agent runtime as `dynamic_mcp_servers` in the invocation payload. The agent runtime maintains a connection pool keyed by `(server_name, actor_id)` to reuse MCP clients across invocations. For API key connectors, the user's personal API key is resolved from Secrets Manager at `loom/mcp/{name}/api-key/{user_sub}`.
 
 The invoke endpoint uses a priority-based token selection: (0) `bearer_token` from request body, (1) `credential_id` for M2M token, (2) user access token (forwarded when agent has authorizer), (3) agent config M2M flow, (4) SigV4 (no token).
 
@@ -1141,16 +1157,20 @@ Core authentication and authorization module. Provides:
 
 ### `services/mcp.py`
 
-Stub service for MCP server integration:
+MCP server connection, tool discovery, and invocation:
 
-- `test_mcp_connection(server) -> dict` — Returns success/failure with message. Validates OAuth2 well-known URL when auth_type is `oauth2`. Actual MCP client connectivity is future work.
-- `fetch_mcp_tools(server) -> list[dict]` — Returns empty list (stub). A real implementation would connect to the server and call `tools/list`.
+- `test_mcp_connection(server, api_key=None) -> dict` — Sends an `initialize` JSON-RPC request to verify the server is reachable. Supports OAuth2, API key, and unauthenticated connections.
+- `fetch_mcp_tools(server, api_key=None) -> list[dict]` — Calls `tools/list` JSON-RPC method and returns tool metadata (name, description, input_schema).
+- `invoke_mcp_tool(server, tool_name, arguments, api_key=None) -> dict` — Calls `tools/call` JSON-RPC method to invoke a specific tool with arguments.
+- `resolve_api_key(server, user_sub=None) -> str | None` — Resolves API key from Secrets Manager. Admin key for admin context (`loom/mcp/{name}/admin-api-key`), user key for user context (`loom/mcp/{name}/api-key/{user_sub}`).
+- `_build_headers(server, api_key=None) -> dict` — Builds request headers with auth injection. For API key auth, uses `api_key_header_name` to set the correct header; `Authorization` headers are prefixed with `Bearer`.
+- `_call_streamable_http()`, `_call_sse()`, `_call_mcp()` — Transport methods accepting optional `api_key` parameter.
 
 ### `services/a2a.py`
 
 A2A Agent Card fetching and connection testing:
 
-- `fetch_agent_card(base_url: str, auth_headers: dict | None) -> dict` — fetches `<base_url>/.well-known/agent.json` and returns the raw JSON. Raises on HTTP errors or invalid JSON.
+- `fetch_agent_card(base_url: str, auth_headers: dict | None) -> dict` — fetches the Agent Card from the well-known endpoint. Standard A2A agents use `/.well-known/agent.json`; AgentCore agents try `/.well-known/agent-card.json` first; Salesforce Agentforce agents use `/v1/card`. Raises on HTTP errors or invalid JSON.
 - `parse_agent_card(card_json: dict) -> dict` — extracts structured fields (name, description, version, provider, capabilities, authentication, skills, etc.) from raw Agent Card JSON.
 - `sync_skills(db: Session, agent_id: int, skills: list[dict])` — synchronizes skills from Agent Card to the database. Adds new skills, removes stale ones.
 - `test_a2a_connection(agent) -> dict` — acquires OAuth2 token if configured and fetches the Agent Card, returning success/failure with details.

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -106,6 +106,8 @@ def _migrate_add_columns(eng) -> None:
         ("agents", "description", "TEXT"),
         ("mcp_servers", "registry_record_id", "VARCHAR"),
         ("mcp_servers", "registry_status", "VARCHAR"),
+        ("mcp_servers", "api_key_header_name", "VARCHAR"),
+        ("mcp_servers", "has_admin_api_key", "VARCHAR"),
         ("a2a_agents", "registry_record_id", "VARCHAR"),
         ("a2a_agents", "registry_status", "VARCHAR"),
         ("agents", "registry_record_id", "VARCHAR"),

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -8,8 +8,10 @@ from typing import Generator
 
 logger = logging.getLogger(__name__)
 
-# Get LOOM_DATABASE_URL from environment, default to SQLite
-DATABASE_URL = os.getenv("LOOM_DATABASE_URL", "sqlite:///./loom.db")
+# Get LOOM_DATABASE_URL from environment, default to SQLite.
+# Use absolute path to avoid data loss when CWD differs between invocations.
+_default_db_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "loom.db")
+DATABASE_URL = os.getenv("LOOM_DATABASE_URL", f"sqlite:///{_default_db_path}")
 
 # Create SQLAlchemy engine
 # PostgreSQL connections (including via RDS Proxy) use pool_pre_ping to detect

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -59,9 +59,9 @@ GROUP_SCOPES: dict[str, list[str]] = {
     ],
 
     # User groups (t-user users - can have multiple)
-    "g-users-demo": ["agent:read", "memory:read", "invoke"],
-    "g-users-test": ["agent:read", "memory:read", "invoke"],
-    "g-users-strategics": ["agent:read", "memory:read", "invoke"],
+    "g-users-demo": ["agent:read", "memory:read", "mcp:read", "invoke"],
+    "g-users-test": ["agent:read", "memory:read", "mcp:read", "invoke"],
+    "g-users-strategics": ["agent:read", "memory:read", "mcp:read", "invoke"],
 }
 
 ALL_SCOPES: set[str] = {s for scopes in GROUP_SCOPES.values() for s in scopes}

--- a/backend/app/models/mcp.py
+++ b/backend/app/models/mcp.py
@@ -20,6 +20,8 @@ class McpServer(Base):
     oauth2_client_id = Column(String, nullable=True)
     oauth2_client_secret = Column(String, nullable=True)
     oauth2_scopes = Column(String, nullable=True)  # space-separated
+    api_key_header_name = Column(String, nullable=True)  # e.g. 'x-api-key', 'Authorization'
+    has_admin_api_key = Column(String, nullable=True)  # 'true' or 'false'
     registry_record_id = Column(String, nullable=True)
     registry_status = Column(String, nullable=True)  # DRAFT, PENDING_APPROVAL, APPROVED, REJECTED, DEPRECATED
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
@@ -41,6 +43,8 @@ class McpServer(Base):
             "oauth2_client_id": self.oauth2_client_id,
             "oauth2_scopes": self.oauth2_scopes,
             "has_oauth2_secret": self.oauth2_client_secret is not None and self.oauth2_client_secret != "",
+            "api_key_header_name": self.api_key_header_name,
+            "has_admin_api_key": self.has_admin_api_key == "true",
             "registry_record_id": self.registry_record_id,
             "registry_status": self.registry_status,
             "created_at": (self.created_at.isoformat() + "Z") if self.created_at else None,

--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -285,6 +285,14 @@ def delete_a2a_agent(
     db: Session = Depends(get_db),
 ) -> A2aAgentResponse:
     agent = _get_agent_or_404(agent_id, db)
+    if agent.registry_record_id:
+        try:
+            from app.services.registry import get_registry_client
+            reg_client = get_registry_client()
+            reg_client.delete_record(agent.registry_record_id)
+            logger.info("Deleted registry record %s for A2A agent %s", agent.registry_record_id, agent.id)
+        except Exception as reg_err:
+            logger.warning("Failed to delete registry record for A2A agent %s: %s", agent.id, reg_err)
     result = A2aAgentResponse(**agent.to_dict())
     db.delete(agent)
     db.commit()

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -735,6 +735,7 @@ def _deploy_agent(request: AgentCreateRequest, db: Session, background_tasks: Ba
             "oauth2_client_id": s.oauth2_client_id,
             "oauth2_client_secret": s.oauth2_client_secret,
             "oauth2_scopes": s.oauth2_scopes,
+            "api_key_header_name": s.api_key_header_name,
         }
         for s in mcp_records
     ]
@@ -940,6 +941,13 @@ def _deploy_agent_background(
                 if server["oauth2_scopes"]:
                     auth_entry["scopes"] = server["oauth2_scopes"]
                 entry["auth"] = auth_entry
+            elif server["auth_type"] == "api_key":
+                secret_name = f"loom/mcp/{server['name']}/api-key/{{actor_id}}"
+                entry["auth"] = {
+                    "type": "api_key",
+                    "credentials_secret_arn": secret_name,
+                    "api_key_header_name": server["api_key_header_name"] or "x-api-key",
+                }
             mcp_server_configs.append(entry)
 
         # Build A2A agent configs from snapshots

--- a/backend/app/routers/invocations.py
+++ b/backend/app/routers/invocations.py
@@ -24,6 +24,7 @@ from app.models.session import InvocationSession
 from app.models.invocation import Invocation
 from app.models.authorizer_config import AuthorizerConfig
 from app.models.authorizer_credential import AuthorizerCredential
+from app.models.mcp import McpServer
 
 from app.services.agentcore import invoke_agent
 from app.services.cloudwatch import (
@@ -50,6 +51,7 @@ class InvokeRequest(BaseModel):
     credential_id: int | None = Field(default=None, description="Authorizer credential ID for token generation")
     bearer_token: str | None = Field(default=None, description="Manual bearer token for agent invocation")
     model_id: str | None = Field(default=None, description="Runtime model override (must be in agent's allowed_model_ids)")
+    connector_ids: list[int] | None = Field(default=None, description="User-enabled MCP connector IDs for runtime tool access")
 
 
 class InvocationResponse(BaseModel):
@@ -449,6 +451,7 @@ async def invoke_agent_stream(
     token_source: str | None = None,
     actor_id: str | None = None,
     runtime_model_id: str | None = None,
+    dynamic_mcp_servers: list[dict[str, Any]] | None = None,
 ) -> AsyncGenerator[str, None]:
     """
     Invoke the agent and yield SSE events as the response streams.
@@ -519,6 +522,8 @@ async def invoke_agent_stream(
             region=region,
             access_token=access_token,
             actor_id=actor_id,
+            dynamic_mcp_servers=dynamic_mcp_servers,
+            runtime_model_id=runtime_model_id,
         )
 
         # Stream chunks to frontend. Each next() call on the synchronous
@@ -924,9 +929,37 @@ async def invoke_agent_endpoint(
     logger.info("Invoking agent %s with token_source=%s, has_token=%s",
                 agent_id, token_source, bool(access_token))
 
+    # Resolve dynamic MCP connector configs for user-enabled connectors
+    dynamic_mcp_servers: list[dict[str, Any]] | None = None
+    if request_body.connector_ids:
+        actor_id = user.username or user.sub or "loom-agent"
+        mcp_records = db.query(McpServer).filter(McpServer.id.in_(request_body.connector_ids)).all()
+        dynamic_mcp_servers = []
+        for server in mcp_records:
+            entry: dict[str, Any] = {
+                "name": server.name,
+                "enabled": True,
+                "transport": server.transport_type,
+                "endpoint_url": server.endpoint_url,
+            }
+            if server.auth_type == "api_key":
+                secret_name = f"loom/mcp/{server.name}/api-key/{actor_id}"
+                entry["auth"] = {
+                    "type": "api_key",
+                    "credentials_secret_arn": secret_name,
+                    "api_key_header_name": server.api_key_header_name or "x-api-key",
+                }
+            elif server.auth_type == "oauth2":
+                entry["auth"] = {
+                    "type": "oauth2",
+                    "well_known_endpoint": server.oauth2_well_known_url or "",
+                }
+            dynamic_mcp_servers.append(entry)
+        logger.info("Resolved %d dynamic MCP connectors for invocation", len(dynamic_mcp_servers))
+
     # Return streaming response
     return StreamingResponse(
-        invoke_agent_stream(agent, session, invocation, db, client_invoke_time, request_body.prompt, access_token, token_source, user.username or user.sub or "loom-agent", runtime_model_id),
+        invoke_agent_stream(agent, session, invocation, db, client_invoke_time, request_body.prompt, access_token, token_source, user.username or user.sub or "loom-agent", runtime_model_id, dynamic_mcp_servers),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/backend/app/routers/mcp.py
+++ b/backend/app/routers/mcp.py
@@ -98,6 +98,14 @@ class McpToolResponse(BaseModel):
     last_refreshed_at: str | None = None
 
 
+class ConnectorInfo(BaseModel):
+    id: int
+    name: str
+    description: str | None = None
+    auth_type: str
+    has_user_api_key: bool = False
+
+
 class McpAccessRuleResponse(BaseModel):
     id: int
     server_id: int
@@ -190,6 +198,37 @@ def list_mcp_servers(
         query = query.filter(or_(McpServer.registry_status == "APPROVED", McpServer.registry_status.is_(None)))
     servers = query.order_by(McpServer.created_at.desc()).all()
     return [McpServerResponse(**s.to_dict()) for s in servers]
+
+
+@router.get("/connectors", response_model=list[ConnectorInfo])
+def list_connectors(
+    user: UserInfo = Depends(require_scopes("mcp:read")),
+    db: Session = Depends(get_db),
+) -> list[ConnectorInfo]:
+    """List MCP servers available as connectors with per-user API key status."""
+    query = db.query(McpServer)
+    if "t-user" in user.groups and "t-admin" not in user.groups:
+        query = query.filter(or_(McpServer.registry_status == "APPROVED", McpServer.registry_status.is_(None)))
+    servers = query.order_by(McpServer.name.asc()).all()
+    region = os.getenv("AWS_REGION", "us-east-1")
+    from app.services.secrets import get_secret
+    results: list[ConnectorInfo] = []
+    for server in servers:
+        has_key = False
+        if server.auth_type == "api_key":
+            try:
+                get_secret(f"loom/mcp/{server.name}/api-key/{user.sub}", region)
+                has_key = True
+            except Exception:
+                pass
+        results.append(ConnectorInfo(
+            id=server.id,
+            name=server.name,
+            description=server.description,
+            auth_type=server.auth_type,
+            has_user_api_key=has_key,
+        ))
+    return results
 
 
 @router.get("/{server_id}", response_model=McpServerResponse)

--- a/backend/app/routers/mcp.py
+++ b/backend/app/routers/mcp.py
@@ -1,6 +1,7 @@
 """MCP server management endpoints."""
 import json
 import logging
+import os
 from datetime import datetime
 from typing import Optional
 
@@ -16,6 +17,8 @@ from app.models.mcp import McpServer, McpTool, McpServerAccess
 from app.services.mcp import test_mcp_connection as svc_test_connection
 from app.services.mcp import fetch_mcp_tools as svc_fetch_tools
 from app.services.mcp import invoke_mcp_tool as svc_invoke_tool
+from app.services.mcp import resolve_api_key
+from app.services.secrets import store_secret, delete_secret
 
 logger = logging.getLogger(__name__)
 
@@ -35,14 +38,19 @@ class McpServerCreateRequest(BaseModel):
     oauth2_client_id: str | None = Field(None, description="OAuth2 client ID")
     oauth2_client_secret: str | None = Field(None, description="OAuth2 client secret")
     oauth2_scopes: str | None = Field(None, description="OAuth2 scopes (space-separated)")
+    api_key_header_name: str | None = Field(None, description="Header name for API key auth")
+    api_key: str | None = Field(None, description="Admin API key (stored in Secrets Manager)")
 
     @model_validator(mode="after")
-    def validate_oauth2_fields(self):
+    def validate_auth_fields(self):
         if self.auth_type == "oauth2":
             if not self.oauth2_well_known_url:
                 raise ValueError("oauth2_well_known_url is required when auth_type is 'oauth2'")
             if not self.oauth2_client_id:
                 raise ValueError("oauth2_client_id is required when auth_type is 'oauth2'")
+        if self.auth_type == "api_key":
+            if not self.api_key_header_name:
+                raise ValueError("api_key_header_name is required when auth_type is 'api_key'")
         return self
 
 
@@ -57,6 +65,8 @@ class McpServerUpdateRequest(BaseModel):
     oauth2_client_id: str | None = None
     oauth2_client_secret: str | None = None
     oauth2_scopes: str | None = None
+    api_key_header_name: str | None = None
+    api_key: str | None = None
 
 
 class McpServerResponse(BaseModel):
@@ -71,6 +81,8 @@ class McpServerResponse(BaseModel):
     oauth2_client_id: str | None = None
     oauth2_scopes: str | None = None
     has_oauth2_secret: bool = False
+    api_key_header_name: str | None = None
+    has_admin_api_key: bool = False
     registry_record_id: str | None = None
     registry_status: str | None = None
     created_at: str | None = None
@@ -156,6 +168,11 @@ def create_mcp_server(
         oauth2_client_secret=request.oauth2_client_secret,
         oauth2_scopes=request.oauth2_scopes,
     )
+    server.api_key_header_name = request.api_key_header_name
+    if request.auth_type == "api_key" and request.api_key:
+        region = os.getenv("AWS_REGION", "us-east-1")
+        store_secret(f"loom/mcp/{request.name}/admin-api-key", request.api_key, region, description=f"Admin API key for MCP server {request.name}")
+        server.has_admin_api_key = "true"
     db.add(server)
     db.commit()
     db.refresh(server)
@@ -195,8 +212,14 @@ def update_mcp_server(
     server = _get_server_or_404(server_id, db)
 
     update_data = request.model_dump(exclude_unset=True)
+    new_api_key = update_data.pop("api_key", None)
     for field, value in update_data.items():
         setattr(server, field, value)
+
+    if new_api_key:
+        region = os.getenv("AWS_REGION", "us-east-1")
+        store_secret(f"loom/mcp/{server.name}/admin-api-key", new_api_key, region, description=f"Admin API key for MCP server {server.name}")
+        server.has_admin_api_key = "true"
 
     server.updated_at = datetime.utcnow()
     db.commit()
@@ -211,6 +234,17 @@ def delete_mcp_server(
     db: Session = Depends(get_db),
 ) -> McpServerResponse:
     server = _get_server_or_404(server_id, db)
+    if server.registry_record_id:
+        try:
+            from app.services.registry import get_registry_client
+            reg_client = get_registry_client()
+            reg_client.delete_record(server.registry_record_id)
+            logger.info("Deleted registry record %s for MCP server %s", server.registry_record_id, server.id)
+        except Exception as reg_err:
+            logger.warning("Failed to delete registry record for MCP server %s: %s", server.id, reg_err)
+    if server.has_admin_api_key == "true":
+        region = os.getenv("AWS_REGION", "us-east-1")
+        delete_secret(f"loom/mcp/{server.name}/admin-api-key", region)
     result = McpServerResponse(**server.to_dict())
     db.delete(server)
     db.commit()
@@ -228,6 +262,8 @@ class TestConnectionRequest(BaseModel):
     oauth2_client_id: str | None = None
     oauth2_client_secret: str | None = None
     oauth2_scopes: str | None = None
+    api_key_header_name: str | None = None
+    api_key: str | None = None
 
 
 @router.post("/test-connection", response_model=TestConnectionResponse)
@@ -235,7 +271,7 @@ def test_connection_pre_create(
     request: TestConnectionRequest,
     user: UserInfo = Depends(require_scopes("mcp:write")),
 ) -> TestConnectionResponse:
-    result = svc_test_connection(request)
+    result = svc_test_connection(request, api_key=request.api_key)
     return TestConnectionResponse(**result)
 
 
@@ -246,7 +282,8 @@ def test_connection(
     db: Session = Depends(get_db),
 ) -> TestConnectionResponse:
     server = _get_server_or_404(server_id, db)
-    result = svc_test_connection(server)
+    api_key = resolve_api_key(server)
+    result = svc_test_connection(server, api_key=api_key)
     return TestConnectionResponse(**result)
 
 
@@ -271,8 +308,9 @@ def refresh_mcp_tools(
     db: Session = Depends(get_db),
 ) -> list[McpToolResponse]:
     server = _get_server_or_404(server_id, db)
+    api_key = resolve_api_key(server)
 
-    fetched_tools = svc_fetch_tools(server)
+    fetched_tools = svc_fetch_tools(server, api_key=api_key)
 
     # Clear existing tools
     db.query(McpTool).filter(McpTool.server_id == server_id).delete()
@@ -296,6 +334,24 @@ def refresh_mcp_tools(
     for t in new_tools:
         db.refresh(t)
 
+    if server.registry_record_id:
+        try:
+            from app.services.registry import get_registry_client
+            reg_client = get_registry_client()
+            tools_for_registry = db.query(McpTool).filter(McpTool.server_id == server_id).all()
+            descriptors = reg_client.build_mcp_descriptors(server, tools_for_registry)
+            reg_client.update_record(
+                record_id=server.registry_record_id,
+                name=server.name,
+                descriptor_type="MCP",
+                descriptors=descriptors,
+                record_version="1.0",
+                description=server.description,
+            )
+            logger.info("Updated registry record %s for MCP server %s", server.registry_record_id, server.id)
+        except Exception as reg_err:
+            logger.warning("Failed to update registry record for MCP server %s: %s", server.id, reg_err)
+
     return [McpToolResponse(**t.to_dict()) for t in new_tools]
 
 
@@ -307,8 +363,66 @@ def invoke_mcp_tool(
     db: Session = Depends(get_db),
 ) -> ToolInvokeResponse:
     server = _get_server_or_404(server_id, db)
-    result = svc_invoke_tool(server, request.tool_name, request.arguments)
+    api_key = resolve_api_key(server)
+    result = svc_invoke_tool(server, request.tool_name, request.arguments, api_key=api_key)
     return ToolInvokeResponse(**result)
+
+
+# ---------------------------------------------------------------------------
+# Per-user API keys
+# ---------------------------------------------------------------------------
+class UserApiKeyRequest(BaseModel):
+    api_key: str = Field(..., description="User's personal API key")
+
+
+class UserApiKeyStatusResponse(BaseModel):
+    has_user_api_key: bool
+
+
+@router.put("/{server_id}/api-key", response_model=UserApiKeyStatusResponse)
+def set_user_api_key(
+    server_id: int,
+    request: UserApiKeyRequest,
+    user: UserInfo = Depends(require_scopes("mcp:read")),
+    db: Session = Depends(get_db),
+) -> UserApiKeyStatusResponse:
+    server = _get_server_or_404(server_id, db)
+    region = os.getenv("AWS_REGION", "us-east-1")
+    store_secret(
+        f"loom/mcp/{server.name}/api-key/{user.sub}",
+        request.api_key,
+        region,
+        description=f"User API key for MCP server {server.name}",
+    )
+    return UserApiKeyStatusResponse(has_user_api_key=True)
+
+
+@router.get("/{server_id}/api-key/status", response_model=UserApiKeyStatusResponse)
+def get_user_api_key_status(
+    server_id: int,
+    user: UserInfo = Depends(require_scopes("mcp:read")),
+    db: Session = Depends(get_db),
+) -> UserApiKeyStatusResponse:
+    server = _get_server_or_404(server_id, db)
+    region = os.getenv("AWS_REGION", "us-east-1")
+    try:
+        from app.services.secrets import get_secret
+        get_secret(f"loom/mcp/{server.name}/api-key/{user.sub}", region)
+        return UserApiKeyStatusResponse(has_user_api_key=True)
+    except Exception:
+        return UserApiKeyStatusResponse(has_user_api_key=False)
+
+
+@router.delete("/{server_id}/api-key", response_model=UserApiKeyStatusResponse)
+def delete_user_api_key(
+    server_id: int,
+    user: UserInfo = Depends(require_scopes("mcp:read")),
+    db: Session = Depends(get_db),
+) -> UserApiKeyStatusResponse:
+    server = _get_server_or_404(server_id, db)
+    region = os.getenv("AWS_REGION", "us-east-1")
+    delete_secret(f"loom/mcp/{server.name}/api-key/{user.sub}", region)
+    return UserApiKeyStatusResponse(has_user_api_key=False)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/routers/registry.py
+++ b/backend/app/routers/registry.py
@@ -21,9 +21,13 @@ router = APIRouter(prefix="/api/registry", tags=["registry"])
 # ---------------------------------------------------------------------------
 # Pydantic models
 # ---------------------------------------------------------------------------
+MCP_NAMESPACES = ("aws.agentcore", "remote.mcp", "npm", "custom")
+
+
 class RegistryRecordCreateRequest(BaseModel):
     resource_type: str = Field(..., description="Resource type: 'mcp', 'a2a', or 'agent'")
     resource_id: int = Field(..., description="ID of the MCP server, A2A agent, or agent")
+    namespace: str | None = Field(None, description="Namespace prefix for MCP servers")
 
 
 class RegistryRecordResponse(BaseModel):
@@ -153,6 +157,12 @@ def create_record(
     client = get_registry_client()
 
     if request.resource_type == "mcp":
+        ns = request.namespace or "aws.agentcore"
+        if ns not in MCP_NAMESPACES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"namespace must be one of: {', '.join(MCP_NAMESPACES)}",
+            )
         server = db.query(McpServer).filter(McpServer.id == request.resource_id).first()
         if not server:
             raise HTTPException(
@@ -160,7 +170,7 @@ def create_record(
                 detail=f"MCP server with id {request.resource_id} not found",
             )
         tools = db.query(McpTool).filter(McpTool.server_id == server.id).all()
-        descriptors = client.build_mcp_descriptors(server, tools)
+        descriptors = client.build_mcp_descriptors(server, tools, namespace=ns)
         name = server.name
         description = server.description
         descriptor_type = "MCP"

--- a/backend/app/services/a2a.py
+++ b/backend/app/services/a2a.py
@@ -20,6 +20,11 @@ def _is_agentcore_url(base_url: str) -> bool:
     return "bedrock-agentcore" in base_url
 
 
+def _is_salesforce_url(base_url: str) -> bool:
+    """Detect if the base URL points to a Salesforce Agentforce endpoint."""
+    return "salesforce.com/einstein/ai-agent" in base_url
+
+
 def _get_oauth2_token(agent: Any) -> str | None:
     """Exchange OAuth2 client credentials for an access token."""
     if agent.auth_type != "oauth2" or not agent.oauth2_client_id or not agent.oauth2_client_secret:
@@ -76,6 +81,33 @@ def _build_headers(agent: Any) -> dict[str, str]:
     return headers
 
 
+def _fetch_salesforce_agent_card(base_url: str, headers: dict[str, str]) -> dict:
+    """Fetch the Agent Card from a Salesforce Agentforce A2A endpoint.
+
+    Salesforce uses /v1/card instead of /.well-known/agent.json and returns
+    401 for unknown paths rather than 404.
+    """
+    url = base_url + "/v1/card"
+    try:
+        resp = httpx.get(url, headers=headers, timeout=A2A_REQUEST_TIMEOUT, follow_redirects=True)
+        resp.raise_for_status()
+        return resp.json()
+    except httpx.HTTPStatusError as e:
+        status_code = e.response.status_code
+        friendly = {
+            401: "authentication required — check OAuth2 credentials",
+            403: "access denied — check OAuth2 credentials and scopes",
+        }
+        detail = friendly.get(status_code, e.response.text[:200])
+        raise ValueError(f"Salesforce Agent Card fetch failed (HTTP {status_code}): {detail}") from e
+    except httpx.ConnectError as e:
+        raise ValueError(f"Cannot connect to {base_url} — verify the URL is correct") from e
+    except httpx.TimeoutException as e:
+        raise ValueError(f"Connection to {base_url} timed out after {A2A_REQUEST_TIMEOUT}s") from e
+    except Exception as e:
+        raise ValueError(f"Failed to fetch Salesforce Agent Card from {url}: {e}") from e
+
+
 def fetch_agent_card(base_url: str, auth_headers: dict[str, str] | None = None) -> dict:
     """Fetch the Agent Card from the well-known endpoint.
 
@@ -91,6 +123,10 @@ def fetch_agent_card(base_url: str, auth_headers: dict[str, str] | None = None) 
     """
     stripped = base_url.rstrip("/")
     headers = auth_headers or {"Accept": "*/*"}
+
+    # Salesforce Agentforce: card is at /v1/card, not .well-known
+    if _is_salesforce_url(base_url):
+        return _fetch_salesforce_agent_card(stripped, headers)
 
     # Try AgentCore path first for AgentCore URLs, then standard; reverse for others
     if _is_agentcore_url(base_url):
@@ -128,7 +164,6 @@ def fetch_agent_card(base_url: str, auth_headers: dict[str, str] | None = None) 
         except Exception as e:
             raise ValueError(f"Failed to fetch Agent Card from {url}: {e}") from e
     else:
-        # Both paths returned 404/424
         raise ValueError(
             "No Agent Card found — tried both /.well-known/agent.json and "
             "/.well-known/agent-card.json. The underlying agent may not implement "

--- a/backend/app/services/agentcore.py
+++ b/backend/app/services/agentcore.py
@@ -6,7 +6,10 @@ for describing runtimes, listing endpoints, and invoking agents with streaming r
 """
 
 import json
+import logging
 from typing import Any, Generator
+
+logger = logging.getLogger(__name__)
 
 
 def describe_runtime(arn: str, region: str) -> dict[str, Any]:
@@ -79,6 +82,8 @@ def invoke_agent(
     region: str,
     access_token: str | None = None,
     actor_id: str | None = None,
+    dynamic_mcp_servers: list[dict[str, Any]] | None = None,
+    runtime_model_id: str | None = None,
 ) -> Generator[dict[str, Any], None, None]:
     """
     Invoke an AgentCore Runtime agent and stream the response.
@@ -108,6 +113,10 @@ def invoke_agent(
     from botocore.config import Config
 
     payload: dict[str, Any] = {"prompt": prompt, "session_id": session_id, "actor_id": actor_id or "loom-agent"}
+    if dynamic_mcp_servers:
+        payload["dynamic_mcp_servers"] = dynamic_mcp_servers
+    if runtime_model_id:
+        payload["model_id"] = runtime_model_id
     payload_bytes = json.dumps(payload).encode('utf-8')
 
     params: dict[str, Any] = {
@@ -145,9 +154,16 @@ def invoke_agent(
     if streaming_body is None:
         return
 
+    line_count = 0
     for line in streaming_body.iter_lines():
         decoded = line.decode('utf-8').strip()
+        if not decoded:
+            continue
+        line_count += 1
+        if line_count <= 10:
+            logger.info("Stream line %d: %s", line_count, decoded[:500])
         if not decoded.startswith('data:'):
+            logger.info("Non-data stream line: %s", decoded[:500])
             continue
         payload = decoded[5:].strip()  # strip "data:" prefix
         if not payload:
@@ -161,3 +177,4 @@ def invoke_agent(
         except json.JSONDecodeError:
             if payload:
                 yield {"type": "text", "content": payload}
+    logger.info("Stream completed: %d total lines received", line_count)

--- a/backend/app/services/mcp.py
+++ b/backend/app/services/mcp.py
@@ -1,9 +1,12 @@
 """MCP server connection and tool discovery service."""
 import json
 import logging
+import os
 from typing import Any
 
 import httpx
+
+from app.services.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -51,13 +54,38 @@ def _get_oauth2_token(server: Any) -> str | None:
         return None
 
 
-def _build_headers(server: Any) -> dict[str, str]:
+def resolve_api_key(server: Any, user_sub: str | None = None) -> str | None:
+    """Resolve API key from Secrets Manager. Admin key for admin context, user key for user context."""
+    if getattr(server, "auth_type", None) != "api_key":
+        return None
+    region = os.getenv("AWS_REGION", "us-east-1")
+    name = getattr(server, "name", "")
+    if user_sub:
+        try:
+            return get_secret(f"loom/mcp/{name}/api-key/{user_sub}", region)
+        except Exception:
+            return None
+    if getattr(server, "has_admin_api_key", None) == "true":
+        try:
+            return get_secret(f"loom/mcp/{name}/admin-api-key", region)
+        except Exception:
+            return None
+    return None
+
+
+def _build_headers(server: Any, api_key: str | None = None) -> dict[str, str]:
     """Build request headers, including auth if configured."""
     headers: dict[str, str] = {"Content-Type": "application/json"}
     if server.auth_type == "oauth2":
         token = _get_oauth2_token(server)
         if token:
             headers["Authorization"] = f"Bearer {token}"
+    elif server.auth_type == "api_key" and api_key:
+        header_name = getattr(server, "api_key_header_name", "x-api-key") or "x-api-key"
+        if header_name.lower() == "authorization":
+            headers["Authorization"] = f"Bearer {api_key}"
+        else:
+            headers[header_name] = api_key
     return headers
 
 
@@ -73,9 +101,10 @@ def _jsonrpc_request(method: str, params: dict | None = None, req_id: int = 1) -
     return msg
 
 
-def _call_streamable_http(server: Any, method: str, params: dict | None = None) -> dict | None:
+def _call_streamable_http(server: Any, method: str, params: dict | None = None, api_key: str | None = None) -> dict | None:
     """Call an MCP server using Streamable HTTP (POST JSON-RPC)."""
-    headers = _build_headers(server)
+    headers = _build_headers(server, api_key)
+    headers["Accept"] = "application/json, text/event-stream"
     body = _jsonrpc_request(method, params)
 
     try:
@@ -98,14 +127,14 @@ def _call_streamable_http(server: Any, method: str, params: dict | None = None) 
         return None
 
 
-def _call_sse(server: Any, method: str, params: dict | None = None) -> dict | None:
+def _call_sse(server: Any, method: str, params: dict | None = None, api_key: str | None = None) -> dict | None:
     """Call an MCP server using SSE transport.
 
     SSE transport: POST JSON-RPC to the endpoint, receive SSE stream back.
     Some SSE servers accept POST directly; others require establishing an SSE
     connection first. We try the POST approach which is the MCP standard.
     """
-    headers = _build_headers(server)
+    headers = _build_headers(server, api_key)
     headers["Accept"] = "text/event-stream"
     body = _jsonrpc_request(method, params)
 
@@ -148,15 +177,15 @@ def _parse_sse_response(text: str) -> dict | None:
     return None
 
 
-def _call_mcp(server: Any, method: str, params: dict | None = None) -> dict | None:
+def _call_mcp(server: Any, method: str, params: dict | None = None, api_key: str | None = None) -> dict | None:
     """Call an MCP server using the configured transport."""
     if server.transport_type == "streamable_http":
-        return _call_streamable_http(server, method, params)
+        return _call_streamable_http(server, method, params, api_key)
     else:
-        return _call_sse(server, method, params)
+        return _call_sse(server, method, params, api_key)
 
 
-def test_mcp_connection(server: Any) -> dict:
+def test_mcp_connection(server: Any, api_key: str | None = None) -> dict:
     """Test connectivity to an MCP server.
 
     Sends an `initialize` JSON-RPC request to verify the server is reachable
@@ -168,7 +197,7 @@ def test_mcp_connection(server: Any) -> dict:
         "clientInfo": {"name": "loom", "version": "1.0.0"},
     }
 
-    result = _call_mcp(server, "initialize", init_params)
+    result = _call_mcp(server, "initialize", init_params, api_key)
 
     if result is None:
         return {"success": False, "message": f"Failed to connect to {server.endpoint_url}"}
@@ -185,9 +214,9 @@ def test_mcp_connection(server: Any) -> dict:
     return {"success": True, "message": f"Connected to {server_name}{version_str}"}
 
 
-def fetch_mcp_tools(server: Any) -> list[dict]:
+def fetch_mcp_tools(server: Any, api_key: str | None = None) -> list[dict]:
     """Fetch available tools from an MCP server via the tools/list method."""
-    result = _call_mcp(server, "tools/list")
+    result = _call_mcp(server, "tools/list", api_key=api_key)
 
     if result is None:
         logger.warning("No response from %s for tools/list", server.endpoint_url)
@@ -214,14 +243,14 @@ def fetch_mcp_tools(server: Any) -> list[dict]:
     return tools
 
 
-def invoke_mcp_tool(server: Any, tool_name: str, arguments: dict) -> dict:
+def invoke_mcp_tool(server: Any, tool_name: str, arguments: dict, api_key: str | None = None) -> dict:
     """Invoke a tool on an MCP server via the tools/call method.
 
     Returns a dict with 'success', 'result' (on success), and 'error' (on failure).
     The 'request' field always contains the sent arguments for display purposes.
     """
     params = {"name": tool_name, "arguments": arguments}
-    result = _call_mcp(server, "tools/call", params)
+    result = _call_mcp(server, "tools/call", params, api_key)
 
     if result is None:
         return {

--- a/backend/app/services/registry.py
+++ b/backend/app/services/registry.py
@@ -199,6 +199,42 @@ class RegistryClient:
             statusReason=reason,
         )
 
+    def update_record(
+        self,
+        record_id: str,
+        name: str,
+        descriptor_type: str,
+        descriptors: dict[str, Any],
+        record_version: str,
+        description: str | None = None,
+    ) -> dict[str, Any]:
+        if not self._require_registry():
+            return {}
+        update_descriptors = self._wrap_descriptors_for_update(descriptors)
+        kwargs: dict[str, Any] = dict(
+            registryId=self.registry_id,
+            recordId=record_id,
+            name=name,
+            descriptorType=descriptor_type,
+            descriptors=update_descriptors,
+            recordVersion=record_version,
+        )
+        if description:
+            kwargs["description"] = {"optionalValue": description}
+        logger.info("update_record payload: %s", json.dumps(kwargs, indent=2, default=str))
+        return self.control.update_registry_record(**kwargs)
+
+    @staticmethod
+    def _wrap_descriptors_for_update(descriptors: dict[str, Any]) -> dict[str, Any]:
+        """Wrap create-style descriptors in the optionalValue structure required by UpdateRegistryRecord."""
+        inner = {}
+        for dtype, fields in descriptors.items():
+            wrapped_fields = {}
+            for field_name, field_value in fields.items():
+                wrapped_fields[field_name] = {"optionalValue": field_value}
+            inner[dtype] = {"optionalValue": wrapped_fields}
+        return {"optionalValue": inner}
+
     def delete_record(self, record_id: str) -> dict[str, Any]:
         if not self._require_registry():
             return {}
@@ -219,13 +255,22 @@ class RegistryClient:
 
     # -- descriptor builders -------------------------------------------------
     @staticmethod
-    def build_mcp_descriptors(server: McpServer, tools: list[McpTool]) -> dict[str, Any]:
-        """Build MCP-type descriptors conforming to the MCP protocol spec."""
-        namespaced_name = f"aws.agentcore/{server.name}"
-        server_info = {
+    def build_mcp_descriptors(server: McpServer, tools: list[McpTool], namespace: str = "aws.agentcore") -> dict[str, Any]:
+        """Build MCP-type descriptors conforming to the MCP InitializeResult schema."""
+        MCP_DESCRIPTION_MAX_LENGTH = 100
+        namespaced_name = f"{namespace}/{server.name}"
+        server_info: dict[str, Any] = {
             "name": namespaced_name,
-            "description": server.description or "",
+            "description": (server.description or "")[:MCP_DESCRIPTION_MAX_LENGTH],
+            "protocolVersion": "2025-12-11",
             "version": "1.0.0",
+            "capabilities": {
+                "tools": {},
+            },
+            "serverInfo": {
+                "name": namespaced_name,
+                "version": "1.0.0",
+            },
             "packages": [{
                 "registryType": "npm",
                 "identifier": namespaced_name,
@@ -233,12 +278,14 @@ class RegistryClient:
                 "transport": {"type": "stdio"},
             }],
         }
+        if server.description:
+            server_info["instructions"] = server.description[:MCP_DESCRIPTION_MAX_LENGTH]
 
         tool_definitions = []
         for tool in tools:
             tool_def: dict[str, Any] = {
                 "name": tool.tool_name,
-                "description": tool.description or "",
+                "description": (tool.description or "")[:MCP_DESCRIPTION_MAX_LENGTH],
             }
             schema = tool.get_input_schema()
             if schema:
@@ -249,8 +296,12 @@ class RegistryClient:
 
         return {
             "mcp": {
-                "server": {"inlineContent": json.dumps(server_info)},
-                "tools": {"inlineContent": json.dumps({"tools": tool_definitions})},
+                "server": {
+                    "inlineContent": json.dumps(server_info),
+                },
+                "tools": {
+                    "inlineContent": json.dumps({"tools": tool_definitions}),
+                },
             }
         }
 

--- a/backend/app/services/secrets.py
+++ b/backend/app/services/secrets.py
@@ -46,6 +46,18 @@ def store_secret(name: str, secret_value: str, region: str, description: str = "
         arn = response["ARN"]
         logger.info("Updated existing secret %s", name)
         return arn
+    except client.exceptions.InvalidRequestException as e:
+        if "scheduled for deletion" in str(e):
+            # Restore the secret then update its value
+            client.restore_secret(SecretId=name)
+            response = client.put_secret_value(
+                SecretId=name,
+                SecretString=secret_value,
+            )
+            arn = response["ARN"]
+            logger.info("Restored and updated secret %s (was pending deletion)", name)
+            return arn
+        raise
 
 
 def get_secret(name: str, region: str) -> str:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -56,9 +56,9 @@ class TestDeriveScopes(unittest.TestCase):
         self.assertIn("a2a:write", scopes)
 
     def test_derive_scopes_for_users_demo_has_minimal_scopes(self) -> None:
-        """Test that g-users-demo group has only agent:read, memory:read, invoke."""
+        """Test that g-users-demo group has agent:read, memory:read, mcp:read, invoke."""
         scopes = derive_scopes(["g-users-demo"])
-        self.assertEqual(scopes, {"agent:read", "memory:read", "invoke"})
+        self.assertEqual(scopes, {"agent:read", "memory:read", "mcp:read", "invoke"})
 
 
 class TestJWTValidator(unittest.TestCase):

--- a/backend/tests/test_registry.py
+++ b/backend/tests/test_registry.py
@@ -198,14 +198,29 @@ class TestRegistryRouter(unittest.TestCase):
         response = self.client.post("/api/registry/records", json={
             "resource_type": "mcp",
             "resource_id": server.id,
+            "namespace": "remote.mcp",
         })
         self.assertEqual(response.status_code, 201)
         data = response.json()
         self.assertEqual(data["record_id"], "rec-new")
+        mock_client.build_mcp_descriptors.assert_called_once()
+        call_kwargs = mock_client.build_mcp_descriptors.call_args
+        self.assertEqual(call_kwargs.kwargs.get("namespace"), "remote.mcp")
 
         self.session.refresh(server)
         self.assertEqual(server.registry_record_id, "rec-new")
         self.assertEqual(server.registry_status, "DRAFT")
+
+    @patch("app.routers.registry.get_registry_client")
+    def test_create_record_mcp_invalid_namespace(self, mock_get_client):
+        server = self._create_mcp_server()
+        mock_get_client.return_value = MagicMock()
+        response = self.client.post("/api/registry/records", json={
+            "resource_type": "mcp",
+            "resource_id": server.id,
+            "namespace": "invalid.ns",
+        })
+        self.assertEqual(response.status_code, 400)
 
     @patch("app.routers.registry.get_registry_client")
     def test_create_record_a2a(self, mock_get_client):
@@ -485,18 +500,59 @@ class TestRegistryService(unittest.TestCase):
         mcp = descriptors["mcp"]
         self.assertIn("server", mcp)
         self.assertIn("tools", mcp)
+        self.assertNotIn("schemaVersion", mcp["server"])
         server_info = json.loads(mcp["server"]["inlineContent"])
         self.assertEqual(server_info["name"], "aws.agentcore/test-server")
         self.assertEqual(server_info["description"], "A test server")
+        self.assertEqual(server_info["protocolVersion"], "2025-12-11")
         self.assertEqual(server_info["version"], "1.0.0")
-        self.assertNotIn("protocolVersion", server_info)
-        self.assertNotIn("url", server_info)
-        self.assertNotIn("transport", server_info)
+        self.assertIn("capabilities", server_info)
+        self.assertEqual(server_info["serverInfo"]["name"], "aws.agentcore/test-server")
+        self.assertEqual(server_info["serverInfo"]["version"], "1.0.0")
+        self.assertEqual(server_info["instructions"], "A test server")
+        self.assertEqual(server_info["packages"][0]["identifier"], "aws.agentcore/test-server")
+        self.assertNotIn("protocolVersion", mcp["tools"])
         tools_wrapper = json.loads(mcp["tools"]["inlineContent"])
         self.assertIn("tools", tools_wrapper)
         self.assertEqual(len(tools_wrapper["tools"]), 1)
         self.assertEqual(tools_wrapper["tools"][0]["name"], "hello")
         self.assertIn("inputSchema", tools_wrapper["tools"][0])
+
+    def test_build_mcp_descriptors_truncates_long_descriptions(self):
+        from app.services.registry import RegistryClient
+
+        long_desc = "A" * 150
+        server = McpServer(
+            name="test-server",
+            description=long_desc,
+            endpoint_url="http://localhost:3000/mcp",
+            transport_type="sse",
+        )
+        tool = McpTool(server_id=1, tool_name="hello", description=long_desc)
+        tool.set_input_schema({"type": "object", "properties": {}})
+
+        descriptors = RegistryClient.build_mcp_descriptors(server, [tool])
+        mcp = descriptors["mcp"]
+        server_info = json.loads(mcp["server"]["inlineContent"])
+        self.assertEqual(len(server_info["description"]), 100)
+        self.assertEqual(len(server_info["instructions"]), 100)
+        tools_wrapper = json.loads(mcp["tools"]["inlineContent"])
+        self.assertEqual(len(tools_wrapper["tools"][0]["description"]), 100)
+
+    def test_build_mcp_descriptors_custom_namespace(self):
+        from app.services.registry import RegistryClient
+
+        server = McpServer(
+            name="exa-search",
+            description="Exa search",
+            endpoint_url="http://localhost:3000/mcp",
+            transport_type="sse",
+        )
+        descriptors = RegistryClient.build_mcp_descriptors(server, [], namespace="remote.mcp")
+        server_info = json.loads(descriptors["mcp"]["server"]["inlineContent"])
+        self.assertEqual(server_info["name"], "remote.mcp/exa-search")
+        self.assertEqual(server_info["serverInfo"]["name"], "remote.mcp/exa-search")
+        self.assertEqual(server_info["packages"][0]["identifier"], "remote.mcp/exa-search")
 
     def test_build_agent_descriptors(self):
         from app.services.registry import RegistryClient

--- a/backend/tests/test_scopes.py
+++ b/backend/tests/test_scopes.py
@@ -29,10 +29,10 @@ class TestDeriveScopes(unittest.TestCase):
         scopes = derive_scopes(["t-admin", "g-admins-super"])
         self.assertEqual(scopes, ALL_SCOPES)
 
-    def test_users_group_only_has_invoke(self) -> None:
+    def test_users_group_has_read_and_invoke(self) -> None:
         scopes = derive_scopes(["t-user", "g-users-demo"])
         self.assertEqual(scopes, {
-            "agent:read", "memory:read", "invoke",
+            "agent:read", "memory:read", "mcp:read", "invoke",
         })
 
     def test_multiple_groups_union(self) -> None:

--- a/frontend/SPECIFICATIONS.md
+++ b/frontend/SPECIFICATIONS.md
@@ -418,8 +418,9 @@ Accessed by clicking a server card/row. Shows:
 Create/edit form with:
 - Name (required, 1/3 width) and Endpoint URL (required, flex-1) and Transport Type (select: SSE/Streamable HTTP, 180px)
 - Description (textarea)
-- Authentication section: radio toggle for None / OAuth2
+- Authentication section: radio toggle for None / OAuth2 / API Key
 - When OAuth2: well-known URL, client ID, client secret (password input with "(unchanged)" placeholder in edit mode), scopes (space-separated)
+- When API Key: Header Name dropdown (`x-api-key` or `Authorization`), API Key password input (with "(unchanged)" placeholder in edit mode when admin key exists)
 - "Test Connection" button (only shown in edit mode) with success/failure badge result
 - Create/Update and Cancel buttons
 
@@ -693,8 +694,8 @@ The invoke panel's credential dropdown includes a "Manual token" sentinel value.
 
 ### Key Components
 - **A2aAgentForm** — Create/edit form for A2A agents with base URL input and progressive OAuth2 disclosure (auth_type toggle reveals well-known URL, client ID, secret, scopes). Test connection button in edit mode.
-- **A2aAgentCardView** — Structured display of the full Agent Card: header (name, version, status, provider, documentation, refresh button with last-fetched timestamp), capabilities (streaming, push notifications, state history as enabled/disabled badges), authentication schemes, input/output mode badges, and skills list.
-- **A2aSkillList** — Expandable skill cards with name, skill ID, description, tag badges, examples (bulleted list), and input/output mode overrides.
+- **A2aAgentCardView** — Structured display of the full Agent Card: header (name, version, status, provider, documentation, refresh button with last-fetched timestamp), capabilities and default modes displayed inline (streaming yes/no, push notifications, state history as badges, input/output modes with "none" fallback for empty arrays), authentication schemes, and skills list.
+- **A2aSkillList** — Compact expandable skill rows matching MCP tool list style. Each row shows name and description with chevron toggle. Expanded view shows skill ID, tag badges, examples (bulleted list), and input/output mode overrides. Single-column grid layout.
 - **A2aAccessControl** — Per-persona access control for A2A agent skills. Checkbox to grant/revoke access, all_skills/selected_skills radio, individual skill checkboxes with descriptions. Deny by default.
 
 ### Views
@@ -802,7 +803,7 @@ A "Previewing end-user experience as [user]" banner is shown to admins when in v
 - Input area with rounded border container: Textarea at top (borderless), footer row with model picker (left of Send) and Send/Cancel buttons (right)
 
 **Model selection:**
-- Model picker button in the input area footer, shown when the agent has multiple allowed models. Displays the current model's display name (or agent default). Click to open a dropdown of available models; click-outside-to-close behavior via `mousedown` listener. Default model marked with "(default)" suffix. Selecting a model sets `selectedModelId`; selecting the default clears it to `null`. Model selection resets when switching agents. The selected non-default model ID is passed as `model_id` in the invoke request.
+- Model picker button in the input area footer (right side, left of Send), shown when the agent has multiple allowed models. Displays the current model's display name (or agent default). Click to open a dropdown grouped by vendor via `groupModels()` with section headers; click-outside-to-close behavior via `mousedown` listener. Default model marked with "(default)" suffix. Selecting a model sets `selectedModelId`; selecting the default clears it to `null`. Model selection resets when switching agents. The selected non-default model ID is passed as `model_id` in the invoke request.
 
 **Session management:**
 - New conversations start with no session ID; a new `InvocationSession` is created automatically on first invocation
@@ -817,6 +818,15 @@ A "Previewing end-user experience as [user]" banner is shown to admins when in v
 
 **`useInvoke` subscription stability:**
 - `clearInvokeState(agentId)` resets the module-level store to `EMPTY` and notifies subscribers, but does NOT remove the listener set for the agent. This keeps the component's subscription alive after "New Conversation" so that subsequent invocations correctly propagate to the UI. Deleting the listener entry (the prior behavior) caused a silent state-update drop where streams ran to completion without any React re-renders.
+
+**MCP Connectors:**
+- "Connectors" button in the input area footer (left of model picker), shown when MCP connectors are available
+- Dropdown lists MCP servers with per-server toggle switches (green when enabled)
+- API key connectors (`auth_type === "api_key"`) show a KeyRound icon when key is not set; toggling on prompts a modal dialog for key entry. Disconnect (Unplug icon) deletes the stored key from Secrets Manager.
+- OAuth2 connectors show "OAuth2" label when disabled (currently no user-side auth flow — admin-configured credentials are used)
+- Enabled connector state persisted to `localStorage` per agent (`loom:enabledConnectors:{agentId}`) and reset when switching agents
+- Active connector count shown as a green badge on the Connectors button
+- Connector IDs are passed through the invoke request as `connector_ids`
 
 **Abstractions (admin details hidden):**
 - No qualifier picker (always uses `DEFAULT`)
@@ -851,4 +861,4 @@ Accessible via the "My Memory" sidebar button when the selected agent has memory
 - **Real-time auto-refresh** of sessions and metrics
 - **Log stream selection** and agent-level log viewer
 - **Latency charts** using Recharts
-- **Memory integration** with agent deployment (attach memory to agents)
+- **OAuth2 user-side connector auth flow** for MCP connectors requiring OAuth2 in the ChatPage

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -202,6 +202,8 @@ function AppContent() {
 
   const [activePersona, setActivePersona] = useState<Persona>(getDefaultPersona());
   const [viewAsUser, setViewAsUser] = useState<string | null>(null);
+  const [pendingMcpId, setPendingMcpId] = useState<number | null>(null);
+  const [pendingA2aId, setPendingA2aId] = useState<number | null>(null);
 
   // Reset all navigation state when user logs in
   useEffect(() => {
@@ -290,6 +292,8 @@ function AppContent() {
     if (isAuthenticated && (activePersona === "catalog" || activePersona === "builder")) {
       void fetchAgents();
     }
+    if (activePersona !== "mcp") setPendingMcpId(null);
+    if (activePersona !== "a2a") setPendingA2aId(null);
   }, [activePersona, isAuthenticated, fetchAgents]);
 
   const [registryEnabled, setRegistryEnabled] = useState(false);
@@ -400,7 +404,7 @@ function AppContent() {
     }
   };
 
-  // Breadcrumb (only for catalog persona drill-down)
+  // Breadcrumb (for builder/agents persona drill-down)
   const breadcrumb: { label: string; onClick?: () => void }[] = [
     {
       label: "Agents",
@@ -658,7 +662,7 @@ function AppContent() {
 
       {/* Main content */}
       <div className="flex-1 flex flex-col overflow-y-auto">
-        {activePersona === "catalog" && selectedAgentId !== null && (
+        {activePersona === "builder" && selectedAgentId !== null && (
           <header className="border-b">
             <div className="max-w-7xl px-8 py-3 flex items-center justify-between gap-4">
               <nav className="flex items-center gap-1 text-sm text-muted-foreground min-w-0">
@@ -684,6 +688,28 @@ function AppContent() {
 
         <main className="max-w-7xl px-8 py-6 flex-1 w-full">
           {activePersona === "catalog" && (
+            <CatalogPage
+              agents={agents}
+              loading={loading}
+              viewMode={catalogViewMode}
+              onViewModeChange={setCatalogViewMode}
+              onSelectAgent={(id) => { handleSelectAgent(id); setActivePersona("builder"); }}
+              onRefreshAgent={refreshAgent}
+              onDelete={handleDelete}
+              readOnly={!effectiveHasScope("agent:write")}
+              agentDeleteStartTimes={deleteStartTimes}
+              canViewAgents={effectiveHasScope("agent:read")}
+              canViewMemories={effectiveHasScope("memory:read")}
+              canViewMcp={effectiveHasScope("mcp:read")}
+              canViewA2a={effectiveHasScope("a2a:read")}
+              groupRestriction={groupRestriction}
+              userGroups={viewAsUser ? (USER_GROUPS[viewAsUser] ?? []) : (user?.groups ?? [])}
+              onNavigateToMcp={(serverId) => { setPendingMcpId(serverId); setActivePersona("mcp"); }}
+              onNavigateToA2a={(agentId) => { setPendingA2aId(agentId); setActivePersona("a2a"); }}
+            />
+          )}
+
+          {activePersona === "builder" && (
             <>
               {selectedAgentId !== null && (
                 <Button variant="ghost" size="sm" onClick={handleBack} className="mb-4">
@@ -692,21 +718,20 @@ function AppContent() {
               )}
 
               {selectedAgentId === null && (
-                <CatalogPage
+                <AgentListPage
                   agents={agents}
                   loading={loading}
-                  viewMode={catalogViewMode}
-                  onViewModeChange={setCatalogViewMode}
+                  viewMode={agentsViewMode}
+                  onViewModeChange={setAgentsViewMode}
+                  onRegister={registerAgent}
+                  onDeploy={deployAgent}
                   onSelectAgent={handleSelectAgent}
                   onRefreshAgent={refreshAgent}
                   onDelete={handleDelete}
                   readOnly={!effectiveHasScope("agent:write")}
-                  agentDeleteStartTimes={deleteStartTimes}
-                  canViewAgents={effectiveHasScope("agent:read")}
-                  canViewMemories={effectiveHasScope("memory:read")}
-                  canViewMcp={effectiveHasScope("mcp:read")}
-                  canViewA2a={effectiveHasScope("a2a:read")}
                   groupRestriction={groupRestriction}
+                  ownerRestriction={ownerRestriction}
+                  deleteStartTimes={deleteStartTimes}
                   userGroups={viewAsUser ? (USER_GROUPS[viewAsUser] ?? []) : (user?.groups ?? [])}
                 />
               )}
@@ -750,33 +775,11 @@ function AppContent() {
             </>
           )}
 
-          {activePersona === "builder" && (
-            <AgentListPage
-              agents={agents}
-              loading={loading}
-              viewMode={agentsViewMode}
-              onViewModeChange={setAgentsViewMode}
-              onRegister={registerAgent}
-              onDeploy={deployAgent}
-              onSelectAgent={(id) => {
-                handleSelectAgent(id);
-                setActivePersona("catalog");
-              }}
-              onRefreshAgent={refreshAgent}
-              onDelete={handleDelete}
-              readOnly={!effectiveHasScope("agent:write")}
-              groupRestriction={groupRestriction}
-              ownerRestriction={ownerRestriction}
-              deleteStartTimes={deleteStartTimes}
-              userGroups={viewAsUser ? (USER_GROUPS[viewAsUser] ?? []) : (user?.groups ?? [])}
-            />
-          )}
-
           {activePersona === "security" && <SecurityAdminPage readOnly={!effectiveHasScope("security:write")} />}
           {activePersona === "memory" && <MemoryManagementPage viewMode={memoryViewMode} onViewModeChange={setMemoryViewMode} readOnly={!effectiveHasScope("memory:write")} groupRestriction={groupRestriction} ownerRestriction={ownerRestriction} userGroups={viewAsUser ? (USER_GROUPS[viewAsUser] ?? []) : (user?.groups ?? [])} />}
           {activePersona === "tagging" && <TaggingPage readOnly={!effectiveHasScope("tagging:write")} userGroups={user?.groups || []} />}
-          {activePersona === "mcp" && <McpServersPage viewMode={mcpViewMode} onViewModeChange={setMcpViewMode} readOnly={!effectiveHasScope("mcp:write")} />}
-          {activePersona === "a2a" && <A2aAgentsPage viewMode={a2aViewMode} onViewModeChange={setA2aViewMode} readOnly={!effectiveHasScope("a2a:write")} />}
+          {activePersona === "mcp" && <McpServersPage viewMode={mcpViewMode} onViewModeChange={setMcpViewMode} readOnly={!effectiveHasScope("mcp:write")} initialSelectedId={pendingMcpId} key={`mcp-${pendingMcpId}`} />}
+          {activePersona === "a2a" && <A2aAgentsPage viewMode={a2aViewMode} onViewModeChange={setA2aViewMode} readOnly={!effectiveHasScope("a2a:write")} initialSelectedId={pendingA2aId} key={`a2a-${pendingA2aId}`} />}
           {activePersona === "registry" && <RegistryPage readOnly={!effectiveHasScope("registry:write")} isEndUserRole={effectiveUserGroups.includes("t-user") && !effectiveUserGroups.includes("t-admin")} />}
           {activePersona === "settings" && <SettingsPage />}
           {activePersona === "costs" && (

--- a/frontend/src/api/mcp.ts
+++ b/frontend/src/api/mcp.ts
@@ -9,10 +9,15 @@ import type {
   ToolInvokeRequest,
   ToolInvokeResult,
   TestConnectionResult,
+  ConnectorInfo,
 } from "./types";
 
 export function listMcpServers(): Promise<McpServer[]> {
   return apiFetch<McpServer[]>("/api/mcp/servers");
+}
+
+export function listConnectors(): Promise<ConnectorInfo[]> {
+  return apiFetch<ConnectorInfo[]>("/api/mcp/servers/connectors");
 }
 
 export function getMcpServer(id: number): Promise<McpServer> {

--- a/frontend/src/api/mcp.ts
+++ b/frontend/src/api/mcp.ts
@@ -87,3 +87,18 @@ export function updateServerAccess(serverId: number, request: McpAccessUpdateReq
     body: JSON.stringify(request),
   });
 }
+
+export function setUserApiKey(serverId: number, apiKey: string): Promise<{ has_user_api_key: boolean }> {
+  return apiFetch(`/api/mcp/servers/${serverId}/api-key`, {
+    method: "PUT",
+    body: JSON.stringify({ api_key: apiKey }),
+  });
+}
+
+export function getUserApiKeyStatus(serverId: number): Promise<{ has_user_api_key: boolean }> {
+  return apiFetch(`/api/mcp/servers/${serverId}/api-key/status`);
+}
+
+export function deleteUserApiKey(serverId: number): Promise<{ has_user_api_key: boolean }> {
+  return apiFetch(`/api/mcp/servers/${serverId}/api-key`, { method: "DELETE" });
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -173,6 +173,7 @@ export interface InvokeRequest {
   credential_id?: number;
   bearer_token?: string;
   model_id?: string;
+  connector_ids?: number[];
 }
 
 export interface InvocationResponse {
@@ -555,6 +556,14 @@ export interface TagProfile {
 export interface TagProfileCreateRequest {
   name: string;
   tags: Record<string, string>;
+}
+
+export interface ConnectorInfo {
+  id: number;
+  name: string;
+  description: string | null;
+  auth_type: "none" | "oauth2" | "api_key";
+  has_user_api_key: boolean;
 }
 
 // MCP Server types

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -565,11 +565,13 @@ export interface McpServer {
   endpoint_url: string;
   transport_type: "sse" | "streamable_http";
   status: "active" | "inactive" | "error";
-  auth_type: "none" | "oauth2";
+  auth_type: "none" | "oauth2" | "api_key";
   oauth2_well_known_url: string | null;
   oauth2_client_id: string | null;
   oauth2_scopes: string | null;
   has_oauth2_secret: boolean;
+  api_key_header_name: string | null;
+  has_admin_api_key: boolean;
   created_at: string | null;
   updated_at: string | null;
   registry_record_id: string | null;
@@ -581,11 +583,13 @@ export interface McpServerCreateRequest {
   description?: string;
   endpoint_url: string;
   transport_type: "sse" | "streamable_http";
-  auth_type?: "none" | "oauth2";
+  auth_type?: "none" | "oauth2" | "api_key";
   oauth2_well_known_url?: string;
   oauth2_client_id?: string;
   oauth2_client_secret?: string;
   oauth2_scopes?: string;
+  api_key_header_name?: string;
+  api_key?: string;
 }
 
 export interface McpServerUpdateRequest {
@@ -594,11 +598,13 @@ export interface McpServerUpdateRequest {
   endpoint_url?: string;
   transport_type?: "sse" | "streamable_http";
   status?: "active" | "inactive" | "error";
-  auth_type?: "none" | "oauth2";
+  auth_type?: "none" | "oauth2" | "api_key";
   oauth2_well_known_url?: string;
   oauth2_client_id?: string;
   oauth2_client_secret?: string;
   oauth2_scopes?: string;
+  api_key_header_name?: string;
+  api_key?: string;
 }
 
 export interface McpTool {
@@ -856,9 +862,12 @@ export interface RegistryRecordDetail extends RegistryRecord {
   status_reason: string | null;
 }
 
+export type McpNamespace = "aws.agentcore" | "remote.mcp" | "npm" | "custom";
+
 export interface RegistryRecordCreateRequest {
   resource_type: "mcp" | "a2a" | "agent";
   resource_id: number;
+  namespace?: McpNamespace;
 }
 
 export interface RegistrySearchResult {

--- a/frontend/src/components/A2aAgentCardView.tsx
+++ b/frontend/src/components/A2aAgentCardView.tsx
@@ -80,10 +80,49 @@ export function A2aAgentCardView({ agent, onRefresh, refreshing }: A2aAgentCardV
         </div>
       )}
 
+      {/* Capabilities & Modes */}
+      <div className="space-y-0.5 text-xs text-muted-foreground">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-muted-foreground/70">Capabilities:</span>
+          <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+            streaming: {agent.capabilities.streaming ? "yes" : "no"}
+          </Badge>
+          {agent.capabilities.pushNotifications !== undefined && (
+            <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+              push notifications: {agent.capabilities.pushNotifications ? "yes" : "no"}
+            </Badge>
+          )}
+          {agent.capabilities.stateTransitionHistory !== undefined && (
+            <Badge variant="outline" className="text-[10px] px-1.5 py-0">
+              state history: {agent.capabilities.stateTransitionHistory ? "yes" : "no"}
+            </Badge>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-muted-foreground/70">Default Modes:</span>
+          <span className="text-[10px] text-muted-foreground/70">Input:</span>
+          {agent.default_input_modes.length > 0 ? agent.default_input_modes.map((m) => (
+            <Badge key={m} variant="outline" className="text-[10px] px-1.5 py-0">
+              {m}
+            </Badge>
+          )) : (
+            <span className="text-[10px] text-muted-foreground/50">none</span>
+          )}
+          <span className="text-[10px] text-muted-foreground/70 ml-1">Output:</span>
+          {agent.default_output_modes.length > 0 ? agent.default_output_modes.map((m) => (
+            <Badge key={m} variant="outline" className="text-[10px] px-1.5 py-0">
+              {m}
+            </Badge>
+          )) : (
+            <span className="text-[10px] text-muted-foreground/50">none</span>
+          )}
+        </div>
+      </div>
+
       {/* Authentication Schemes */}
       {agent.authentication_schemes.length > 0 && (
         <div className="space-y-1">
-          <h4 className="text-xs font-medium text-muted-foreground">Authentication Schemes</h4>
+          <h4 className="text-xs font-medium text-muted-foreground">Authentication</h4>
           <div className="flex flex-wrap gap-1.5">
             {agent.authentication_schemes.map((scheme) => (
               <Badge key={scheme} variant="outline" className="text-[10px] px-1.5 py-0">

--- a/frontend/src/components/A2aSkillList.tsx
+++ b/frontend/src/components/A2aSkillList.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ChevronRight, ChevronDown } from "lucide-react";
 import { toast } from "sonner";
@@ -11,73 +10,71 @@ interface A2aSkillListProps {
   agentId: number;
 }
 
-function SkillCard({ skill }: { skill: A2aAgentSkill }) {
+function SkillRow({ skill }: { skill: A2aAgentSkill }) {
   const [expanded, setExpanded] = useState(false);
 
   return (
-    <Card className="py-2 gap-1">
-      <CardHeader className="gap-0 pb-1">
-        <button
-          type="button"
-          onClick={() => setExpanded(!expanded)}
-          className="flex items-center gap-1.5 text-left w-full"
-        >
-          {expanded ? (
-            <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
-          ) : (
-            <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+    <div className="rounded border bg-input-bg px-3 py-2">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-1.5 text-left w-full"
+      >
+        {expanded ? (
+          <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+        )}
+        <span className="text-sm font-medium">{skill.name}</span>
+        {skill.description && (
+          <span className="text-xs text-muted-foreground truncate"> — {skill.description}</span>
+        )}
+      </button>
+      {expanded && (
+        <div className="mt-2 pl-[22px] space-y-1.5 text-xs text-muted-foreground">
+          <div className="text-[10px] text-muted-foreground/70">ID: {skill.skill_id}</div>
+          {skill.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {skill.tags.map((tag) => (
+                <Badge key={tag} variant="outline" className="text-[10px] px-1.5 py-0 font-normal">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
           )}
-          <span className="text-sm font-medium truncate">{skill.name}</span>
-          <span className="text-[10px] text-muted-foreground/70 shrink-0">({skill.skill_id})</span>
-        </button>
-      </CardHeader>
-      <CardContent className="text-xs text-muted-foreground space-y-1.5">
-        <p>{skill.description}</p>
-        {skill.tags.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {skill.tags.map((tag) => (
-              <Badge key={tag} variant="outline" className="text-[10px] px-1.5 py-0 font-normal">
-                {tag}
-              </Badge>
-            ))}
-          </div>
-        )}
-        {expanded && (
-          <div className="space-y-1.5 pt-1 border-t">
-            {skill.examples && skill.examples.length > 0 && (
-              <div>
-                <span className="text-[10px] font-medium text-muted-foreground/70">Examples:</span>
-                <ul className="list-disc list-inside text-[11px] mt-0.5">
-                  {skill.examples.map((ex, i) => (
-                    <li key={i}>{ex}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            {skill.input_modes && skill.input_modes.length > 0 && (
-              <div className="flex flex-wrap items-center gap-1">
-                <span className="text-[10px] text-muted-foreground/70">Input:</span>
-                {skill.input_modes.map((m) => (
-                  <Badge key={m} variant="outline" className="text-[10px] px-1 py-0 font-normal">
-                    {m}
-                  </Badge>
+          {skill.examples && skill.examples.length > 0 && (
+            <div>
+              <span className="text-[10px] font-medium text-muted-foreground/70">Examples:</span>
+              <ul className="list-disc list-inside text-[11px] mt-0.5">
+                {skill.examples.map((ex, i) => (
+                  <li key={i}>{ex}</li>
                 ))}
-              </div>
-            )}
-            {skill.output_modes && skill.output_modes.length > 0 && (
-              <div className="flex flex-wrap items-center gap-1">
-                <span className="text-[10px] text-muted-foreground/70">Output:</span>
-                {skill.output_modes.map((m) => (
-                  <Badge key={m} variant="outline" className="text-[10px] px-1 py-0 font-normal">
-                    {m}
-                  </Badge>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+              </ul>
+            </div>
+          )}
+          {skill.input_modes && skill.input_modes.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1">
+              <span className="text-[10px] text-muted-foreground/70">Input:</span>
+              {skill.input_modes.map((m) => (
+                <Badge key={m} variant="outline" className="text-[10px] px-1 py-0 font-normal">
+                  {m}
+                </Badge>
+              ))}
+            </div>
+          )}
+          {skill.output_modes && skill.output_modes.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1">
+              <span className="text-[10px] text-muted-foreground/70">Output:</span>
+              {skill.output_modes.map((m) => (
+                <Badge key={m} variant="outline" className="text-[10px] px-1 py-0 font-normal">
+                  {m}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -104,7 +101,7 @@ export function A2aSkillList({ agentId }: A2aSkillListProps) {
     return (
       <div className="space-y-2">
         {Array.from({ length: 2 }).map((_, i) => (
-          <Skeleton key={i} className="h-16" />
+          <Skeleton key={i} className="h-10" />
         ))}
       </div>
     );
@@ -116,9 +113,9 @@ export function A2aSkillList({ agentId }: A2aSkillListProps) {
       {skills.length === 0 ? (
         <p className="text-xs text-muted-foreground/50 py-2">No skills defined in the Agent Card.</p>
       ) : (
-        <div className="grid gap-2 md:grid-cols-2">
+        <div className="grid gap-2 grid-cols-1">
           {skills.map((skill) => (
-            <SkillCard key={skill.id} skill={skill} />
+            <SkillRow key={skill.id} skill={skill} />
           ))}
         </div>
       )}

--- a/frontend/src/components/AgentCard.tsx
+++ b/frontend/src/components/AgentCard.tsx
@@ -109,18 +109,20 @@ export function AgentCard({ agent, onSelect, onRefresh, onDelete, readOnly, show
             <CardTitle className="text-sm font-medium truncate">
               {agent.name ?? agent.runtime_id}
             </CardTitle>
-            <RegistryStatusBadge status={agent.registry_status} showUnregistered={registryEnabled} registryEnabled={registryEnabled} />
+            {!creating && (
+              <RegistryStatusBadge status={agent.registry_status} showUnregistered={registryEnabled} registryEnabled={registryEnabled} />
+            )}
             {agent.status && agent.status !== "READY" && (
               <Badge variant={statusVariant(agent.status)} className="text-[10px] px-1.5 py-0 shrink-0">
                 {agent.status}
               </Badge>
             )}
-            {agent.active_session_count > 0 && (
+            {!creating && agent.active_session_count > 0 && (
               <span className="inline-flex items-center justify-center h-5 min-w-5 px-1.5 rounded-full bg-primary text-primary-foreground text-[10px] font-medium shrink-0">
                 {agent.active_session_count}
               </span>
             )}
-            {agent.cost_summary && agent.cost_summary.total_cost > 0 && (
+            {!creating && agent.cost_summary && agent.cost_summary.total_cost > 0 && (
               <Badge variant="outline" className="text-[10px] px-1.5 py-0 shrink-0 font-mono">
                 {agent.cost_summary.total_cost < 0.01
                   ? `~$${agent.cost_summary.total_cost.toFixed(6)}`

--- a/frontend/src/components/AgentCard.tsx
+++ b/frontend/src/components/AgentCard.tsx
@@ -105,7 +105,7 @@ export function AgentCard({ agent, onSelect, onRefresh, onDelete, readOnly, show
     >
       <CardHeader className="gap-1 pb-3">
         <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2 min-w-0">
+          <div className="flex items-center gap-2 min-w-0 overflow-hidden">
             <CardTitle className="text-sm font-medium truncate">
               {agent.name ?? agent.runtime_id}
             </CardTitle>

--- a/frontend/src/components/McpServerForm.tsx
+++ b/frontend/src/components/McpServerForm.tsx
@@ -28,11 +28,13 @@ export function McpServerForm({ onSubmit, onCancel, initialData }: McpServerForm
   const [transportType, setTransportType] = useState<"sse" | "streamable_http">(
     initialData?.transport_type ?? "sse",
   );
-  const [authType, setAuthType] = useState<"none" | "oauth2">(initialData?.auth_type ?? "none");
+  const [authType, setAuthType] = useState<"none" | "oauth2" | "api_key">(initialData?.auth_type ?? "none");
   const [wellKnownUrl, setWellKnownUrl] = useState(initialData?.oauth2_well_known_url ?? "");
   const [clientId, setClientId] = useState(initialData?.oauth2_client_id ?? "");
   const [clientSecret, setClientSecret] = useState("");
   const [scopes, setScopes] = useState(initialData?.oauth2_scopes ?? "");
+  const [apiKeyHeaderName, setApiKeyHeaderName] = useState(initialData?.api_key_header_name ?? "x-api-key");
+  const [apiKey, setApiKey] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<TestConnectionResult | null>(null);
@@ -53,6 +55,10 @@ export function McpServerForm({ onSubmit, onCancel, initialData }: McpServerForm
         if (clientId.trim()) request.oauth2_client_id = clientId.trim();
         if (clientSecret) request.oauth2_client_secret = clientSecret;
         if (scopes.trim()) request.oauth2_scopes = scopes.trim();
+      }
+      if (authType === "api_key") {
+        request.api_key_header_name = apiKeyHeaderName;
+        if (apiKey) request.api_key = apiKey;
       }
       await onSubmit(request);
     } finally {
@@ -80,6 +86,10 @@ export function McpServerForm({ onSubmit, onCancel, initialData }: McpServerForm
           if (clientSecret) config.oauth2_client_secret = clientSecret;
           if (scopes.trim()) config.oauth2_scopes = scopes.trim();
         }
+        if (authType === "api_key") {
+          (config as Record<string, string>).api_key_header_name = apiKeyHeaderName;
+          if (apiKey) (config as Record<string, string>).api_key = apiKey;
+        }
         result = await testConnectionPreCreate(config);
       }
       setTestResult(result);
@@ -102,13 +112,15 @@ export function McpServerForm({ onSubmit, onCancel, initialData }: McpServerForm
             if (parsed.transport_type && ["sse", "streamable_http"].includes(parsed.transport_type)) {
               setTransportType(parsed.transport_type);
             }
-            if (parsed.auth_type && ["none", "oauth2"].includes(parsed.auth_type)) {
+            if (parsed.auth_type && ["none", "oauth2", "api_key"].includes(parsed.auth_type)) {
               setAuthType(parsed.auth_type);
             }
             if (parsed.oauth2_well_known_url !== undefined) setWellKnownUrl(parsed.oauth2_well_known_url);
             if (parsed.oauth2_client_id !== undefined) setClientId(parsed.oauth2_client_id);
             if (parsed.oauth2_client_secret !== undefined) setClientSecret(parsed.oauth2_client_secret);
             if (parsed.oauth2_scopes !== undefined) setScopes(parsed.oauth2_scopes);
+            if (parsed.api_key_header_name !== undefined) setApiKeyHeaderName(parsed.api_key_header_name);
+            if (parsed.api_key !== undefined) setApiKey(parsed.api_key);
             return null;
           } catch {
             return "Invalid JSON. Please check the format and try again.";
@@ -127,9 +139,13 @@ export function McpServerForm({ onSubmit, onCancel, initialData }: McpServerForm
             result.oauth2_client_secret = "(redacted)";
             if (scopes) result.oauth2_scopes = scopes;
           }
+          if (authType === "api_key") {
+            result.api_key_header_name = apiKeyHeaderName;
+            result.api_key = "(redacted)";
+          }
           return JSON.stringify(result, null, 2);
         }}
-        placeholder={'{"name": "...", "endpoint_url": "https://...", "transport_type": "sse", "auth_type": "oauth2", "oauth2_well_known_url": "https://...", "oauth2_client_id": "...", "oauth2_client_secret": "...", "oauth2_scopes": "..."}'}
+        placeholder={'{"name": "...", "endpoint_url": "https://...", "transport_type": "sse", "auth_type": "oauth2|api_key", "oauth2_well_known_url": "https://...", "oauth2_client_id": "...", "oauth2_client_secret": "...", "oauth2_scopes": "...", "api_key_header_name": "x-api-key", "api_key": "..."}'}
       />
 
       <div className="flex gap-3">
@@ -190,6 +206,15 @@ export function McpServerForm({ onSubmit, onCancel, initialData }: McpServerForm
             />
             OAuth2
           </label>
+          <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+            <input
+              type="radio"
+              checked={authType === "api_key"}
+              onChange={() => setAuthType("api_key")}
+              className="h-3.5 w-3.5"
+            />
+            API Key
+          </label>
         </div>
 
         {authType === "oauth2" && (
@@ -222,6 +247,34 @@ export function McpServerForm({ onSubmit, onCancel, initialData }: McpServerForm
             <div>
               <label className="text-xs text-muted-foreground">Scopes</label>
               <Input value={scopes} onChange={(e) => setScopes(e.target.value)} placeholder="openid profile (space-separated)" />
+            </div>
+          </div>
+        )}
+
+        {authType === "api_key" && (
+          <div className="space-y-2 pl-2 border-l-2 border-border ml-1">
+            <div className="flex gap-3">
+              <div className="w-[200px]">
+                <label className="text-xs text-muted-foreground">Header Name</label>
+                <Select value={apiKeyHeaderName} onValueChange={setApiKeyHeaderName}>
+                  <SelectTrigger className="w-full text-sm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="x-api-key">x-api-key</SelectItem>
+                    <SelectItem value="Authorization">Authorization</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex-1 min-w-0">
+                <label className="text-xs text-muted-foreground">API Key</label>
+                <Input
+                  type="password"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  placeholder={initialData?.id ? "(unchanged)" : "API key"}
+                />
+              </div>
             </div>
           </div>
         )}

--- a/frontend/src/components/RegistryActions.tsx
+++ b/frontend/src/components/RegistryActions.tsx
@@ -3,6 +3,14 @@ import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import * as registryApi from "@/api/registry";
+import type { McpNamespace, RegistryRecordCreateRequest } from "@/api/types";
+
+const MCP_NAMESPACES: { value: McpNamespace; label: string }[] = [
+  { value: "aws.agentcore", label: "aws.agentcore" },
+  { value: "remote.mcp", label: "remote.mcp" },
+  { value: "npm", label: "npm" },
+  { value: "custom", label: "custom" },
+];
 
 interface RegistryActionsProps {
   resourceType: "mcp" | "a2a" | "agent";
@@ -24,6 +32,7 @@ export function RegistryActions({ resourceType, resourceId, registryRecordId, re
   const [showRejectInput, setShowRejectInput] = useState(false);
   const [approveReason, setApproveReason] = useState("");
   const [showApproveInput, setShowApproveInput] = useState(false);
+  const [namespace, setNamespace] = useState<McpNamespace>("aws.agentcore");
 
   const timerActive = creating || submitting || approving || rejecting;
   useEffect(() => {
@@ -72,17 +81,33 @@ export function RegistryActions({ resourceType, resourceId, registryRecordId, re
 
   if (!registryRecordId && !registryStatus) {
     return (
-      <div className="flex items-center gap-1.5">
+      <div className="flex items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
+        {resourceType === "mcp" && (
+          <select
+            value={namespace}
+            onChange={(e) => setNamespace(e.target.value as McpNamespace)}
+            className="h-6 text-xs border rounded px-1 bg-input-bg"
+            disabled={loading || creating}
+          >
+            {MCP_NAMESPACES.map((ns) => (
+              <option key={ns.value} value={ns.value}>{ns.label}</option>
+            ))}
+          </select>
+        )}
         <Button
           size="sm"
           variant="outline"
           className="h-6 text-xs w-[5.5rem] justify-center"
           disabled={loading || creating}
-          onClick={(e) => {
-            e.stopPropagation();
+          onClick={() => {
             setCreating(true);
+            const req: RegistryRecordCreateRequest = {
+              resource_type: resourceType,
+              resource_id: resourceId,
+              ...(resourceType === "mcp" ? { namespace } : {}),
+            };
             void handleAction(
-              () => registryApi.createRegistryRecord({ resource_type: resourceType, resource_id: resourceId }).then(() => {}),
+              () => registryApi.createRegistryRecord(req).then(() => {}),
               "Registered in registry"
             ).then((ok) => { if (!ok) setCreating(false); });
           }}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -80,9 +80,9 @@ const GROUP_SCOPES: Record<string, Scope[]> = {
   ],
 
   // User groups (t-user users - can have multiple)
-  "g-users-demo": ["agent:read", "memory:read", "invoke"],
-  "g-users-test": ["agent:read", "memory:read", "invoke"],
-  "g-users-strategics": ["agent:read", "memory:read", "invoke"],
+  "g-users-demo": ["agent:read", "memory:read", "mcp:read", "invoke"],
+  "g-users-test": ["agent:read", "memory:read", "mcp:read", "invoke"],
+  "g-users-strategics": ["agent:read", "memory:read", "mcp:read", "invoke"],
 };
 
 function deriveScopes(groups: string[]): Set<Scope> {

--- a/frontend/src/hooks/useInvoke.ts
+++ b/frontend/src/hooks/useInvoke.ts
@@ -70,6 +70,7 @@ async function _startInvoke(
   credentialId?: number,
   bearerToken?: string,
   modelId?: string,
+  connectorIds?: number[],
 ) {
   // Abort any in-flight stream for this agent
   _controllers.get(agentId)?.abort();
@@ -98,6 +99,7 @@ async function _startInvoke(
         ...(credentialId ? { credential_id: credentialId } : {}),
         ...(bearerToken ? { bearer_token: bearerToken } : {}),
         ...(modelId ? { model_id: modelId } : {}),
+        ...(connectorIds && connectorIds.length > 0 ? { connector_ids: connectorIds } : {}),
       },
       {
         onSessionStart: (data) => _update(agentId, { sessionStart: data }),
@@ -184,8 +186,8 @@ export function useInvoke(agentId: number, authorizerName?: string) {
   }, [agentId]);
 
   const invoke = useCallback(
-    async (prompt: string, qualifier: string, sessionId?: string, credentialId?: number, bearerToken?: string, modelId?: string) => {
-      await _startInvoke(agentId, prompt, qualifier, authorizerRef.current, sessionId, credentialId, bearerToken, modelId);
+    async (prompt: string, qualifier: string, sessionId?: string, credentialId?: number, bearerToken?: string, modelId?: string, connectorIds?: number[]) => {
+      await _startInvoke(agentId, prompt, qualifier, authorizerRef.current, sessionId, credentialId, bearerToken, modelId, connectorIds);
     },
     [agentId],
   );

--- a/frontend/src/pages/A2aAgentsPage.tsx
+++ b/frontend/src/pages/A2aAgentsPage.tsx
@@ -31,14 +31,15 @@ interface A2aAgentsPageProps {
   viewMode: "cards" | "table";
   onViewModeChange: (mode: "cards" | "table") => void;
   readOnly?: boolean;
+  initialSelectedId?: number | null;
 }
 
-export function A2aAgentsPage({ viewMode, onViewModeChange, readOnly }: A2aAgentsPageProps) {
+export function A2aAgentsPage({ viewMode, onViewModeChange, readOnly, initialSelectedId }: A2aAgentsPageProps) {
   const { timezone } = useTimezone();
   const { user, browserSessionId } = useAuth();
   const { agents, loading, fetchAgents, createAgent, updateAgent, deleteAgent, refreshCard } = useA2aAgents();
   const [showAddForm, setShowAddForm] = useState(false);
-  const [selectedAgentId, setSelectedAgentId] = useState<number | null>(null);
+  const [selectedAgentId, setSelectedAgentId] = useState<number | null>(initialSelectedId ?? null);
   const [detailTab, setDetailTab] = useState<"card" | "access">("card");
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<number | null>(null);
   const [editingAgent, setEditingAgent] = useState<A2aAgent | null>(null);

--- a/frontend/src/pages/CatalogPage.tsx
+++ b/frontend/src/pages/CatalogPage.tsx
@@ -45,6 +45,8 @@ interface CatalogPageProps {
   canViewA2a?: boolean;
   groupRestriction?: string;
   userGroups?: string[];
+  onNavigateToMcp?: (serverId: number) => void;
+  onNavigateToA2a?: (agentId: number) => void;
 }
 
 export function CatalogPage({
@@ -63,6 +65,8 @@ export function CatalogPage({
   canViewA2a = true,
   groupRestriction,
   userGroups = [],
+  onNavigateToMcp,
+  onNavigateToA2a,
 }: CatalogPageProps) {
   const { timezone } = useTimezone();
   // Tag filter state
@@ -726,7 +730,10 @@ export function CatalogPage({
             sortDirection={mcpSortDir}
             onSortDirectionChange={(d) => { if (d) { setMcpSortDir(d); saveSortDirection("catalog-mcp", d); } }}
             renderItem={(server) => (
-              <Card className="py-3 gap-1 transition-colors hover:bg-accent/50">
+              <Card
+                className={`py-3 gap-1 transition-colors hover:bg-accent/50${onNavigateToMcp ? " cursor-pointer" : ""}`}
+                onClick={onNavigateToMcp ? () => onNavigateToMcp(server.id) : undefined}
+              >
                 <CardHeader className="gap-0 pb-2">
                   <div className="flex items-center gap-2">
                     <div className="text-sm font-medium truncate" title={server.name}>
@@ -768,7 +775,11 @@ export function CatalogPage({
                   auth: (s) => s.auth_type,
                   created: (s) => s.created_at ?? "",
                 }).map((server) => (
-                  <TableRow key={server.id} className="bg-input-bg hover:bg-input-bg/80">
+                  <TableRow
+                    key={server.id}
+                    className={`bg-input-bg hover:bg-input-bg/80${onNavigateToMcp ? " cursor-pointer" : ""}`}
+                    onClick={onNavigateToMcp ? () => onNavigateToMcp(server.id) : undefined}
+                  >
                     <TableCell className="font-medium text-sm">
                       <div className="flex items-center gap-2">
                         {server.name}
@@ -820,7 +831,10 @@ export function CatalogPage({
             sortDirection={a2aSortDir}
             onSortDirectionChange={(d) => { if (d) { setA2aSortDir(d); saveSortDirection("catalog-a2a", d); } }}
             renderItem={(agent) => (
-              <Card className="py-3 gap-1 transition-colors hover:bg-accent/50">
+              <Card
+                className={`py-3 gap-1 transition-colors hover:bg-accent/50${onNavigateToA2a ? " cursor-pointer" : ""}`}
+                onClick={onNavigateToA2a ? () => onNavigateToA2a(agent.id) : undefined}
+              >
                 <CardHeader className="gap-0 pb-2">
                   <div className="flex items-center gap-2">
                     <div className="text-sm font-medium truncate" title={agent.name}>
@@ -868,7 +882,11 @@ export function CatalogPage({
                   auth: (a) => a.auth_type,
                   created: (a) => a.created_at ?? "",
                 }).map((agent) => (
-                  <TableRow key={agent.id} className="bg-input-bg hover:bg-input-bg/80">
+                  <TableRow
+                    key={agent.id}
+                    className={`bg-input-bg hover:bg-input-bg/80${onNavigateToA2a ? " cursor-pointer" : ""}`}
+                    onClick={onNavigateToA2a ? () => onNavigateToA2a(agent.id) : undefined}
+                  >
                     <TableCell className="font-medium text-sm">
                       <div className="flex items-center gap-2">
                         {agent.name}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import { Send, Plus, Brain, LogOut, Bot, User, X, Loader2, Palette, RefreshCw, ChevronDown, Wrench } from "lucide-react";
+import { Send, Plus, Brain, LogOut, Bot, User, X, Loader2, Palette, RefreshCw, ChevronDown, Wrench, Plug, KeyRound } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import ReactMarkdown from "react-markdown";
@@ -13,7 +13,10 @@ import { trackAction } from "@/api/audit";
 import { useInvoke, clearInvokeState } from "@/hooks/useInvoke";
 import { useAuth } from "@/contexts/AuthContext";
 import { useTheme, isLightTheme, THEME_LABELS, type Theme } from "@/contexts/ThemeContext";
-import type { AgentResponse, SessionResponse, MemoryResponse, MemoryRecordItem, ModelOption } from "@/api/types";
+import { listConnectors, setUserApiKey } from "@/api/mcp";
+import { Input } from "@/components/ui/input";
+import { groupModels } from "@/lib/models";
+import type { AgentResponse, SessionResponse, MemoryResponse, MemoryRecordItem, ModelOption, ConnectorInfo } from "@/api/types";
 
 interface ChatMessage {
   id: string;
@@ -101,6 +104,81 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [showModelPicker]);
+
+  // Connectors state
+  const [connectors, setConnectors] = useState<ConnectorInfo[]>([]);
+  const [enabledConnectors, setEnabledConnectors] = useState<Set<number>>(() => {
+    try {
+      const stored = JSON.parse(localStorage.getItem("loom:enabledConnectors") || "[]") as number[];
+      return new Set(stored);
+    } catch { return new Set(); }
+  });
+  const [showConnectors, setShowConnectors] = useState(false);
+  const [apiKeyDialog, setApiKeyDialog] = useState<{ serverId: number; serverName: string } | null>(null);
+  const [apiKeyInput, setApiKeyInput] = useState("");
+  const [savingApiKey, setSavingApiKey] = useState(false);
+  const connectorsRef = useRef<HTMLDivElement>(null);
+
+  const toggleConnector = (c: ConnectorInfo) => {
+    const isEnabled = enabledConnectors.has(c.id);
+    if (isEnabled) {
+      setEnabledConnectors((prev) => {
+        const next = new Set(prev);
+        next.delete(c.id);
+        localStorage.setItem("loom:enabledConnectors", JSON.stringify([...next]));
+        return next;
+      });
+    } else if (c.auth_type === "api_key" && !c.has_user_api_key) {
+      setApiKeyDialog({ serverId: c.id, serverName: c.name });
+      setShowConnectors(false);
+    } else {
+      setEnabledConnectors((prev) => {
+        const next = new Set(prev);
+        next.add(c.id);
+        localStorage.setItem("loom:enabledConnectors", JSON.stringify([...next]));
+        return next;
+      });
+    }
+  };
+
+  useEffect(() => {
+    listConnectors().then(setConnectors).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!showConnectors) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (connectorsRef.current && !connectorsRef.current.contains(e.target as Node)) {
+        setShowConnectors(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [showConnectors]);
+
+  const handleSaveApiKey = async () => {
+    if (!apiKeyDialog || !apiKeyInput.trim()) return;
+    setSavingApiKey(true);
+    try {
+      await setUserApiKey(apiKeyDialog.serverId, apiKeyInput.trim());
+      setConnectors((prev) =>
+        prev.map((c) => (c.id === apiKeyDialog.serverId ? { ...c, has_user_api_key: true } : c)),
+      );
+      setEnabledConnectors((prev) => {
+        const next = new Set(prev);
+        next.add(apiKeyDialog.serverId);
+        localStorage.setItem("loom:enabledConnectors", JSON.stringify([...next]));
+        return next;
+      });
+      setApiKeyDialog(null);
+      setApiKeyInput("");
+      toast.success("API key saved");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to save API key");
+    } finally {
+      setSavingApiKey(false);
+    }
+  };
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -326,9 +404,10 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
       if (user && browserSessionId) trackAction(user.username ?? user.sub, browserSessionId, "agent", "invoke", agentName);
       const agent = agents.find((a) => a.id === selectedAgentId);
       const rtModel = selectedModelId && agent && selectedModelId !== agent.model_id ? selectedModelId : undefined;
-      invoke(prompt, "DEFAULT", currentSessionId ?? undefined, undefined, undefined, rtModel);
+      const activeConnectorIds = enabledConnectors.size > 0 ? Array.from(enabledConnectors) : undefined;
+      invoke(prompt, "DEFAULT", currentSessionId ?? undefined, undefined, undefined, rtModel, activeConnectorIds);
     }
-  }, [isStreaming, queuedPrompt, error, selectedModelId, selectedAgentId, agents]);
+  }, [isStreaming, queuedPrompt, error, selectedModelId, selectedAgentId, agents, enabledConnectors]);
 
   // Scroll to bottom on new messages or streaming updates
   useEffect(() => {
@@ -349,8 +428,9 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
     const agentName = agents.find((a) => a.id === selectedAgentId)?.name ?? String(selectedAgentId);
     if (user && browserSessionId) trackAction(user.username ?? user.sub, browserSessionId, "agent", "invoke", agentName);
     const runtimeModelId = selectedModelId && selectedAgent && selectedModelId !== selectedAgent.model_id ? selectedModelId : undefined;
-    await invoke(prompt, "DEFAULT", currentSessionId ?? undefined, undefined, undefined, runtimeModelId);
-  }, [input, isStreaming, selectedAgentId, currentSessionId, invoke, agents, user, browserSessionId, selectedModelId, selectedAgent]);
+    const activeConnectorIds = enabledConnectors.size > 0 ? Array.from(enabledConnectors) : undefined;
+    await invoke(prompt, "DEFAULT", currentSessionId ?? undefined, undefined, undefined, runtimeModelId, activeConnectorIds);
+  }, [input, isStreaming, selectedAgentId, currentSessionId, invoke, agents, user, browserSessionId, selectedModelId, selectedAgent, enabledConnectors]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
@@ -843,8 +923,96 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
                     className="resize-none border-0 shadow-none focus-visible:ring-0 rounded-none rounded-t-xl"
                   />
                   <div className="flex items-center justify-between px-3 py-2 bg-background rounded-b-xl">
-                    <div>
-                      {/* Left side — reserved for future '+' connectors button */}
+                    <div className="relative" ref={connectorsRef}>
+                      {connectors.length > 0 && (
+                        <button
+                          onClick={() => setShowConnectors((v) => !v)}
+                          className="flex items-center gap-1 text-xs text-muted-foreground rounded-md border px-2 py-1 hover:text-foreground hover:border-foreground/30 cursor-pointer"
+                          title="Connectors"
+                        >
+                          <Plug className="h-3 w-3" />
+                          <span>Connectors</span>
+                          {enabledConnectors.size > 0 && (
+                            <span className="ml-0.5 text-[10px] text-green-600 dark:text-green-400">{enabledConnectors.size}</span>
+                          )}
+                        </button>
+                      )}
+                      {showConnectors && (
+                        <div className="absolute bottom-8 left-0 z-50 w-72 rounded-lg border bg-background shadow-md py-1">
+                          <div className="px-3 py-1.5 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+                            MCP Connectors
+                          </div>
+                          {connectors.map((c) => {
+                            const isEnabled = enabledConnectors.has(c.id);
+                            const needsKey = c.auth_type === "api_key" && !c.has_user_api_key;
+                            return (
+                              <button
+                                key={c.id}
+                                onClick={() => toggleConnector(c)}
+                                className="w-full flex items-center justify-between px-3 py-2 text-xs hover:bg-accent transition-colors"
+                              >
+                                <div className="flex items-center gap-2 min-w-0">
+                                  <span className="truncate" title={c.name}>{c.name}</span>
+                                  {needsKey && (
+                                    <span className="flex items-center gap-0.5 text-amber-500 shrink-0">
+                                      <KeyRound className="h-3 w-3" />
+                                    </span>
+                                  )}
+                                  {c.auth_type === "oauth2" && !isEnabled && (
+                                    <span className="text-[10px] text-muted-foreground shrink-0">OAuth2</span>
+                                  )}
+                                </div>
+                                <div
+                                  className={`relative w-7 h-4 rounded-full transition-colors shrink-0 ${
+                                    isEnabled ? "bg-green-500" : "bg-muted-foreground/30"
+                                  }`}
+                                >
+                                  <div
+                                    className={`absolute top-0.5 h-3 w-3 rounded-full bg-white shadow-sm transition-transform ${
+                                      isEnabled ? "translate-x-3.5" : "translate-x-0.5"
+                                    }`}
+                                  />
+                                </div>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      )}
+                      {apiKeyDialog && (
+                        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+                          <div className="w-96 rounded-lg border bg-background shadow-lg p-4 space-y-3">
+                            <div className="text-sm font-medium">
+                              API Key for {apiKeyDialog.serverName}
+                            </div>
+                            <p className="text-xs text-muted-foreground">
+                              Enter your personal API key to connect to this MCP server.
+                            </p>
+                            <Input
+                              type="password"
+                              value={apiKeyInput}
+                              onChange={(e) => setApiKeyInput(e.target.value)}
+                              placeholder="Enter your API key"
+                              onKeyDown={(e) => { if (e.key === "Enter") void handleSaveApiKey(); }}
+                            />
+                            <div className="flex justify-end gap-2">
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => { setApiKeyDialog(null); setApiKeyInput(""); }}
+                              >
+                                Cancel
+                              </Button>
+                              <Button
+                                size="sm"
+                                onClick={() => void handleSaveApiKey()}
+                                disabled={!apiKeyInput.trim() || savingApiKey}
+                              >
+                                {savingApiKey ? "Saving..." : "Save"}
+                              </Button>
+                            </div>
+                          </div>
+                        </div>
+                      )}
                     </div>
                     <div className="flex items-center gap-2">
                       {availableModels.length > 0 && (
@@ -863,27 +1031,34 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
                             {availableModels.length > 1 && <ChevronDown className="h-3 w-3" />}
                           </button>
                           {showModelPicker && (
-                            <div className="absolute bottom-7 right-0 z-50 w-52 rounded-lg border bg-white shadow-md py-1">
-                              {availableModels.map((m) => {
-                                const isDefault = m.model_id === selectedAgent?.model_id;
-                                const isSelected = selectedModelId ? m.model_id === selectedModelId : isDefault;
-                                return (
-                                  <button
-                                    key={m.model_id}
-                                    onClick={() => {
-                                      setSelectedModelId(isDefault ? null : m.model_id);
-                                      setShowModelPicker(false);
-                                    }}
-                                    className={`w-full text-left px-3 py-1.5 text-xs transition-colors hover:bg-accent ${
-                                      isSelected ? "font-semibold text-foreground" : "text-muted-foreground"
-                                    }`}
-                                  >
-                                    {m.display_name}
-                                    {isDefault && <span className="text-[10px] opacity-60 ml-1">(default)</span>}
-                                    {isSelected && !isDefault && <span className="text-[10px] opacity-60 ml-1">(selected)</span>}
-                                  </button>
-                                );
-                              })}
+                            <div className="absolute bottom-7 right-0 z-50 w-56 rounded-lg border bg-background shadow-md py-1 max-h-64 overflow-y-auto">
+                              {groupModels(availableModels).map(([group, models]) => (
+                                <div key={group}>
+                                  <div className="px-3 py-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+                                    {group}
+                                  </div>
+                                  {models.map((m) => {
+                                    const isDefault = m.model_id === selectedAgent?.model_id;
+                                    const isSelected = selectedModelId ? m.model_id === selectedModelId : isDefault;
+                                    return (
+                                      <button
+                                        key={m.model_id}
+                                        onClick={() => {
+                                          setSelectedModelId(isDefault ? null : m.model_id);
+                                          setShowModelPicker(false);
+                                        }}
+                                        className={`w-full text-left px-3 py-1.5 text-xs transition-colors hover:bg-accent ${
+                                          isSelected ? "font-semibold text-foreground" : "text-muted-foreground"
+                                        }`}
+                                      >
+                                        {m.display_name}
+                                        {isDefault && <span className="text-[10px] opacity-60 ml-1">(default)</span>}
+                                        {isSelected && !isDefault && <span className="text-[10px] opacity-60 ml-1">(selected)</span>}
+                                      </button>
+                                    );
+                                  })}
+                                </div>
+                              ))}
                             </div>
                           )}
                         </div>

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import { Send, Plus, Brain, LogOut, Bot, User, X, Loader2, Palette, RefreshCw, ChevronDown, Wrench, Plug, KeyRound } from "lucide-react";
+import { Send, Plus, Brain, LogOut, Bot, User, X, Loader2, Palette, RefreshCw, ChevronDown, Wrench, Plug, KeyRound, Unplug } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import ReactMarkdown from "react-markdown";
@@ -13,7 +13,7 @@ import { trackAction } from "@/api/audit";
 import { useInvoke, clearInvokeState } from "@/hooks/useInvoke";
 import { useAuth } from "@/contexts/AuthContext";
 import { useTheme, isLightTheme, THEME_LABELS, type Theme } from "@/contexts/ThemeContext";
-import { listConnectors, setUserApiKey } from "@/api/mcp";
+import { listConnectors, setUserApiKey, deleteUserApiKey } from "@/api/mcp";
 import { Input } from "@/components/ui/input";
 import { groupModels } from "@/lib/models";
 import type { AgentResponse, SessionResponse, MemoryResponse, MemoryRecordItem, ModelOption, ConnectorInfo } from "@/api/types";
@@ -105,19 +105,23 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [showModelPicker]);
 
-  // Connectors state
+  // Connectors state (scoped per agent)
+  const connectorStorageKey = selectedAgentId != null ? `loom:enabledConnectors:${selectedAgentId}` : null;
   const [connectors, setConnectors] = useState<ConnectorInfo[]>([]);
-  const [enabledConnectors, setEnabledConnectors] = useState<Set<number>>(() => {
-    try {
-      const stored = JSON.parse(localStorage.getItem("loom:enabledConnectors") || "[]") as number[];
-      return new Set(stored);
-    } catch { return new Set(); }
-  });
+  const [enabledConnectors, setEnabledConnectors] = useState<Set<number>>(new Set());
   const [showConnectors, setShowConnectors] = useState(false);
   const [apiKeyDialog, setApiKeyDialog] = useState<{ serverId: number; serverName: string } | null>(null);
   const [apiKeyInput, setApiKeyInput] = useState("");
   const [savingApiKey, setSavingApiKey] = useState(false);
   const connectorsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!connectorStorageKey) { setEnabledConnectors(new Set()); return; }
+    try {
+      const stored = JSON.parse(localStorage.getItem(connectorStorageKey) || "[]") as number[];
+      setEnabledConnectors(new Set(stored));
+    } catch { setEnabledConnectors(new Set()); }
+  }, [connectorStorageKey]);
 
   const toggleConnector = (c: ConnectorInfo) => {
     const isEnabled = enabledConnectors.has(c.id);
@@ -125,7 +129,7 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
       setEnabledConnectors((prev) => {
         const next = new Set(prev);
         next.delete(c.id);
-        localStorage.setItem("loom:enabledConnectors", JSON.stringify([...next]));
+        if (connectorStorageKey) localStorage.setItem(connectorStorageKey, JSON.stringify([...next]));
         return next;
       });
     } else if (c.auth_type === "api_key" && !c.has_user_api_key) {
@@ -135,7 +139,7 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
       setEnabledConnectors((prev) => {
         const next = new Set(prev);
         next.add(c.id);
-        localStorage.setItem("loom:enabledConnectors", JSON.stringify([...next]));
+        if (connectorStorageKey) localStorage.setItem(connectorStorageKey, JSON.stringify([...next]));
         return next;
       });
     }
@@ -167,7 +171,7 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
       setEnabledConnectors((prev) => {
         const next = new Set(prev);
         next.add(apiKeyDialog.serverId);
-        localStorage.setItem("loom:enabledConnectors", JSON.stringify([...next]));
+        if (connectorStorageKey) localStorage.setItem(connectorStorageKey, JSON.stringify([...next]));
         return next;
       });
       setApiKeyDialog(null);
@@ -177,6 +181,26 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
       toast.error(e instanceof Error ? e.message : "Failed to save API key");
     } finally {
       setSavingApiKey(false);
+    }
+  };
+
+  const disconnectConnector = async (c: ConnectorInfo) => {
+    try {
+      if (c.auth_type === "api_key" && c.has_user_api_key) {
+        await deleteUserApiKey(c.id);
+      }
+      setConnectors((prev) =>
+        prev.map((item) => (item.id === c.id ? { ...item, has_user_api_key: false } : item)),
+      );
+      setEnabledConnectors((prev) => {
+        const next = new Set(prev);
+        next.delete(c.id);
+        if (connectorStorageKey) localStorage.setItem(connectorStorageKey, JSON.stringify([...next]));
+        return next;
+      });
+      toast.success(`Disconnected from ${c.name}`);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to disconnect");
     }
   };
 
@@ -945,13 +969,16 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
                           {connectors.map((c) => {
                             const isEnabled = enabledConnectors.has(c.id);
                             const needsKey = c.auth_type === "api_key" && !c.has_user_api_key;
+                            const isConnected = c.auth_type === "none" || (c.auth_type === "api_key" && c.has_user_api_key);
                             return (
-                              <button
+                              <div
                                 key={c.id}
-                                onClick={() => toggleConnector(c)}
-                                className="w-full flex items-center justify-between px-3 py-2 text-xs hover:bg-accent transition-colors"
+                                className="flex items-center justify-between px-3 py-2 text-xs hover:bg-accent transition-colors"
                               >
-                                <div className="flex items-center gap-2 min-w-0">
+                                <button
+                                  onClick={() => toggleConnector(c)}
+                                  className="flex items-center gap-2 min-w-0 flex-1"
+                                >
                                   <span className="truncate" title={c.name}>{c.name}</span>
                                   {needsKey && (
                                     <span className="flex items-center gap-0.5 text-amber-500 shrink-0">
@@ -961,19 +988,32 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
                                   {c.auth_type === "oauth2" && !isEnabled && (
                                     <span className="text-[10px] text-muted-foreground shrink-0">OAuth2</span>
                                   )}
+                                </button>
+                                <div className="flex items-center gap-1.5 shrink-0">
+                                  {isConnected && c.auth_type !== "none" && (
+                                    <button
+                                      onClick={(e) => { e.stopPropagation(); void disconnectConnector(c); }}
+                                      className="text-muted-foreground/50 hover:text-destructive transition-colors"
+                                      title={`Disconnect ${c.name}`}
+                                    >
+                                      <Unplug className="h-3 w-3" />
+                                    </button>
+                                  )}
+                                  <button onClick={() => toggleConnector(c)}>
+                                    <div
+                                      className={`relative w-7 h-4 rounded-full transition-colors ${
+                                        isEnabled ? "bg-green-500" : "bg-muted-foreground/30"
+                                      }`}
+                                    >
+                                      <div
+                                        className={`absolute top-0.5 h-3 w-3 rounded-full bg-white shadow-sm transition-transform ${
+                                          isEnabled ? "translate-x-3.5" : "translate-x-0.5"
+                                        }`}
+                                      />
+                                    </div>
+                                  </button>
                                 </div>
-                                <div
-                                  className={`relative w-7 h-4 rounded-full transition-colors shrink-0 ${
-                                    isEnabled ? "bg-green-500" : "bg-muted-foreground/30"
-                                  }`}
-                                >
-                                  <div
-                                    className={`absolute top-0.5 h-3 w-3 rounded-full bg-white shadow-sm transition-transform ${
-                                      isEnabled ? "translate-x-3.5" : "translate-x-0.5"
-                                    }`}
-                                  />
-                                </div>
-                              </button>
+                              </div>
                             );
                           })}
                         </div>

--- a/frontend/src/pages/McpServersPage.tsx
+++ b/frontend/src/pages/McpServersPage.tsx
@@ -20,6 +20,8 @@ import { useMcpServers } from "@/hooks/useMcpServers";
 import { McpServerForm } from "@/components/McpServerForm";
 import { McpToolList } from "@/components/McpToolList";
 import { McpAccessControl } from "@/components/McpAccessControl";
+import { setUserApiKey, getUserApiKeyStatus, deleteUserApiKey } from "@/api/mcp";
+import { Input } from "@/components/ui/input";
 import { SortableCardGrid, SortButton, loadSortDirection, toggleSortDirection, saveSortDirection, type SortDirection } from "@/components/SortableCardGrid";
 import { SortableTableHead, sortRows } from "@/components/SortableTableHead";
 import { RegistryStatusBadge } from "@/components/RegistryStatusBadge";
@@ -30,15 +32,16 @@ interface McpServersPageProps {
   viewMode: "cards" | "table";
   onViewModeChange: (mode: "cards" | "table") => void;
   readOnly?: boolean;
+  initialSelectedId?: number | null;
 }
 
-export function McpServersPage({ viewMode, onViewModeChange, readOnly }: McpServersPageProps) {
+export function McpServersPage({ viewMode, onViewModeChange, readOnly, initialSelectedId }: McpServersPageProps) {
   const { timezone } = useTimezone();
   const { user, browserSessionId } = useAuth();
   const { servers, loading, fetchServers, createServer, updateServer, deleteServer } = useMcpServers();
   const [showAddForm, setShowAddForm] = useState(false);
-  const [selectedServerId, setSelectedServerId] = useState<number | null>(null);
-  const [detailTab, setDetailTab] = useState<"tools" | "access">("tools");
+  const [selectedServerId, setSelectedServerId] = useState<number | null>(initialSelectedId ?? null);
+  const [detailTab, setDetailTab] = useState<"tools" | "access" | "api-key">("tools");
   const [confirmingDeleteId, setConfirmingDeleteId] = useState<number | null>(null);
   const [editingServer, setEditingServer] = useState<McpServer | null>(null);
   const [registryEnabled, setRegistryEnabled] = useState(false);
@@ -143,6 +146,7 @@ export function McpServersPage({ viewMode, onViewModeChange, readOnly }: McpServ
                   oauth2_well_known_url: editingServer.oauth2_well_known_url ?? undefined,
                   oauth2_client_id: editingServer.oauth2_client_id ?? undefined,
                   oauth2_scopes: editingServer.oauth2_scopes ?? undefined,
+                  api_key_header_name: editingServer.api_key_header_name ?? undefined,
                 }}
               />
             </CardContent>
@@ -150,14 +154,16 @@ export function McpServersPage({ viewMode, onViewModeChange, readOnly }: McpServ
         )}
 
         <div className="flex rounded-md border text-sm w-fit" role="tablist">
-          {(["tools", "access"] as const).map((tab) => (
+          {(["tools", "access"] as const).map((tab, idx) => (
             <button
               key={tab}
               type="button"
               role="tab"
               aria-selected={detailTab === tab}
               className={`px-4 py-1.5 transition-colors ${
-                tab === "tools" ? "rounded-l-md" : "rounded-r-md"
+                idx === 0 ? "rounded-l-md" : ""
+              } ${
+                idx === 1 && selectedServer.auth_type !== "api_key" ? "rounded-r-md" : ""
               } ${
                 detailTab === tab
                   ? "bg-primary text-primary-foreground"
@@ -168,10 +174,28 @@ export function McpServersPage({ viewMode, onViewModeChange, readOnly }: McpServ
               {tab === "tools" ? "Tools" : "Access"}
             </button>
           ))}
+          {selectedServer.auth_type === "api_key" && (
+            <button
+              type="button"
+              role="tab"
+              aria-selected={detailTab === "api-key"}
+              className={`px-4 py-1.5 transition-colors rounded-r-md ${
+                detailTab === "api-key"
+                  ? "bg-primary text-primary-foreground"
+                  : "hover:bg-accent"
+              }`}
+              onClick={() => setDetailTab("api-key")}
+            >
+              API Key
+            </button>
+          )}
         </div>
 
         {detailTab === "tools" && <McpToolList serverId={selectedServer.id} readOnly={readOnly} />}
         {detailTab === "access" && <McpAccessControl serverId={selectedServer.id} readOnly={readOnly} />}
+        {detailTab === "api-key" && selectedServer && (
+          <McpUserApiKeyPanel serverId={selectedServer.id} hasAdminApiKey={selectedServer.has_admin_api_key} />
+        )}
       </div>
     );
   }
@@ -298,7 +322,7 @@ export function McpServersPage({ viewMode, onViewModeChange, readOnly }: McpServ
                 <div className="rounded border bg-input-bg p-3 space-y-0.5">
                   <div className="truncate" title={server.endpoint_url}><span className="text-muted-foreground/70">Endpoint:</span> {server.endpoint_url}</div>
                   <div><span className="text-muted-foreground/70">Transport:</span> {server.transport_type === "streamable_http" ? "Streamable HTTP" : "SSE"}</div>
-                  <div><span className="text-muted-foreground/70">Authentication:</span> {server.auth_type === "oauth2" ? "OAuth2" : "None"}</div>
+                  <div><span className="text-muted-foreground/70">Authentication:</span> {server.auth_type === "oauth2" ? "OAuth2" : server.auth_type === "api_key" ? "API Key" : "None"}</div>
                   {server.created_at && (
                     <div><span className="text-muted-foreground/70">Created:</span> {formatTimestamp(server.created_at, timezone)}</div>
                   )}
@@ -362,7 +386,7 @@ export function McpServersPage({ viewMode, onViewModeChange, readOnly }: McpServ
                   <TableCell className="font-medium text-sm">{server.name}</TableCell>
                   <TableCell className="text-xs text-muted-foreground truncate">{server.endpoint_url}</TableCell>
                   <TableCell className="text-xs text-muted-foreground">{server.transport_type === "streamable_http" ? "Streamable HTTP" : "SSE"}</TableCell>
-                  <TableCell className="text-xs text-muted-foreground">{server.auth_type === "oauth2" ? "OAuth2" : "None"}</TableCell>
+                  <TableCell className="text-xs text-muted-foreground">{server.auth_type === "oauth2" ? "OAuth2" : server.auth_type === "api_key" ? "API Key" : "None"}</TableCell>
                   <TableCell className="text-xs text-muted-foreground">
                     <RegistryStatusBadge status={server.registry_status} showUnregistered={registryEnabled} registryEnabled={registryEnabled} />
                   </TableCell>
@@ -376,5 +400,89 @@ export function McpServersPage({ viewMode, onViewModeChange, readOnly }: McpServ
         </div>
       )}
     </div>
+  );
+}
+
+function McpUserApiKeyPanel({ serverId, hasAdminApiKey }: { serverId: number; hasAdminApiKey: boolean }) {
+  const [apiKeyValue, setApiKeyValue] = useState("");
+  const [hasKey, setHasKey] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    getUserApiKeyStatus(serverId)
+      .then((res) => setHasKey(res.has_user_api_key))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [serverId]);
+
+  const handleSave = async () => {
+    if (!apiKeyValue.trim()) return;
+    try {
+      const res = await setUserApiKey(serverId, apiKeyValue.trim());
+      setHasKey(res.has_user_api_key);
+      setApiKeyValue("");
+      toast.success("API key saved");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to save API key");
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      const res = await deleteUserApiKey(serverId);
+      setHasKey(res.has_user_api_key);
+      toast.success("API key removed");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to remove API key");
+    }
+  };
+
+  if (loading) {
+    return <Skeleton className="h-20" />;
+  }
+
+  return (
+    <Card>
+      <CardContent className="pt-4 space-y-4">
+        <div className="text-sm space-y-1">
+          <div>
+            <span className="font-medium">Admin Key:</span>{" "}
+            {hasAdminApiKey ? (
+              <span className="text-green-600 dark:text-green-400">Configured</span>
+            ) : (
+              <span className="text-muted-foreground">Not configured</span>
+            )}
+          </div>
+          <div>
+            <span className="font-medium">User Key:</span>{" "}
+            {hasKey ? (
+              <span className="text-green-600 dark:text-green-400">Configured</span>
+            ) : (
+              <span className="text-muted-foreground">Not configured</span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-end gap-2">
+          <div className="flex-1 min-w-0">
+            <label className="text-xs text-muted-foreground">{hasKey ? "Update User API Key" : "Set User API Key"}</label>
+            <Input
+              type="password"
+              value={apiKeyValue}
+              onChange={(e) => setApiKeyValue(e.target.value)}
+              placeholder="Enter your API key"
+            />
+          </div>
+          <Button size="sm" onClick={handleSave} disabled={!apiKeyValue.trim()}>
+            Save
+          </Button>
+          {hasKey && (
+            <Button size="sm" variant="destructive" onClick={handleDelete}>
+              Delete
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/frontend/src/pages/RegistryPage.tsx
+++ b/frontend/src/pages/RegistryPage.tsx
@@ -23,6 +23,7 @@ import { useTimezone } from "@/contexts/TimezoneContext";
 import { formatTimestamp } from "@/lib/format";
 import { useRegistry } from "@/hooks/useRegistry";
 import { RegistryStatusBadge } from "@/components/RegistryStatusBadge";
+import { RegistryActions } from "@/components/RegistryActions";
 import { SortableTableHead, sortRows } from "@/components/SortableTableHead";
 import { SortableCardGrid, loadSortDirection, saveSortDirection, type SortDirection } from "@/components/SortableCardGrid";
 import * as registryApi from "@/api/registry";
@@ -395,11 +396,6 @@ export function RegistryPage({ readOnly, isEndUserRole }: RegistryPageProps) {
   const [selectedRecordId, setSelectedRecordId] = useState<string | null>(null);
   const [recordDetail, setRecordDetail] = useState<RegistryRecordDetail | null>(null);
   const [loadingDetail, setLoadingDetail] = useState(false);
-  const [rejectReason, setRejectReason] = useState("");
-  const [showRejectInput, setShowRejectInput] = useState(false);
-  const [approveReason, setApproveReason] = useState("");
-  const [showApproveInput, setShowApproveInput] = useState(false);
-  const [actionLoading, setActionLoading] = useState(false);
 
   // Apply filters
   useEffect(() => {
@@ -452,49 +448,6 @@ export function RegistryPage({ readOnly, isEndUserRole }: RegistryPageProps) {
     }
   };
 
-  const handleSubmit = async (recordId: string) => {
-    setActionLoading(true);
-    try {
-      await registryApi.submitForApproval(recordId);
-      toast.success("Submitted for approval");
-      void fetchRecords();
-      void refreshDetail(recordId);
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Submit failed");
-    } finally {
-      setActionLoading(false);
-    }
-  };
-
-  const handleApprove = async (recordId: string, reason: string) => {
-    setActionLoading(true);
-    try {
-      await registryApi.approveRecord(recordId, reason);
-      toast.success("Record approved");
-      void fetchRecords();
-      void refreshDetail(recordId);
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Approve failed");
-    } finally {
-      setActionLoading(false);
-    }
-  };
-
-  const handleReject = async (recordId: string, reason: string) => {
-    setActionLoading(true);
-    try {
-      await registryApi.rejectRecord(recordId, reason);
-      toast.success("Record rejected");
-      void fetchRecords();
-      void refreshDetail(recordId);
-      setShowRejectInput(false);
-      setRejectReason("");
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Reject failed");
-    } finally {
-      setActionLoading(false);
-    }
-  };
 
   // Compute display records before any early returns so hooks are called consistently
   const displayRecords = searchResults !== null
@@ -520,10 +473,6 @@ export function RegistryPage({ readOnly, isEndUserRole }: RegistryPageProps) {
   const goBackToList = () => {
     setSelectedRecordId(null);
     setRecordDetail(null);
-    setShowRejectInput(false);
-    setRejectReason("");
-    setShowApproveInput(false);
-    setApproveReason("");
   };
 
   // Detail view
@@ -556,119 +505,23 @@ export function RegistryPage({ readOnly, isEndUserRole }: RegistryPageProps) {
                 )}
               </div>
 
-              {/* Header: name, badges */}
-              <div className="flex items-center gap-3">
+              {/* Header: name, badges, actions */}
+              <div className="flex items-center gap-2">
                 <h2 className="text-lg font-semibold">{recordDetail.name}</h2>
                 <RegistryStatusBadge status={recordDetail.status} showUnregistered />
                 <Badge variant="outline" className="text-[10px] px-1.5 py-0">
                   {recordDetail.descriptor_type}
                 </Badge>
+                {!readOnly && (
+                  <RegistryActions
+                    resourceType={recordDetail.descriptor_type.toLowerCase() as "mcp" | "a2a" | "agent"}
+                    resourceId={0}
+                    registryRecordId={recordDetail.record_id}
+                    registryStatus={recordDetail.status}
+                    onAction={() => { void fetchRecords(); void refreshDetail(recordDetail.record_id); }}
+                  />
+                )}
               </div>
-
-              {/* Action buttons based on status */}
-              {!readOnly && recordDetail.status === "DRAFT" && (
-                <div className="flex items-center gap-2">
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={actionLoading}
-                    onClick={() => void handleSubmit(recordDetail.record_id)}
-                  >
-                    Submit for Approval
-                  </Button>
-                </div>
-              )}
-
-              {!readOnly && recordDetail.status === "PENDING_APPROVAL" && (
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    {!showApproveInput ? (
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        disabled={actionLoading}
-                        onClick={() => { setShowApproveInput(true); setShowRejectInput(false); }}
-                      >
-                        Approve
-                      </Button>
-                    ) : (
-                      <div className="flex items-center gap-2">
-                        <input
-                          type="text"
-                          value={approveReason}
-                          onChange={(e) => setApproveReason(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter" && approveReason.trim()) {
-                              void handleApprove(recordDetail.record_id, approveReason.trim());
-                            }
-                          }}
-                          placeholder="Approval reason..."
-                          className="h-8 text-xs border rounded px-2 bg-input-bg w-[30rem]"
-                          autoFocus
-                        />
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          disabled={actionLoading || !approveReason.trim()}
-                          onClick={() => void handleApprove(recordDetail.record_id, approveReason.trim())}
-                        >
-                          Confirm Approve
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => { setShowApproveInput(false); setApproveReason(""); }}
-                        >
-                          Cancel
-                        </Button>
-                      </div>
-                    )}
-
-                    {!showRejectInput ? (
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="text-destructive"
-                        disabled={actionLoading}
-                        onClick={() => { setShowRejectInput(true); setShowApproveInput(false); }}
-                      >
-                        Reject
-                      </Button>
-                    ) : (
-                      <div className="flex items-center gap-2">
-                        <input
-                          type="text"
-                          value={rejectReason}
-                          onChange={(e) => setRejectReason(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter" && rejectReason.trim()) {
-                              void handleReject(recordDetail.record_id, rejectReason.trim());
-                            }
-                          }}
-                          placeholder="Rejection reason..."
-                          className="h-8 text-xs border rounded px-2 bg-input-bg w-[30rem]"
-                          autoFocus
-                        />
-                        <Button
-                          size="sm"
-                          variant="destructive"
-                          disabled={actionLoading || !rejectReason.trim()}
-                          onClick={() => void handleReject(recordDetail.record_id, rejectReason.trim())}
-                        >
-                          Confirm Reject
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => { setShowRejectInput(false); setRejectReason(""); }}
-                        >
-                          Cancel
-                        </Button>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )}
 
               {/* Descriptors + Record metadata */}
               <DescriptorView


### PR DESCRIPTION
## Summary
- Add API key authentication for MCP servers with admin keys stored in Secrets Manager and per-user key management via ChatPage connector UI
- Add dynamic MCP connector toggles in ChatPage input area with per-agent scoping, API key entry modal, and disconnect action
- Add runtime model override via `model_id` in invoke payload with cached `BedrockModel` instances at the agent runtime level
- Add Salesforce Agentforce A2A integration: `/v1/card` agent card path, trust card's declared RPC URL, capability-aware `message/send` vs `message/stream` selection
- Improve A2A agent card UX: compact expandable skill rows, inline capabilities/modes display, empty mode indicators
- Add registry lifecycle improvements: MCP server deletion cleans up registry records, tool refresh propagates to registry
- Add catalog navigation: clicking items navigates to admin page with item pre-selected

## Test Plan
- [x] Create MCP server with `api_key` auth type, verify admin key stored in Secrets Manager
- [x] As end-user, enable API key connector in ChatPage, enter personal key, verify invoke uses the key
- [x] Disconnect connector, verify key deleted from Secrets Manager
- [x] Register Salesforce Agentforce A2A agent, verify `/v1/card` card fetch and `message/send` invocation
- [x] Verify A2A agent card displays capabilities, modes, and compact skill list
- [x] Verify registry record cleanup on MCP server deletion
- [x] Verify catalog item click navigates to correct admin page
- [x] Frontend type-check passes (`npx tsc --noEmit`)

Closes #49

Co-Authored-By: Claude <noreply@anthropic.com>