### PR TITLE
feat: display endpoint and auth for external integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Loom seamlessly weaves together agents, memory stores, MCP servers, and agent-to
 - Progressive deployment status tracking and async deletion
 - Cold-start latency measurement via CloudWatch log parsing
 - Active session tracking with idle timeout heuristic
+- External integration info: invocation URLs, auth requirements (SigV4/OAuth2), and copy-ready code snippets for connecting from outside Loom
 
 ### Memory Management
 - Create and manage AgentCore Memory resources

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -583,7 +583,15 @@ Agents support runtime model selection, allowing users to choose from a set of a
 - **Frontend wiring:** `useAgents` hook includes `deployHarnessAgent` function with harness-specific polling support. `AgentListPage` and `App.tsx` wire `onDeployHarness` prop through to the registration form.
 - **21 backend tests** in `test_harness.py` covering deployment CRUD, validation, MCP server integration, built-in tools, model parameters, status polling, refresh, deletion, config storage, and service module functions (create, get, delete, invoke stream with text and tool_use events).
 
-### Phase 26 — Advanced Operations
+### Phase 26 — External Integration Info *(Complete)*
+- **Backend endpoint:** `GET /api/agents/{id}/integration` returns assembled integration details for READY agents: invocation URLs (per qualifier), protocol, network mode, authentication requirements, and example code snippets.
+- **URL construction:** Invocation URLs follow the `bedrock-agentcore.{region}.amazonaws.com/runtimes/{runtime_id}/endpoints/{qualifier}/invoke` pattern. Protocol-specific URLs for MCP (`/mcp`) and A2A (`/.well-known/agent.json`) are included.
+- **Auth info (SigV4):** For agents without an authorizer, displays required IAM action (`InvokeAgentRuntime` for custom, `InvokeHarness` for managed), resource ARN, example IAM policy, boto3 snippet, and AWS CLI snippet.
+- **Auth info (OAuth2):** For agents with an authorizer, displays authorizer type, OIDC discovery URL, token endpoint (derived from Cognito pool ID or custom discovery URL), allowed client IDs and scopes, example token request and invocation curl snippets. Client secrets are never returned.
+- **Frontend component:** `ExternalIntegrationSection` displays endpoint info with copy-to-clipboard buttons, protocol badges, network mode indicators, and syntax-highlighted code blocks. Only shown for agents with status READY.
+- **10 backend tests** in `test_integration_info.py` covering SigV4 custom/harness agents, OAuth2 Cognito/custom OIDC, MCP/A2A protocol URLs, multiple qualifiers, VPC network mode, and error cases.
+
+### Phase 27 — Advanced Operations
 - Real-time metrics auto-refresh.
 - Multi-agent comparison views.
 - Alert configuration.

--- a/backend/README.md
+++ b/backend/README.md
@@ -315,6 +315,7 @@ Write-only audit tables populated by the frontend. `audit_login` records user lo
 | `GET` | `/api/agents/models` | List supported models (with display name and group) |
 | `GET` | `/api/agents/models/pricing` | List models with pricing metadata |
 | `GET` | `/api/agents/defaults` | Get configurable defaults (idle timeout, max lifetime) |
+| `GET` | `/api/agents/{agent_id}/integration` | Get external integration info (endpoints, auth, code snippets) |
 
 ### Security Administration
 

--- a/backend/SPECIFICATIONS.md
+++ b/backend/SPECIFICATIONS.md
@@ -123,7 +123,8 @@ backend/
 │   ├── test_traces.py       # Trace router + OTEL parsing tests (12 tests)
 │   ├── test_harness.py      # AgentCore Harness tests (21 tests: deploy CRUD, MCP integration, built-in tools, model params, status, config, service module)
 │   ├── test_model_selection.py  # Runtime model selection tests (12 tests: allowed_model_ids, invoke validation, PATCH)
-│   └── test_admin_audit.py  # Admin audit router tests (14 tests: login, action, pageview, sessions, summary)
+│   ├── test_admin_audit.py  # Admin audit router tests (14 tests: login, action, pageview, sessions, summary)
+│   └── test_integration_info.py  # External integration info tests (10 tests: SigV4, OAuth2, protocols, qualifiers, network modes)
 ├── etc/
 │   ├── environment.sh           # Sources account-specific file + shared outputs
 │   ├── environment.sh.example   # Example environment configuration template
@@ -549,6 +550,7 @@ The `/api/auth/config` endpoint returns only the pool ID and region. The user cl
 | `PATCH` | `/api/agents/{agent_id}` | Update editable agent fields (description, model_id, allowed_model_ids). Description changes propagated to AgentCore. |
 | `PUT` | `/api/agents/{agent_id}/config` | Update agent configuration entries. |
 | `GET` | `/api/agents/{agent_id}/config` | Get agent configuration entries. |
+| `GET` | `/api/agents/{agent_id}/integration` | Get external integration info (endpoints, auth, code snippets). Only for READY agents. |
 
 **`DELETE /api/agents/{agent_id}` behavior:**
 - When `cleanup_aws=false` or agent has no `runtime_id`: immediately deletes from local DB, returns the `AgentResponse` with HTTP 200.

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -2200,3 +2200,250 @@ def update_agent_config(
             d["value"] = "********"
         result.append(ConfigEntryResponse(**d))
     return result
+
+
+# ---------------------------------------------------------------------------
+# External Integration Info
+# ---------------------------------------------------------------------------
+
+class IntegrationEndpoint(BaseModel):
+    qualifier: str
+    invocation_url: str
+    protocol_url: str | None = None
+    protocol_url_label: str | None = None
+
+class IntegrationAuthSigV4(BaseModel):
+    method: str = "SigV4"
+    iam_action: str
+    resource_arn: str
+    execution_role_arn: str | None = None
+    example_policy: dict
+    example_boto3: str
+    example_cli: str
+
+class IntegrationAuthOAuth2(BaseModel):
+    method: str = "OAuth2"
+    authorizer_type: str
+    discovery_url: str | None = None
+    token_endpoint: str | None = None
+    allowed_client_ids: list[str] = []
+    allowed_scopes: list[str] = []
+    example_token_request: str
+    example_invocation: str
+
+class IntegrationInfoResponse(BaseModel):
+    runtime_arn: str
+    region: str
+    protocol: str
+    network_mode: str
+    endpoints: list[IntegrationEndpoint]
+    auth: IntegrationAuthSigV4 | IntegrationAuthOAuth2
+
+
+def _build_integration_info(agent, db) -> IntegrationInfoResponse:
+    from urllib.parse import quote
+
+    region = agent.region or "us-east-1"
+    arn = agent.arn or ""
+    runtime_id = agent.runtime_id or ""
+    protocol = (agent.protocol or "HTTP").upper()
+    network_mode = (agent.network_mode or "PUBLIC").upper()
+    source = agent.source or "custom"
+    base_host = f"https://bedrock-agentcore.{region}.amazonaws.com"
+
+    qualifiers_raw = agent.available_qualifiers
+    if isinstance(qualifiers_raw, str):
+        import json as _json
+        try:
+            qualifiers = _json.loads(qualifiers_raw)
+        except Exception:
+            qualifiers = [qualifiers_raw]
+    elif isinstance(qualifiers_raw, list):
+        qualifiers = qualifiers_raw
+    else:
+        qualifiers = ["DEFAULT"]
+
+    encoded_arn = quote(arn, safe="")
+    endpoints: list[IntegrationEndpoint] = []
+    if source == "harness":
+        for q in qualifiers:
+            endpoints.append(IntegrationEndpoint(
+                qualifier=q,
+                invocation_url=f"{base_host}/harnesses/invoke",
+                protocol_url=None,
+                protocol_url_label=None,
+            ))
+    else:
+        for q in qualifiers:
+            invoke_url = f"{base_host}/runtimes/{encoded_arn}/invocations"
+            proto_url = None
+            proto_label = None
+            if protocol == "MCP":
+                proto_url = f"{base_host}/runtimes/{encoded_arn}/mcp"
+                proto_label = "MCP Streamable HTTP"
+            elif protocol == "A2A":
+                proto_url = f"{base_host}/runtimes/{encoded_arn}/.well-known/agent.json"
+                proto_label = "A2A Agent Card"
+            endpoints.append(IntegrationEndpoint(
+                qualifier=q,
+                invocation_url=invoke_url,
+                protocol_url=proto_url,
+                protocol_url_label=proto_label,
+            ))
+
+    auth_config = agent.authorizer_config
+    if isinstance(auth_config, str):
+        import json as _json
+        try:
+            auth_config = _json.loads(auth_config)
+        except Exception:
+            auth_config = None
+
+    if not auth_config or not auth_config.get("type"):
+        iam_action = "bedrock-agentcore:InvokeHarness" if source == "harness" else "bedrock-agentcore:InvokeAgentRuntime"
+        example_policy = {
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": iam_action,
+                "Resource": arn or f"arn:aws:bedrock-agentcore:{region}:*:runtime/{runtime_id}",
+            }],
+        }
+        first_url = endpoints[0].invocation_url if endpoints else "<invocation_url>"
+        if source == "harness":
+            harness_arn = getattr(agent, "harness_id", None) or arn
+            example_boto3 = (
+                'import boto3\n'
+                'import json\n\n'
+                f'client = boto3.client("bedrock-agentcore", region_name="{region}")\n'
+                f'response = client.invoke_harness(\n'
+                f'    harnessArn="{harness_arn}",\n'
+                f'    runtimeSessionId="your-session-id",\n'
+                f'    messages=[{{"role": "user", "content": [{{"text": "Hello"}}]}}]\n'
+                f')'
+            )
+            example_cli = (
+                f'aws bedrock-agentcore invoke-harness \\\n'
+                f'  --harness-arn "{harness_arn}" \\\n'
+                f'  --runtime-session-id "your-session-id" \\\n'
+                f'  --messages \'[{{"role":"user","content":[{{"text":"Hello"}}]}}]\' \\\n'
+                f'  --region {region}'
+            )
+        else:
+            example_boto3 = (
+                'import boto3\n'
+                'import json\n\n'
+                f'client = boto3.client("bedrock-agentcore", region_name="{region}")\n'
+                f'response = client.invoke_agent_runtime(\n'
+                f'    agentRuntimeArn="{arn}",\n'
+                f'    qualifier="{qualifiers[0]}",\n'
+                f'    runtimeSessionId="your-session-id",\n'
+                f'    contentType="application/json",\n'
+                f'    accept="application/json",\n'
+                f'    payload=json.dumps({{"prompt": "Hello", "session_id": "your-session-id"}})\n'
+                f')'
+            )
+            example_cli = (
+                f'aws bedrock-agentcore invoke-agent-runtime \\\n'
+                f'  --agent-runtime-arn "{arn}" \\\n'
+                f'  --qualifier "{qualifiers[0]}" \\\n'
+                f'  --runtime-session-id "your-session-id" \\\n'
+                f'  --content-type "application/json" \\\n'
+                f'  --accept "application/json" \\\n'
+                f'  --payload \'{{"prompt": "Hello", "session_id": "your-session-id"}}\' \\\n'
+                f'  --region {region} \\\n'
+                f'  output.json'
+            )
+        execution_role = getattr(agent, "execution_role_arn", None)
+        auth: IntegrationAuthSigV4 | IntegrationAuthOAuth2 = IntegrationAuthSigV4(
+            iam_action=iam_action,
+            resource_arn=arn or f"arn:aws:bedrock-agentcore:{region}:*:runtime/{runtime_id}",
+            execution_role_arn=execution_role,
+            example_policy=example_policy,
+            example_boto3=example_boto3,
+            example_cli=example_cli,
+        )
+    else:
+        auth_type = auth_config.get("type", "custom")
+        pool_id = auth_config.get("pool_id", "")
+        discovery_url = auth_config.get("discovery_url", "")
+        allowed_clients = auth_config.get("allowed_clients", [])
+        allowed_scopes = auth_config.get("allowed_scopes", [])
+
+        if auth_type.lower() == "cognito" and pool_id:
+            discovery_url = discovery_url or f"https://cognito-idp.{region}.amazonaws.com/{pool_id}/.well-known/openid-configuration"
+            try:
+                from app.services.cognito import _get_pool_domain
+                cognito_domain = _get_pool_domain(pool_id, region)
+                token_endpoint = f"https://{cognito_domain}/oauth2/token"
+            except Exception:
+                token_endpoint = f"https://<your-domain>.auth.{region}.amazoncognito.com/oauth2/token"
+        else:
+            token_endpoint = discovery_url.replace("/.well-known/openid-configuration", "/oauth2/token") if discovery_url else "<token_endpoint>"
+
+        first_url = endpoints[0].invocation_url if endpoints else "<invocation_url>"
+        client_id_placeholder = allowed_clients[0] if allowed_clients else "<client_id>"
+
+        scope_param = ""
+        if allowed_scopes:
+            scopes_str = " ".join(allowed_scopes)
+            scope_param = f"&scope={scopes_str}"
+
+        example_token = (
+            f'TOKEN=$(curl -s -X POST "{token_endpoint}" \\\n'
+            f'  -H "Content-Type: application/x-www-form-urlencoded" \\\n'
+            f'  -d "grant_type=client_credentials'
+            f'&client_id={client_id_placeholder}'
+            f'&client_secret=YOUR_SECRET'
+            f'{scope_param}" \\\n'
+            f'  | jq -r \'.access_token\')'
+        )
+        if source == "harness":
+            harness_arn = getattr(agent, "harness_id", None) or arn
+            invoke_body = json.dumps({
+                "harnessArn": harness_arn,
+                "runtimeSessionId": "your-session-id",
+                "messages": [{"role": "user", "content": [{"text": "Hello"}]}],
+            }, indent=2)
+        else:
+            invoke_body = json.dumps({
+                "prompt": "Hello",
+                "session_id": "your-session-id",
+            })
+        example_invoke = (
+            f'curl -X POST "{first_url}" \\\n'
+            f'  -H "Authorization: Bearer $TOKEN" \\\n'
+            f'  -H "Content-Type: application/json" \\\n'
+            f'  --no-buffer \\\n'
+            f"  -d '{invoke_body}'"
+        )
+        auth = IntegrationAuthOAuth2(
+            authorizer_type=auth_type,
+            discovery_url=discovery_url or None,
+            token_endpoint=token_endpoint,
+            allowed_client_ids=allowed_clients,
+            allowed_scopes=allowed_scopes,
+            example_token_request=example_token,
+            example_invocation=example_invoke,
+        )
+
+    return IntegrationInfoResponse(
+        runtime_arn=arn,
+        region=region,
+        protocol=protocol,
+        network_mode=network_mode,
+        endpoints=endpoints,
+        auth=auth,
+    )
+
+
+@router.get("/{agent_id}/integration", response_model=IntegrationInfoResponse)
+async def get_agent_integration(
+    agent_id: int,
+    db: Session = Depends(get_db),
+    user: dict = Depends(require_scopes("agent:read")),
+):
+    agent = get_agent_or_404(agent_id, db)
+    if agent.status != "READY":
+        raise HTTPException(status_code=400, detail="Integration info is only available for agents with status READY")
+    return _build_integration_info(agent, db)

--- a/backend/tests/test_integration_info.py
+++ b/backend/tests/test_integration_info.py
@@ -1,0 +1,184 @@
+"""Tests for agent external integration info endpoint."""
+import json
+import unittest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.db import Base, get_db
+from app.models.agent import Agent
+
+
+class TestIntegrationInfoEndpoint(unittest.TestCase):
+    """Test cases for GET /api/agents/{id}/integration."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+
+        @event.listens_for(cls.engine, "connect")
+        def _set_sqlite_pragma(dbapi_conn, connection_record):
+            cursor = dbapi_conn.cursor()
+            cursor.execute("PRAGMA foreign_keys=ON")
+            cursor.close()
+
+        Base.metadata.create_all(bind=cls.engine)
+        cls.TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=cls.engine)
+
+    def setUp(self):
+        self.session = self.TestingSessionLocal()
+
+        def override_get_db():
+            try:
+                yield self.session
+            finally:
+                pass
+
+        app.dependency_overrides[get_db] = override_get_db
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        self.session.rollback()
+        self.session.close()
+        Base.metadata.drop_all(bind=self.engine)
+        Base.metadata.create_all(bind=self.engine)
+
+    @classmethod
+    def tearDownClass(cls):
+        Base.metadata.drop_all(bind=cls.engine)
+
+    def _create_agent(self, **overrides) -> Agent:
+        defaults = {
+            "arn": "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/rt-abc123",
+            "runtime_id": "rt-abc123",
+            "name": "test-agent",
+            "status": "READY",
+            "region": "us-east-1",
+            "account_id": "123456789012",
+            "source": "deploy",
+            "protocol": "HTTP",
+            "network_mode": "PUBLIC",
+            "available_qualifiers": json.dumps(["DEFAULT"]),
+        }
+        defaults.update(overrides)
+        agent = Agent(**defaults)
+        self.session.add(agent)
+        self.session.commit()
+        self.session.refresh(agent)
+        return agent
+
+    def test_integration_sigv4_custom_agent(self):
+        agent = self._create_agent()
+        resp = self.client.get(f"/api/agents/{agent.id}/integration")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["protocol"], "HTTP")
+        self.assertEqual(data["network_mode"], "PUBLIC")
+        self.assertEqual(data["region"], "us-east-1")
+        self.assertEqual(len(data["endpoints"]), 1)
+        ep = data["endpoints"][0]
+        self.assertEqual(ep["qualifier"], "DEFAULT")
+        self.assertIn("/runtimes/", ep["invocation_url"])
+        self.assertIn("/invocations", ep["invocation_url"])
+        self.assertIsNone(ep["protocol_url"])
+        auth = data["auth"]
+        self.assertEqual(auth["method"], "SigV4")
+        self.assertEqual(auth["iam_action"], "bedrock-agentcore:InvokeAgentRuntime")
+        self.assertIn("example_boto3", auth)
+        self.assertIn("example_cli", auth)
+
+    def test_integration_sigv4_harness_agent(self):
+        agent = self._create_agent(source="harness")
+        resp = self.client.get(f"/api/agents/{agent.id}/integration")
+        self.assertEqual(resp.status_code, 200)
+        auth = resp.json()["auth"]
+        self.assertEqual(auth["iam_action"], "bedrock-agentcore:InvokeHarness")
+
+    def test_integration_oauth2_cognito(self):
+        auth_config = json.dumps({
+            "type": "cognito",
+            "pool_id": "us-east-1_abcXYZ",
+            "allowed_clients": ["client-1", "client-2"],
+            "allowed_scopes": ["openid", "profile"],
+        })
+        agent = self._create_agent(authorizer_config=auth_config)
+        resp = self.client.get(f"/api/agents/{agent.id}/integration")
+        self.assertEqual(resp.status_code, 200)
+        auth = resp.json()["auth"]
+        self.assertEqual(auth["method"], "OAuth2")
+        self.assertEqual(auth["authorizer_type"], "cognito")
+        self.assertIn("cognito-idp.us-east-1.amazonaws.com/us-east-1_abcXYZ", auth["discovery_url"])
+        self.assertIn("oauth2/token", auth["token_endpoint"])
+        self.assertEqual(auth["allowed_client_ids"], ["client-1", "client-2"])
+        self.assertEqual(auth["allowed_scopes"], ["openid", "profile"])
+        auth_json = json.dumps(auth)
+        self.assertNotIn("real_secret_value", auth_json)
+        self.assertIn("YOUR_SECRET", auth_json)
+
+    def test_integration_oauth2_custom_oidc(self):
+        auth_config = json.dumps({
+            "type": "custom",
+            "discovery_url": "https://idp.example.com/.well-known/openid-configuration",
+            "allowed_clients": ["my-app"],
+            "allowed_scopes": ["api"],
+        })
+        agent = self._create_agent(authorizer_config=auth_config)
+        resp = self.client.get(f"/api/agents/{agent.id}/integration")
+        self.assertEqual(resp.status_code, 200)
+        auth = resp.json()["auth"]
+        self.assertEqual(auth["method"], "OAuth2")
+        self.assertEqual(auth["authorizer_type"], "custom")
+        self.assertEqual(auth["discovery_url"], "https://idp.example.com/.well-known/openid-configuration")
+        self.assertIn("oauth2/token", auth["token_endpoint"])
+
+    def test_integration_mcp_protocol_url(self):
+        agent = self._create_agent(protocol="MCP")
+        resp = self.client.get(f"/api/agents/{agent.id}/integration")
+        self.assertEqual(resp.status_code, 200)
+        ep = resp.json()["endpoints"][0]
+        self.assertIn("/mcp", ep["protocol_url"])
+        self.assertEqual(ep["protocol_url_label"], "MCP Streamable HTTP")
+
+    def test_integration_a2a_protocol_url(self):
+        agent = self._create_agent(protocol="A2A")
+        resp = self.client.get(f"/api/agents/{agent.id}/integration")
+        self.assertEqual(resp.status_code, 200)
+        ep = resp.json()["endpoints"][0]
+        self.assertIn("/.well-known/agent.json", ep["protocol_url"])
+        self.assertEqual(ep["protocol_url_label"], "A2A Agent Card")
+
+    def test_integration_multiple_qualifiers(self):
+        agent = self._create_agent(available_qualifiers=json.dumps(["DEFAULT", "STAGING"]))
+        resp = self.client.get(f"/api/agents/{agent.id}/integration")
+        self.assertEqual(resp.status_code, 200)
+        endpoints = resp.json()["endpoints"]
+        self.assertEqual(len(endpoints), 2)
+        qualifiers = [e["qualifier"] for e in endpoints]
+        self.assertIn("DEFAULT", qualifiers)
+        self.assertIn("STAGING", qualifiers)
+
+    def test_integration_vpc_network_mode(self):
+        agent = self._create_agent(network_mode="VPC")
+        resp = self.client.get(f"/api/agents/{agent.id}/integration")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["network_mode"], "VPC")
+
+    def test_integration_not_ready(self):
+        agent = self._create_agent(status="CREATING")
+        resp = self.client.get(f"/api/agents/{agent.id}/integration")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_integration_not_found(self):
+        resp = self.client.get("/api/agents/99999/integration")
+        self.assertEqual(resp.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -124,13 +124,14 @@ src/
 │   ├── ResourceTagFields.tsx      # Shared tag profile selector + tag resolution
 │   ├── InvokePanel.tsx            # Qualifier, credential selector, model badge, prompt
 │   ├── DeploymentPanel.tsx        # Deployment details for deployed agents
+│   ├── ExternalIntegrationSection.tsx # Endpoint URLs, auth info, code snippets for external callers
 │   └── ui/
 │       ├── searchable-select.tsx  # Searchable dropdown with group headers
 │       └── multi-select.tsx       # Checkbox-based multi-select dropdown
 ├── pages/        # Page-level view components
 │   ├── CatalogPage.tsx         # Platform Catalog: agents, memory, MCP, A2A sections
 │   ├── AgentListPage.tsx       # Agents: Deploy/Import form + agent grid
-│   ├── AgentDetailPage.tsx     # Sessions, invoke, latency, response
+│   ├── AgentDetailPage.tsx     # Tabbed: Details (overview, integration) + Invoke (sessions, invoke, response)
 │   ├── SecurityAdminPage.tsx   # Roles, authorizers, credentials, permissions
 │   ├── MemoryManagementPage.tsx # Memory resource management
 │   ├── McpServersPage.tsx      # MCP server management with tool/access tabs
@@ -212,7 +213,7 @@ The `AuthContext` also provides scope-based authorization using a two-dimensiona
 |------|---------|-------------|
 | LoginPage | — | Cognito login + set new password |
 | CatalogPage | Platform Catalog | Agents (with multi-select tag filter bar), memory resources (with tag badges), MCP servers, A2A agents sections |
-| AgentDetailPage | Platform Catalog | Sessions, invoke, latency, streaming response, deployment details |
+| AgentDetailPage | Platform Catalog | Tabbed layout — Details (overview, deployment, external integration) + Invoke (sessions, invoke, latency, streaming response) |
 | SessionDetailPage | Platform Catalog | Session metadata, invocation timing, tabbed Logs/Traces view with paginated CloudWatch logs, stream selector, vended log sources, and interactive OTEL trace visualization (waterfall timeline) |
 | InvocationDetailPage | Platform Catalog | Invocation details, cost breakdown, prompt/response, Traces tab with invocation-scoped trace graph |
 | AgentListPage | Agents | Deploy/Import form (with tag profile selector) + agent card/table grid with multi-select tag filters |

--- a/frontend/SPECIFICATIONS.md
+++ b/frontend/SPECIFICATIONS.md
@@ -68,6 +68,7 @@ frontend/
 │   │   ├── MemoryManagementPanel.tsx    # Memory resource create form + list table
 │   │   ├── ResourceTagFields.tsx       # Shared tag profile selector + tag resolution
 │   │   ├── DeploymentPanel.tsx # Deployment details panel
+│   │   ├── ExternalIntegrationSection.tsx # External integration info (endpoints, auth, code snippets)
 │   │   ├── InvokePanel.tsx     # Qualifier select, credential select, model select, prompt input, invoke/cancel
 │   │   ├── LatencySummary.tsx  # Invocation metrics (timing + token usage + cost)
 │   │   ├── SessionTable.tsx    # Clickable session list
@@ -291,6 +292,12 @@ Full deployment form with sections:
 ### Deployment Section (deployed agents only)
 - `DeploymentPanel` component restructured: "Allowed Models" section at top with inline edit mode (pencil icon triggers grouped checkbox editor with "set default" toggle per model, Save/Cancel buttons). "Deployed Configuration" section below with runtime status, protocol, network mode, execution role, deployed timestamp.
 - `RegisteredAgentModelConfig` card shown for non-deployed agents with model configuration. Same edit flow as `DeploymentPanel` allowed models.
+
+### External Integration (READY deployed agents only)
+- `ExternalIntegrationSection` component fetches integration info from `GET /api/agents/{id}/integration` and displays endpoint URLs, auth requirements, and copy-ready code snippets.
+- **Endpoint info:** Runtime ARN, protocol badge (HTTP/MCP/A2A), network mode badge (PUBLIC/VPC with icon), per-qualifier invocation URLs and protocol-specific URLs (MCP streamable HTTP, A2A agent card). All URL/ARN fields have copy-to-clipboard buttons.
+- **Auth info (SigV4):** IAM action, resource ARN, execution role, example IAM policy (JSON), boto3 snippet, and AWS CLI snippet in syntax-highlighted copyable code blocks.
+- **Auth info (OAuth2):** Authorizer type badge, OIDC discovery URL, token endpoint, allowed client IDs and scopes as badges, example token request and invocation curl snippets. Client secrets are never displayed — a note directs users to their identity provider administrator.
 
 ---
 

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -9,6 +9,7 @@ import type {
   IamRole,
   CognitoPool,
   ModelOption,
+  IntegrationInfoResponse,
 } from "./types";
 
 export function listAgents(): Promise<AgentResponse[]> {
@@ -118,4 +119,8 @@ export interface LoomDefaults {
 
 export function fetchDefaults(): Promise<LoomDefaults> {
   return apiFetch<LoomDefaults>("/api/agents/defaults");
+}
+
+export function getAgentIntegration(id: number): Promise<IntegrationInfoResponse> {
+  return apiFetch<IntegrationInfoResponse>(`/api/agents/${id}/integration`);
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -22,7 +22,7 @@ export interface AgentResponse {
   endpoint_status: string | null;
   protocol: string | null;
   network_mode: string | null;
-  authorizer_config: { type?: string; name?: string; pool_id?: string; discovery_url?: string } | null;
+  authorizer_config: { type?: string; name?: string; pool_id?: string; discovery_url?: string; allowed_clients?: string[]; allowed_scopes?: string[] } | null;
   model_id: string | null;
   allowed_model_ids: string[];
   deployed_at: string | null;
@@ -908,4 +908,42 @@ export interface RegistryRecordCreateRequest {
 
 export interface RegistrySearchResult {
   results: Array<Record<string, unknown>>;
+}
+
+// External integration types
+export interface IntegrationEndpoint {
+  qualifier: string;
+  invocation_url: string;
+  protocol_url: string | null;
+  protocol_url_label: string | null;
+}
+
+export interface IntegrationAuthSigV4 {
+  method: "SigV4";
+  iam_action: string;
+  resource_arn: string;
+  execution_role_arn: string | null;
+  example_policy: Record<string, unknown>;
+  example_boto3: string;
+  example_cli: string;
+}
+
+export interface IntegrationAuthOAuth2 {
+  method: "OAuth2";
+  authorizer_type: string;
+  discovery_url: string | null;
+  token_endpoint: string | null;
+  allowed_client_ids: string[];
+  allowed_scopes: string[];
+  example_token_request: string;
+  example_invocation: string;
+}
+
+export interface IntegrationInfoResponse {
+  runtime_arn: string;
+  region: string;
+  protocol: string;
+  network_mode: string;
+  endpoints: IntegrationEndpoint[];
+  auth: IntegrationAuthSigV4 | IntegrationAuthOAuth2;
 }

--- a/frontend/src/components/ExternalIntegrationSection.tsx
+++ b/frontend/src/components/ExternalIntegrationSection.tsx
@@ -1,0 +1,232 @@
+import { useState, useEffect } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Copy, Check, Globe, Lock, ExternalLink } from "lucide-react";
+import { getAgentIntegration } from "@/api/agents";
+import type { IntegrationInfoResponse, IntegrationAuthSigV4, IntegrationAuthOAuth2 } from "@/api/types";
+
+interface ExternalIntegrationSectionProps {
+  agentId: number;
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+  return (
+    <Button variant="ghost" size="icon" className="h-5 w-5 shrink-0" onClick={handleCopy}>
+      {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
+    </Button>
+  );
+}
+
+function CodeBlock({ code, language }: { code: string; language?: string }) {
+  return (
+    <div className="relative group">
+      <div className="absolute right-1 top-1 opacity-0 group-hover:opacity-100 transition-opacity">
+        <CopyButton text={code} />
+      </div>
+      <pre className="overflow-x-auto rounded bg-black/10 dark:bg-white/10 p-3 text-xs font-mono whitespace-pre-wrap">
+        {language && <span className="text-[10px] text-muted-foreground/60 block mb-1">{language}</span>}
+        {code}
+      </pre>
+    </div>
+  );
+}
+
+function CopyableField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center gap-1.5 text-xs">
+      <span className="font-medium text-muted-foreground shrink-0">{label}:</span>
+      <code className="rounded bg-black/10 dark:bg-white/10 px-1.5 py-0.5 font-mono text-xs break-all">{value}</code>
+      <CopyButton text={value} />
+    </div>
+  );
+}
+
+function SigV4AuthSection({ auth }: { auth: IntegrationAuthSigV4 }) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Badge variant="outline" className="text-[10px]">AWS IAM (SigV4)</Badge>
+      </div>
+      <CopyableField label="IAM Action" value={auth.iam_action} />
+      <CopyableField label="Resource ARN" value={auth.resource_arn} />
+      {auth.execution_role_arn && (
+        <CopyableField label="Execution Role" value={auth.execution_role_arn} />
+      )}
+
+      <div className="space-y-1">
+        <p className="text-xs font-medium text-muted-foreground">Example IAM Policy</p>
+        <CodeBlock code={JSON.stringify(auth.example_policy, null, 2)} language="json" />
+      </div>
+
+      <div className="space-y-1">
+        <p className="text-xs font-medium text-muted-foreground">Example (boto3)</p>
+        <CodeBlock code={auth.example_boto3} language="python" />
+      </div>
+
+      <div className="space-y-1">
+        <p className="text-xs font-medium text-muted-foreground">Example (AWS CLI)</p>
+        <CodeBlock code={auth.example_cli} language="bash" />
+      </div>
+    </div>
+  );
+}
+
+function OAuth2AuthSection({ auth }: { auth: IntegrationAuthOAuth2 }) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Badge variant="outline" className="text-[10px]">OAuth2 / JWT</Badge>
+        <Badge variant="secondary" className="text-[10px]">{auth.authorizer_type}</Badge>
+      </div>
+      {auth.discovery_url && (
+        <CopyableField label="Discovery URL" value={auth.discovery_url} />
+      )}
+      {auth.token_endpoint && (
+        <CopyableField label="Token Endpoint" value={auth.token_endpoint} />
+      )}
+      {auth.allowed_client_ids.length > 0 && (
+        <div className="text-xs">
+          <span className="font-medium text-muted-foreground">Allowed Client IDs:</span>
+          <div className="flex flex-wrap gap-1 mt-1">
+            {auth.allowed_client_ids.map((id) => (
+              <Badge key={id} variant="outline" className="text-[10px] font-mono">{id}</Badge>
+            ))}
+          </div>
+        </div>
+      )}
+      {auth.allowed_scopes.length > 0 && (
+        <div className="text-xs">
+          <span className="font-medium text-muted-foreground">Allowed Scopes:</span>
+          <div className="flex flex-wrap gap-1 mt-1">
+            {auth.allowed_scopes.map((s) => (
+              <Badge key={s} variant="outline" className="text-[10px] font-mono">{s}</Badge>
+            ))}
+          </div>
+        </div>
+      )}
+      <p className="text-[10px] text-muted-foreground/70 italic">
+        Client secrets must be obtained from your identity provider administrator.
+      </p>
+
+      <div className="space-y-1">
+        <p className="text-xs font-medium text-muted-foreground">Obtain Token</p>
+        <CodeBlock code={auth.example_token_request} language="bash" />
+      </div>
+
+      <div className="space-y-1">
+        <p className="text-xs font-medium text-muted-foreground">Invoke Agent</p>
+        <CodeBlock code={auth.example_invocation} language="bash" />
+      </div>
+    </div>
+  );
+}
+
+export function ExternalIntegrationSection({ agentId }: ExternalIntegrationSectionProps) {
+  const [info, setInfo] = useState<IntegrationInfoResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    getAgentIntegration(agentId)
+      .then(setInfo)
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoading(false));
+  }, [agentId]);
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="pt-6 text-center text-xs text-muted-foreground">
+          Loading integration info…
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error || !info) {
+    return null;
+  }
+
+  const isSigV4 = info.auth.method === "SigV4";
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center gap-2">
+          <ExternalLink className="h-4 w-4" />
+          <CardTitle className="text-sm font-medium">External Integration</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Endpoint Info */}
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline" className="text-[10px]">{info.protocol}</Badge>
+            <Badge variant={info.network_mode === "PUBLIC" ? "secondary" : "outline"} className="text-[10px] gap-1">
+              {info.network_mode === "PUBLIC" ? <Globe className="h-3 w-3" /> : <Lock className="h-3 w-3" />}
+              {info.network_mode}
+            </Badge>
+          </div>
+
+          {info.network_mode === "VPC" && (
+            <p className="text-[10px] text-muted-foreground/70 italic">
+              This endpoint requires VPC connectivity. Callers must have network access to the VPC.
+            </p>
+          )}
+
+          <CopyableField label="Runtime ARN" value={info.runtime_arn} />
+
+          {info.endpoints.map((ep) => (
+            <div key={ep.qualifier} className="space-y-1.5 pl-2 border-l-2 border-muted-foreground/20">
+              <div className="flex items-center gap-1.5">
+                <Badge variant="outline" className="text-[10px] font-mono">{ep.qualifier}</Badge>
+              </div>
+              <CopyableField label="Invoke URL" value={ep.invocation_url} />
+              {ep.protocol_url && (
+                <CopyableField label={ep.protocol_url_label ?? "Protocol URL"} value={ep.protocol_url} />
+              )}
+            </div>
+          ))}
+
+          {info.protocol === "HTTP" && (
+            <p className="text-[10px] text-muted-foreground/70">
+              Standard request/response invocation via the AgentCore Runtime API or direct HTTPS endpoint.
+            </p>
+          )}
+          {info.protocol === "MCP" && (
+            <p className="text-[10px] text-muted-foreground/70">
+              Streamable HTTP transport. External MCP clients connect to the protocol URL above.
+            </p>
+          )}
+          {info.protocol === "A2A" && (
+            <p className="text-[10px] text-muted-foreground/70">
+              Agent-to-agent protocol. External agents discover capabilities via the agent card URL above.
+            </p>
+          )}
+        </div>
+
+        {/* Divider */}
+        <div className="border-t" />
+
+        {/* Auth Info */}
+        <div>
+          <p className="text-xs font-medium mb-3">Authentication</p>
+          {isSigV4 ? (
+            <SigV4AuthSection auth={info.auth as IntegrationAuthSigV4} />
+          ) : (
+            <OAuth2AuthSection auth={info.auth as IntegrationAuthOAuth2} />
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/pages/AgentDetailPage.tsx
+++ b/frontend/src/pages/AgentDetailPage.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Key, Pencil, Check, X, Wrench } from "lucide-react";
 import { fetchModels } from "@/api/agents";
 import type { ModelOption } from "@/api/types";
@@ -16,6 +17,7 @@ import { SessionTable } from "@/components/SessionTable";
 import { DeploymentPanel } from "@/components/DeploymentPanel";
 import { RegistryStatusBadge } from "@/components/RegistryStatusBadge";
 import { RegistryActions } from "@/components/RegistryActions";
+import { ExternalIntegrationSection } from "@/components/ExternalIntegrationSection";
 import { useInvoke } from "@/hooks/useInvoke";
 import { useAuth } from "@/contexts/AuthContext";
 import { trackAction } from "@/api/audit";
@@ -109,214 +111,221 @@ export function AgentDetailPage({
   const isDeployed = agent.source === "deploy" || agent.source === "harness";
 
   return (
-    <div className="space-y-4">
-      {/* Overview */}
-      <Card>
-        <CardHeader className="pb-0">
-          <div className="flex items-center gap-2">
-            <CardTitle className="text-sm font-medium">Overview</CardTitle>
-            {agent.source === "harness" && (
-              <Badge variant="outline" className="text-[10px] px-1.5 py-0">MANAGED</Badge>
-            )}
-            {agent.source === "deploy" && (
-              <Badge variant="outline" className="text-[10px] px-1.5 py-0">CUSTOM</Badge>
-            )}
-            <RegistryStatusBadge status={agent.registry_status} showUnregistered={registryEnabled} registryEnabled={registryEnabled} />
-            {!registryReadOnly && registryEnabled && (
-              <RegistryActions
-                resourceType="agent"
-                resourceId={agent.id}
-                registryRecordId={agent.registry_record_id}
-                registryStatus={agent.registry_status}
-                onAction={() => onRefreshAgents?.()}
-              />
-            )}
-          </div>
-        </CardHeader>
-        <CardContent className="pt-0 space-y-1 text-xs text-muted-foreground">
-          {/* Description */}
-          {editingDescription ? (
-            <div className="space-y-2">
-              <Textarea
-                value={descriptionDraft}
-                onChange={(e) => setDescriptionDraft(e.target.value)}
-                placeholder="Describe what this agent does..."
-                className="text-xs resize-none"
-                rows={3}
-              />
-              <div className="flex gap-2">
-                <Button size="sm" className="h-6 text-xs" onClick={() => void handleSaveDescription()} disabled={savingDescription}>
-                  <Check className="h-3 w-3 mr-1" />
-                  Save
-                </Button>
-                <Button size="sm" variant="ghost" className="h-6 text-xs" onClick={handleCancelDescription} disabled={savingDescription}>
-                  <X className="h-3 w-3 mr-1" />
-                  Cancel
-                </Button>
-              </div>
-            </div>
-          ) : (
-            <div className="flex items-center gap-1.5">
-              <span className="font-medium shrink-0">Description:</span>
-              <span>{agent.description ?? <span className="italic">No description set.</span>}</span>
-              {onPatchAgent && (
-                <Button variant="ghost" size="icon" className="h-5 w-5 shrink-0" onClick={handleEditDescription}>
-                  <Pencil className="h-3 w-3" />
-                </Button>
-              )}
-            </div>
-          )}
-          {isDeployed && (
-            <div>
-              <DeploymentPanel
-                agent={agent}
-                onRedeploy={onRedeploy ?? (async () => {})}
-                onPatchAgent={onPatchAgent}
-              />
-            </div>
-          )}
-          {!isDeployed && agent.model_id && onPatchAgent && (
-            <div className="pt-2">
-              <RegisteredAgentModelConfig agent={agent} onPatchAgent={onPatchAgent} />
-            </div>
-          )}
-        </CardContent>
-      </Card>
+    <Tabs defaultValue="details" className="space-y-4">
+      <TabsList>
+        <TabsTrigger value="details">Details</TabsTrigger>
+        <TabsTrigger value="invoke">Invoke</TabsTrigger>
+      </TabsList>
 
-      {/* Sessions — full width across top */}
-      <section>
-        <SessionTable
-          sessions={sessions}
-          onSelectSession={onSelectSession}
-          loading={sessionsLoading}
-          currentUserId={user?.username ?? user?.sub}
-        />
-      </section>
-
-      {/* Invoke form */}
-      {effectiveCanInvoke ? (
-        <InvokePanel
-          agentId={agent.id}
-          qualifiers={agent.available_qualifiers}
-          sessions={sessions}
-          isStreaming={isStreaming}
-          modelId={agent.model_id}
-          allowedModelIds={agent.allowed_model_ids}
-          authorizerName={agent.authorizer_config?.name}
-          currentUserId={user?.username ?? user?.sub}
-          onInvoke={handleInvoke}
-          onCancel={cancel}
-        />
-      ) : (
-        <Card className="border-muted-foreground/20">
-          <CardContent className="pt-6 pb-6 text-center text-sm text-muted-foreground">
-            <Key className="h-8 w-8 mx-auto mb-2 opacity-50" />
-            {!canInvoke ? (
-              <>
-                <p>You don't have permission to invoke agents.</p>
-                <p className="text-xs mt-1">Contact your administrator for the <code className="px-1 py-0.5 rounded bg-muted">invoke</code> scope.</p>
-              </>
-            ) : (
-              <>
-                <p>This agent is in the <code className="px-1 py-0.5 rounded bg-muted">{agentGroup}</code> group.</p>
-                <p className="text-xs mt-1">You can only invoke agents in your assigned groups.</p>
-              </>
-            )}
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Latency summary — shown only after invocation completes */}
-      {sessionEnd && <LatencySummary sessionEnd={sessionEnd} />}
-
-      {/* Error */}
-      {error && (
-        <Card className="border-destructive">
-          <CardContent className="pt-4 text-sm text-destructive space-y-2">
-            <p>{error}</p>
-            {rawError && rawError !== error && (
-              <details className="text-xs">
-                <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
-                  Show details
-                </summary>
-                <pre className="mt-1 p-2 rounded bg-muted text-muted-foreground whitespace-pre-wrap font-mono text-xs">
-                  {rawError}
-                </pre>
-              </details>
-            )}
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Response — full width, expands dynamically with content */}
-      {(streamedText || isStreaming || sessionStart) && (
+      {/* Details tab: Overview + External Integration */}
+      <TabsContent value="details" className="space-y-4">
         <Card>
-          <CardHeader className="pb-2">
+          <CardHeader className="pb-0">
             <div className="flex items-center gap-2">
-              <CardTitle className="text-sm font-medium">Response</CardTitle>
-              {sessionStart && (
-                <Badge variant="outline" className="font-mono text-xs">
-                  {sessionStart.session_id}
-                </Badge>
+              <CardTitle className="text-sm font-medium">Overview</CardTitle>
+              {agent.source === "harness" && (
+                <Badge variant="outline" className="text-[10px] px-1.5 py-0">MANAGED</Badge>
               )}
-              {sessionStart?.has_token && (
-                <Badge variant="outline" className="border-border bg-input-bg text-xs gap-1">
-                  <Key className="h-3 w-3" />
-                  {sessionStart.token_source ?? "token"}
-                </Badge>
+              {agent.source === "deploy" && (
+                <Badge variant="outline" className="text-[10px] px-1.5 py-0">CUSTOM</Badge>
               )}
-              {isStreaming && (
-                <Badge variant="secondary" className="animate-pulse">
-                  streaming
-                </Badge>
+              <RegistryStatusBadge status={agent.registry_status} showUnregistered={registryEnabled} registryEnabled={registryEnabled} />
+              {!registryReadOnly && registryEnabled && (
+                <RegistryActions
+                  resourceType="agent"
+                  resourceId={agent.id}
+                  registryRecordId={agent.registry_record_id}
+                  registryStatus={agent.registry_status}
+                  onAction={() => onRefreshAgents?.()}
+                />
               )}
             </div>
           </CardHeader>
-          <CardContent>
-            {isStreaming && segments.length === 0 && (
-              <div className="flex items-center gap-2 mb-2 text-xs text-muted-foreground">
-                <span className="flex gap-0.5">
-                  <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:0ms]" />
-                  <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:150ms]" />
-                  <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:300ms]" />
-                </span>
-                <span>Thinking…</span>
+          <CardContent className="pt-0 space-y-1 text-xs text-muted-foreground">
+            {editingDescription ? (
+              <div className="space-y-2">
+                <Textarea
+                  value={descriptionDraft}
+                  onChange={(e) => setDescriptionDraft(e.target.value)}
+                  placeholder="Describe what this agent does..."
+                  className="text-xs resize-none"
+                  rows={3}
+                />
+                <div className="flex gap-2">
+                  <Button size="sm" className="h-6 text-xs" onClick={() => void handleSaveDescription()} disabled={savingDescription}>
+                    <Check className="h-3 w-3 mr-1" />
+                    Save
+                  </Button>
+                  <Button size="sm" variant="ghost" className="h-6 text-xs" onClick={handleCancelDescription} disabled={savingDescription}>
+                    <X className="h-3 w-3 mr-1" />
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="flex items-center gap-1.5">
+                <span className="font-medium shrink-0">Description:</span>
+                <span>{agent.description ?? <span className="italic">No description set.</span>}</span>
+                {onPatchAgent && (
+                  <Button variant="ghost" size="icon" className="h-5 w-5 shrink-0" onClick={handleEditDescription}>
+                    <Pencil className="h-3 w-3" />
+                  </Button>
+                )}
               </div>
             )}
-            <div className="rounded border bg-input-bg p-4 text-sm">
-              {(() => {
-                const blocks: React.ReactNode[] = [];
-                let toolGroup: { name: string; index: number; total: number; timestamp: number }[] = [];
-                let toolGroupStart = 0;
-                const flushTools = () => {
-                  if (toolGroup.length > 0) {
-                    const lastIdx = toolGroupStart + toolGroup.length - 1;
-                    const active = isStreaming && lastIdx === segments.length - 1;
-                    blocks.push(<ToolUseBlock key={`tools-${toolGroupStart}`} tools={toolGroup} isActive={active} />);
-                    toolGroup = [];
-                  }
-                };
-                segments.forEach((seg, i) => {
-                  if (seg.type === "tool_use") {
-                    if (toolGroup.length === 0) toolGroupStart = i;
-                    toolGroup.push({ name: seg.name, index: seg.index, total: seg.total, timestamp: seg.timestamp });
-                  } else {
-                    flushTools();
-                    blocks.push(<MarkdownBlock key={i} text={seg.content} />);
-                  }
-                });
-                flushTools();
-                return blocks;
-              })()}
-              {isStreaming && (
-                <span className="inline-block w-1.5 h-4 bg-foreground/70 animate-pulse ml-0.5 align-text-bottom" />
-              )}
-            </div>
+            {isDeployed && (
+              <div>
+                <DeploymentPanel
+                  agent={agent}
+                  onRedeploy={onRedeploy ?? (async () => {})}
+                  onPatchAgent={onPatchAgent}
+                />
+              </div>
+            )}
+            {!isDeployed && agent.model_id && onPatchAgent && (
+              <div className="pt-2">
+                <RegisteredAgentModelConfig agent={agent} onPatchAgent={onPatchAgent} />
+              </div>
+            )}
           </CardContent>
         </Card>
-      )}
 
-    </div>
+        {agent.status === "READY" && (agent.deployment_status === "deployed" || isDeployed) && (
+          <ExternalIntegrationSection agentId={agent.id} />
+        )}
+      </TabsContent>
+
+      {/* Invoke tab: Sessions + Invoke form + Response */}
+      <TabsContent value="invoke" className="space-y-4">
+        <section>
+          <SessionTable
+            sessions={sessions}
+            onSelectSession={onSelectSession}
+            loading={sessionsLoading}
+            currentUserId={user?.username ?? user?.sub}
+          />
+        </section>
+
+        {effectiveCanInvoke ? (
+          <InvokePanel
+            agentId={agent.id}
+            qualifiers={agent.available_qualifiers}
+            sessions={sessions}
+            isStreaming={isStreaming}
+            modelId={agent.model_id}
+            allowedModelIds={agent.allowed_model_ids}
+            authorizerName={agent.authorizer_config?.name}
+            currentUserId={user?.username ?? user?.sub}
+            onInvoke={handleInvoke}
+            onCancel={cancel}
+          />
+        ) : (
+          <Card className="border-muted-foreground/20">
+            <CardContent className="pt-6 pb-6 text-center text-sm text-muted-foreground">
+              <Key className="h-8 w-8 mx-auto mb-2 opacity-50" />
+              {!canInvoke ? (
+                <>
+                  <p>You don't have permission to invoke agents.</p>
+                  <p className="text-xs mt-1">Contact your administrator for the <code className="px-1 py-0.5 rounded bg-muted">invoke</code> scope.</p>
+                </>
+              ) : (
+                <>
+                  <p>This agent is in the <code className="px-1 py-0.5 rounded bg-muted">{agentGroup}</code> group.</p>
+                  <p className="text-xs mt-1">You can only invoke agents in your assigned groups.</p>
+                </>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {sessionEnd && <LatencySummary sessionEnd={sessionEnd} />}
+
+        {error && (
+          <Card className="border-destructive">
+            <CardContent className="pt-4 text-sm text-destructive space-y-2">
+              <p>{error}</p>
+              {rawError && rawError !== error && (
+                <details className="text-xs">
+                  <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+                    Show details
+                  </summary>
+                  <pre className="mt-1 p-2 rounded bg-muted text-muted-foreground whitespace-pre-wrap font-mono text-xs">
+                    {rawError}
+                  </pre>
+                </details>
+              )}
+            </CardContent>
+          </Card>
+        )}
+
+        {(streamedText || isStreaming || sessionStart) && (
+          <Card>
+            <CardHeader className="pb-2">
+              <div className="flex items-center gap-2">
+                <CardTitle className="text-sm font-medium">Response</CardTitle>
+                {sessionStart && (
+                  <Badge variant="outline" className="font-mono text-xs">
+                    {sessionStart.session_id}
+                  </Badge>
+                )}
+                {sessionStart?.has_token && (
+                  <Badge variant="outline" className="border-border bg-input-bg text-xs gap-1">
+                    <Key className="h-3 w-3" />
+                    {sessionStart.token_source ?? "token"}
+                  </Badge>
+                )}
+                {isStreaming && (
+                  <Badge variant="secondary" className="animate-pulse">
+                    streaming
+                  </Badge>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent>
+              {isStreaming && segments.length === 0 && (
+                <div className="flex items-center gap-2 mb-2 text-xs text-muted-foreground">
+                  <span className="flex gap-0.5">
+                    <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:0ms]" />
+                    <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:150ms]" />
+                    <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:300ms]" />
+                  </span>
+                  <span>Thinking…</span>
+                </div>
+              )}
+              <div className="rounded border bg-input-bg p-4 text-sm">
+                {(() => {
+                  const blocks: React.ReactNode[] = [];
+                  let toolGroup: { name: string; index: number; total: number; timestamp: number }[] = [];
+                  let toolGroupStart = 0;
+                  const flushTools = () => {
+                    if (toolGroup.length > 0) {
+                      const lastIdx = toolGroupStart + toolGroup.length - 1;
+                      const active = isStreaming && lastIdx === segments.length - 1;
+                      blocks.push(<ToolUseBlock key={`tools-${toolGroupStart}`} tools={toolGroup} isActive={active} />);
+                      toolGroup = [];
+                    }
+                  };
+                  segments.forEach((seg, i) => {
+                    if (seg.type === "tool_use") {
+                      if (toolGroup.length === 0) toolGroupStart = i;
+                      toolGroup.push({ name: seg.name, index: seg.index, total: seg.total, timestamp: seg.timestamp });
+                    } else {
+                      flushTools();
+                      blocks.push(<MarkdownBlock key={i} text={seg.content} />);
+                    }
+                  });
+                  flushTools();
+                  return blocks;
+                })()}
+                {isStreaming && (
+                  <span className="inline-block w-1.5 h-4 bg-foreground/70 animate-pulse ml-0.5 align-text-bottom" />
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </TabsContent>
+    </Tabs>
   );
 }
 


### PR DESCRIPTION
## Summary
- Add `GET /api/agents/{id}/integration` backend endpoint that assembles invocation URLs, auth requirements (SigV4 or OAuth2/JWT), and copy-ready code snippets (boto3, AWS CLI, curl) for READY agents
- Create `ExternalIntegrationSection` frontend component with per-qualifier endpoint URLs, protocol/network badges, copyable fields, and syntax-highlighted code blocks
- Restructure `AgentDetailPage` into **Details** and **Invoke** tabs to reduce page clutter
- Correct invocation URL patterns to match actual AgentCore API (`/runtimes/{arn}/invocations`, `/harnesses/invoke`) and resolve Cognito token endpoint from hosted UI domain

## Test Plan
- 10 backend tests in `test_integration_info.py` covering SigV4 custom/harness agents, OAuth2 Cognito/custom OIDC, MCP/A2A protocol URLs, multiple qualifiers, VPC network mode, and error cases
- TypeScript type check passes (`npx tsc --noEmit`)
- Manual verification of curl token request and agent invocation against live AgentCore deployment

Closes #84

Co-Authored-By: Claude <noreply@anthropic.com>