### PR TITLE
feat: add Okta IdP support, fix session cleanup and login UX

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -527,7 +527,7 @@ Model and IAM role are required fields. The deployment supports configurable pro
 
 Tags are resolved from the tag policy system at deploy time. Deploy-time tags are auto-applied from their default values; build-time tags are resolved from the selected tag profile. Required tags that are missing cause deployment to fail with a 400 error. Resolved tags are applied to all created AWS resources (AgentCore runtimes, endpoints, IAM execution roles, memory resources) and stored locally on Agent and Memory records. For registered agents and imported memories, tags are fetched from AWS via `list_tags_for_resource`; missing required tags are filled with `"missing"`.
 
-Deletion with `cleanup_aws=true` initiates background async AWS deletion (endpoint + runtime + MCP and A2A credential providers + Secrets Manager cleanup), explicitly deletes sessions/invocations,, marks the agent as DELETING, and returns the updated agent. The frontend polls the status endpoint until AWS confirms deletion (404), then calls the purge endpoint to remove the local record. Credential providers cascade delete when the agent is deleted.
+Deletion with `cleanup_aws=true` immediately deletes all sessions and invocations for the agent (preventing stale data on admin pages), then initiates background async AWS deletion (endpoint + runtime + MCP and A2A credential providers + Secrets Manager cleanup), marks the agent as DELETING, and returns the updated agent. The frontend polls the status endpoint until AWS confirms deletion (404), then calls the purge endpoint to remove the local record. Credential providers cascade delete when the agent is deleted.
 
 ## Authenticated Invocation
 

--- a/backend/SPECIFICATIONS.md
+++ b/backend/SPECIFICATIONS.md
@@ -554,7 +554,7 @@ The `/api/auth/config` endpoint returns only the pool ID and region. The user cl
 
 **`DELETE /api/agents/{agent_id}` behavior:**
 - When `cleanup_aws=false` or agent has no `runtime_id`: immediately deletes from local DB, returns the `AgentResponse` with HTTP 200.
-- When `cleanup_aws=true` and agent has a `runtime_id`: initiates async deletion via `BackgroundTasks`. The background task:
+- When `cleanup_aws=true` and agent has a `runtime_id`: immediately deletes all sessions and invocations for the agent from the local database (preventing stale session data from appearing on admin pages), then initiates async deletion via `BackgroundTasks`. The background task:
   1. Deletes non-DEFAULT runtime endpoints (AWS automatically handles DEFAULT endpoints).
   2. Deletes the runtime.
   3. Cleans up Secrets Manager secrets.
@@ -1423,7 +1423,7 @@ Linking endpoints under `/api/security/authorizers/{auth_id}/link`: `GET .../sta
 
 The `AuthorizerConfig` model includes an `allowed_audience` field (JSON array) for configuring the `allowedAudience` parameter on AgentCore runtimes. This is distinct from `allowedClients` — audience validates the `aud` claim, while clients validates the `azp` claim.
 
-**Entra ID compatibility:** Microsoft Entra ID v1.0 access tokens do not include the standard OAuth2 `azp` claim (they use a proprietary `appid` claim instead). AgentCore's `allowedClients` validates against `azp`, causing `UnrecognizedClientException` (401) for Entra ID tokens. The deploy paths for both custom and harness agents omit `allowedClients` when `authorizer_type == "entra_id"`, relying on `allowedAudience` alone for token validation.
+**Entra ID and Okta compatibility:** Microsoft Entra ID v1.0 access tokens use a proprietary `appid` claim instead of the standard OAuth2 `azp` claim, and Okta access tokens use `cid` instead of `azp`. AgentCore's `allowedClients` validates against `azp`, causing `UnrecognizedClientException` (401) for both providers. The deploy paths for both custom and harness agents omit `allowedClients` when `authorizer_type` is `"entra_id"` or `"okta"`, relying on `allowedAudience` alone for token validation.
 
 ### Entra ID v1.0/v2.0 Issuer Handling
 

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -99,7 +99,7 @@ class AgentDeployRequest(BaseModel):
     network_mode: str = Field(default="PUBLIC", description="PUBLIC or VPC")
     idle_timeout: int | None = Field(None, description="Idle runtime session timeout (seconds)")
     max_lifetime: int | None = Field(None, description="Max lifetime (seconds)")
-    authorizer_type: str | None = Field(None, description="Authorizer type: 'cognito' or 'other'")
+    authorizer_type: str | None = Field(None, description="Authorizer type: 'cognito', 'entra_id', 'okta', or 'other'")
     authorizer_pool_id: str | None = Field(None, description="Cognito pool ID for authorizer (when type is 'cognito')")
     authorizer_discovery_url: str | None = Field(None, description="OIDC discovery URL (when type is 'other')")
     authorizer_allowed_audience: list[str] = Field(default_factory=list, description="Allowed JWT audience values")
@@ -133,7 +133,7 @@ class AgentCreateRequest(BaseModel):
     network_mode: str = Field(default="PUBLIC", description="PUBLIC or VPC")
     idle_timeout: int | None = Field(None, description="Idle runtime session timeout (seconds)")
     max_lifetime: int | None = Field(None, description="Max lifetime (seconds)")
-    authorizer_type: str | None = Field(None, description="Authorizer type: 'cognito' or 'other'")
+    authorizer_type: str | None = Field(None, description="Authorizer type: 'cognito', 'entra_id', 'okta', or 'other'")
     authorizer_pool_id: str | None = Field(None, description="Cognito pool ID for authorizer (when type is 'cognito')")
     authorizer_discovery_url: str | None = Field(None, description="OIDC discovery URL (when type is 'other')")
     authorizer_allowed_audience: list[str] = Field(default_factory=list, description="Allowed JWT audience values")
@@ -1119,13 +1119,14 @@ def _deploy_agent_background(
             if request.authorizer_allowed_scopes:
                 jwt_config["allowedScopes"] = request.authorizer_allowed_scopes
             authorizer_config = {"customJWTAuthorizer": jwt_config}
-        elif request.authorizer_type in ("other", "entra_id") and request.authorizer_discovery_url:
+        elif request.authorizer_type in ("other", "entra_id", "okta") and request.authorizer_discovery_url:
             jwt_config = {"discoveryUrl": request.authorizer_discovery_url}
             if request.authorizer_allowed_audience:
                 jwt_config["allowedAudience"] = request.authorizer_allowed_audience
-            # Entra ID v1.0 tokens lack the standard 'azp' claim that AgentCore
-            # validates allowedClients against, so omit it for entra_id.
-            if request.authorizer_allowed_clients and request.authorizer_type != "entra_id":
+            # Entra ID v1.0 tokens use 'appid' and Okta tokens use 'cid'
+            # instead of the standard 'azp' claim that AgentCore validates
+            # allowedClients against, so omit it for these providers.
+            if request.authorizer_allowed_clients and request.authorizer_type not in ("entra_id", "okta"):
                 jwt_config["allowedClients"] = request.authorizer_allowed_clients
             if request.authorizer_allowed_scopes:
                 jwt_config["allowedScopes"] = request.authorizer_allowed_scopes
@@ -1331,11 +1332,11 @@ def _deploy_harness(request: AgentCreateRequest, db: Session, background_tasks: 
         if request.authorizer_allowed_scopes:
             jwt_config["allowedScopes"] = request.authorizer_allowed_scopes
         authorizer_config = {"customJWTAuthorizer": jwt_config}
-    elif request.authorizer_type in ("other", "entra_id") and request.authorizer_discovery_url:
+    elif request.authorizer_type in ("other", "entra_id", "okta") and request.authorizer_discovery_url:
         jwt_config = {"discoveryUrl": request.authorizer_discovery_url}
         if request.authorizer_allowed_audience:
             jwt_config["allowedAudience"] = request.authorizer_allowed_audience
-        if request.authorizer_allowed_clients and request.authorizer_type != "entra_id":
+        if request.authorizer_allowed_clients and request.authorizer_type not in ("entra_id", "okta"):
             jwt_config["allowedClients"] = request.authorizer_allowed_clients
         if request.authorizer_allowed_scopes:
             jwt_config["allowedScopes"] = request.authorizer_allowed_scopes
@@ -1916,6 +1917,16 @@ def delete_agent(
     # Clean up Cognito client secret from Secrets Manager
     if _secret_arn:
         delete_secret(_secret_arn, _region)
+
+    # Delete sessions/invocations immediately so they don't appear if a new
+    # agent reuses the same ID or the DELETING agent is still visible.
+    session_ids = [
+        s.session_id for s in
+        db.query(InvocationSession.session_id).filter(InvocationSession.agent_id == agent.id).all()
+    ]
+    if session_ids:
+        db.query(Invocation).filter(Invocation.session_id.in_(session_ids)).delete(synchronize_session="fetch")
+    db.query(InvocationSession).filter(InvocationSession.agent_id == agent.id).delete()
 
     # Mark as DELETING so frontend can poll for completion
     agent.status = "DELETING"

--- a/frontend/SPECIFICATIONS.md
+++ b/frontend/SPECIFICATIONS.md
@@ -205,7 +205,7 @@ Clicking the Trash2 icon triggers an overlay confirmation panel:
 - Cancel and Confirm buttons (right-aligned)
 - Clicks within the overlay are stopped from propagating to the card's `onClick`
 
-When deletion is confirmed with "Also delete in AgentCore" checked, the agent transitions to DELETING status with a spinner and timer on the card. The `useAgents` hook polls the agent status at 5-second intervals. When the poll returns 404, the hook calls the purge endpoint to remove the agent from the local database and shows a success toast.
+When deletion is confirmed with "Also delete in AgentCore" checked, the agent transitions to DELETING status with a spinner and timer on the card. The `useAgents` hook polls the agent status at 5-second intervals. When the poll returns 404, the hook calls the purge endpoint to remove the agent from the local database and shows a success toast. On deletion, persisted connector preferences (`loom:enabledConnectors:{agentId}:*`) are also cleaned up from `localStorage`.
 
 ---
 
@@ -310,8 +310,8 @@ Full deployment form with sections:
 **Content:**
 - `SecurityAdminPage` with sections for:
   - **Managed Roles**: list, create (import existing / wizard), view policy document, delete. Uses `SortableCardGrid` with drag-to-reorder (storage key `security-roles`), full-width single-column layout (role cards contain long ARNs and expandable policy documents), default alphabetical sort by role name, and A-Z/Z-A sort toggle.
-  - **Authorizer Configs**: list, create (Cognito type with pool selection and auto-populated discovery URL), update, delete. Uses `SortableCardGrid` with drag-to-reorder (storage key `security-authorizers`), default alphabetical sort by config name, and A-Z/Z-A sort toggle.
-  - **Authorizer Credentials**: per-config credential management (add label + client_id + client_secret, list, delete). Credential form uses 1/4 / 1/4 / 1/2 field widths. Authorizer type displayed as "Amazon Cognito" for cognito type.
+  - **Authorizer Configs**: list, create (Amazon Cognito, Microsoft Entra ID, Okta, or Other type with auto-populated discovery URL for Cognito), update, delete. Uses `SortableCardGrid` with drag-to-reorder (storage key `security-authorizers`), default alphabetical sort by config name, and A-Z/Z-A sort toggle.
+  - **Authorizer Credentials**: per-config credential management (add label + client_id + client_secret, list, delete). Credential form uses 1/4 / 1/4 / 1/2 field widths. Authorizer type displayed as "Amazon Cognito", "Microsoft Entra ID", or "Okta" for known types.
   - **Permission Requests**: create requests for additional IAM permissions, review (approve/deny) with role application. Uses `SortableCardGrid` with drag-to-reorder (storage key `security-permissions`), default alphabetical sort by role name, and A-Z/Z-A sort toggle.
 
 ---
@@ -614,7 +614,8 @@ Inline component for adding/removing tag-style values (clients, scopes). Single 
 Cognito client secrets are password-masked in forms. Secrets are sent to the backend which stores them in AWS Secrets Manager — they never persist in the frontend or local database.
 
 ### User Authentication
-- `AuthContext` provides login, logout, token refresh, user state, and scope-based authorization to the entire app.
+- `AuthContext` provides login, logout, logoutIdP, token refresh, user state, and scope-based authorization to the entire app.
+- `logout()` clears local state only (tokens, user, session storage). `logoutIdP()` calls `logout()` then redirects to the external IdP's logout endpoint (Okta or Entra ID) so the browser session is also cleared. Regular logout uses `logout()`; "Sign in as a different user" on the login page uses `logoutIdP()`.
 - Tokens (id, access, refresh) are stored in React state only — never in localStorage or cookies.
 - On logout, all `loom:invokePrompt:*` keys are cleared from `sessionStorage` so per-agent prompt drafts do not persist across user sessions.
 - The `AuthProvider` wraps the app at the top level (outside `TimezoneProvider`). If Cognito is not configured (empty pool ID from backend or missing `VITE_COGNITO_USER_CLIENT_ID`), authentication is bypassed and all scopes are granted.
@@ -804,7 +805,7 @@ A "Previewing end-user experience as [user]" banner is shown to admins when in v
 - "My Memory" button (shown only when the selected agent has memory resources attached)
 - User indicator and logout button
 
-**Agent filtering:** Agents are filtered client-side by comparing the agent's `loom:group` tag against the user's `g-users-*` group names. An agent with no `loom:group` tag is visible to all users.
+**Agent filtering:** Agents are filtered client-side by comparing the agent's `loom:group` tag against the user's `g-users-*` group names. An agent with no `loom:group` tag is visible to all users. Agents with `deployment_status === "removing"` (DELETING) are excluded from the list.
 
 **Chat area:**
 - Header with agent name and "responding..." indicator while streaming (scoped to the active conversation)
@@ -880,7 +881,7 @@ When an external IdP is active, `AuthContext` uses the standard Authorization Co
 
 1. `startOIDCLogin()` generates a cryptographic code verifier and challenge, stores state in `sessionStorage`, and redirects to the provider's authorization endpoint.
 2. On callback, `exchangeOIDCCode()` exchanges the authorization code for tokens at the provider's token endpoint using the stored code verifier.
-3. Group claims are extracted from the ID token using the provider's configured `group_claim` and mapped to Loom groups via the `group_mapping` from the auth config.
+3. Group claims are extracted from the ID token using the provider's configured `group_claim` and mapped to Loom groups via the `group_mapping` from the auth config. Empty group mappings (`{}`) are treated as "no mappings" — raw groups are passed through unchanged. This prevents the JavaScript truthiness of `{}` from discarding all groups.
 
 Functions are implemented in `frontend/src/api/auth.ts`.
 
@@ -889,7 +890,9 @@ Functions are implemented in `frontend/src/api/auth.ts`.
 When an external IdP is active:
 - A provider-branded button is shown (e.g., "Sign in with Microsoft Entra ID", "Sign in with Okta").
 - Clicking the button initiates the OIDC redirect flow.
-- The existing Cognito username/password form is hidden.
+- Below the button, the last OIDC username is displayed if available (persisted in `localStorage` as `loom_last_oidc_user`): "Currently logged in as [username]".
+- A "Sign in as a different user" link triggers `logoutIdP()` which redirects to the IdP's logout endpoint (Okta `/v1/logout` or Entra ID `/oauth2/v2.0/logout`) with `post_logout_redirect_uri` back to the app.
+- When both an external IdP and Cognito are configured, a tab bar allows switching between providers. The existing Cognito username/password form is shown on the Cognito tab.
 
 When no external IdP is active, the login page behaves identically to the existing Cognito flow.
 
@@ -900,7 +903,8 @@ When no external IdP is active, the login page behaves identically to the existi
 - **OIDC Discovery button**: fetches `.well-known/openid-configuration` and auto-populates authorization, token, JWKS, and userinfo endpoints.
 - **Test Discovery button**: validates that the provider's discovery endpoint is reachable and returns valid metadata.
 - **Group Mapping table**: editable table for mapping external IdP group names/IDs to Loom groups. Each row has external group (text input) and Loom group (dropdown of known groups).
-- **Active toggle**: at most one provider can be active. Activating a provider deactivates any previously active one.
+- **Status indicators**: each provider card shows a green/gray status dot (green for active, gray for inactive) and an "Active" badge when active.
+- **Activate/Deactivate button**: each provider card has an "Activate" or "Deactivate" button. At most one external provider can be active; deactivating all falls back to Cognito.
 
 ### API Client
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -402,6 +402,10 @@ function AppContent() {
       // bleed into a new agent that might reuse the same DB id.
       clearInvokeState(id);
       sessionStorage.removeItem(`loom:invokePrompt:${id}`);
+      // Remove persisted connector preferences for this agent
+      Object.keys(localStorage)
+        .filter((k) => k.startsWith(`loom:enabledConnectors:${id}:`))
+        .forEach((k) => localStorage.removeItem(k));
       // If the deleted agent was selected, clear all drill-down state
       if (selectedAgentId === id) {
         setSelectedAgentId(null);

--- a/frontend/src/components/AuthorizerManagementPanel.tsx
+++ b/frontend/src/components/AuthorizerManagementPanel.tsx
@@ -344,6 +344,7 @@ export function AuthorizerManagementPanel({ readOnly }: { readOnly?: boolean }) 
             <SelectContent>
               <SelectItem value="cognito">Amazon Cognito</SelectItem>
               <SelectItem value="entra_id">Microsoft Entra ID</SelectItem>
+              <SelectItem value="okta">Okta</SelectItem>
               <SelectItem value="other">Other</SelectItem>
             </SelectContent>
           </Select>
@@ -487,7 +488,7 @@ export function AuthorizerManagementPanel({ readOnly }: { readOnly?: boolean }) 
                       <div className="flex items-center gap-2">
                         <span className="text-sm font-medium">{config.name}</span>
                         <Badge variant="outline" className="text-[10px]">
-                          {config.authorizer_type === "cognito" ? "Amazon Cognito" : config.authorizer_type === "entra_id" ? "Microsoft Entra ID" : config.authorizer_type}
+                          {config.authorizer_type === "cognito" ? "Amazon Cognito" : config.authorizer_type === "entra_id" ? "Microsoft Entra ID" : config.authorizer_type === "okta" ? "Okta" : config.authorizer_type}
                         </Badge>
                         {config.user_client_id && (
                           <Badge variant="outline" className="text-[10px] border-green-500/50 text-green-600 dark:text-green-400">Linkable</Badge>

--- a/frontend/src/components/IdentityProviderPanel.tsx
+++ b/frontend/src/components/IdentityProviderPanel.tsx
@@ -259,6 +259,16 @@ export function IdentityProviderPanel({ readOnly }: IdentityProviderPanelProps) 
     }
   };
 
+  const handleToggleStatus = async (idp: IdentityProviderResponse) => {
+    try {
+      const newStatus = idp.status === "active" ? "inactive" : "active";
+      await updateIdentityProvider(idp.id, { status: newStatus });
+      await fetchProviders();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to update status");
+    }
+  };
+
   const editingProvider = editingId ? providers.find((p) => p.id === editingId) : null;
 
   const renderForm = (isEdit: boolean) => (
@@ -433,16 +443,31 @@ export function IdentityProviderPanel({ readOnly }: IdentityProviderPanelProps) 
                 </button>
                 <div className="min-w-0">
                   <div className="flex items-center gap-2">
+                    <span
+                      className={`inline-block h-2 w-2 rounded-full shrink-0 ${idp.status === "active" ? "bg-green-500" : "bg-muted-foreground/30"}`}
+                      title={idp.status === "active" ? "Active — login enabled" : "Inactive"}
+                    />
                     <span className="text-sm font-medium">{idp.name}</span>
                     <Badge variant="outline" className="text-[10px]">
                       {PROVIDER_TYPES.find((p) => p.value === idp.provider_type)?.label ?? idp.provider_type}
                     </Badge>
+                    {idp.status === "active" && (
+                      <Badge variant="outline" className="text-[10px] border-green-500/50 text-green-600 dark:text-green-400">Active</Badge>
+                    )}
                   </div>
                   <div className="text-xs text-muted-foreground">{idp.issuer_url}</div>
                 </div>
               </div>
               {!readOnly && (
-                <div className="flex items-center gap-1 shrink-0">
+                <div className="flex items-center gap-2 shrink-0">
+                  <Button
+                    size="sm"
+                    variant={idp.status === "active" ? "outline" : "default"}
+                    className="h-6 text-xs"
+                    onClick={() => void handleToggleStatus(idp)}
+                  >
+                    {idp.status === "active" ? "Deactivate" : "Activate"}
+                  </Button>
                   <button
                     type="button"
                     onClick={() => openEdit(idp)}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -116,6 +116,7 @@ interface AuthContextValue {
     newPassword: string,
   ) => Promise<void>;
   logout: () => void;
+  logoutIdP: () => void;
   browserSessionId: string | null;
 }
 
@@ -140,6 +141,7 @@ const AuthContext = createContext<AuthContextValue>({
   loginWithOIDC: async () => {},
   completeNewPassword: async () => {},
   logout: () => {},
+  logoutIdP: () => {},
   browserSessionId: null,
 });
 
@@ -217,19 +219,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           ?? (claims["cognito:groups"] as string[] | undefined)
           ?? [];
         const mappings = cfg.group_mappings;
-        const groups = mappings
+        const hasMappings = mappings && Object.keys(mappings).length > 0;
+        const groups = hasMappings
           ? rawGroups.flatMap((g) => mappings[g] ?? [])
           : rawGroups;
-        setUser({
-          sub: claims.sub as string,
-          email: (claims.email as string | undefined) ?? (claims.preferred_username as string | undefined),
-          username:
+        const oidcUsername =
             (claims.preferred_username as string)
             || (claims.email as string)
             || (claims.name as string)
-            || (claims.sub as string),
+            || (claims.sub as string);
+        setUser({
+          sub: claims.sub as string,
+          email: (claims.email as string | undefined) ?? (claims.preferred_username as string | undefined),
+          username: oidcUsername,
           groups,
         });
+        try { localStorage.setItem("loom_last_oidc_user", oidcUsername); } catch { /* ignore */ }
       } catch {
         setUser({ sub: "unknown" });
       }
@@ -473,6 +478,24 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .forEach((k) => sessionStorage.removeItem(k));
   }, []);
 
+  const logoutIdP = useCallback(() => {
+    const currentConfig = configRef.current;
+    const idToken = tokens?.idToken;
+    logout();
+    if (currentConfig && isExternalOIDC(currentConfig) && currentConfig.issuer_url) {
+      const issuer = currentConfig.issuer_url.replace(/\/+$/, "");
+      const returnUrl = window.location.origin;
+      if (currentConfig.provider_type === "okta") {
+        const params = new URLSearchParams({ post_logout_redirect_uri: returnUrl });
+        if (idToken) params.set("id_token_hint", idToken);
+        window.location.href = `${issuer}/v1/logout?${params.toString()}`;
+      } else if (currentConfig.provider_type === "entra_id") {
+        const params = new URLSearchParams({ post_logout_redirect_uri: returnUrl });
+        window.location.href = `${issuer}/oauth2/v2.0/logout?${params.toString()}`;
+      }
+    }
+  }, [tokens, logout]);
+
   useEffect(() => {
     return () => {
       if (refreshTimerRef.current) {
@@ -512,6 +535,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         loginWithOIDC,
         completeNewPassword,
         logout,
+        logoutIdP,
         browserSessionId,
       }}
     >

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -323,6 +323,7 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
     listAgents()
       .then((all) => {
         const accessible = all.filter((a) => {
+          if (a.deployment_status === "removing") return false;
           const group = (a.tags["loom:group"] as string | undefined) ?? "";
           return !group || userGroupNames.includes(group);
         });

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -13,7 +13,7 @@ const PROVIDER_LABELS: Record<string, string> = {
 };
 
 export function LoginPage() {
-  const { login, loginWithOIDC, completeNewPassword, authConfig } = useAuth();
+  const { login, loginWithOIDC, completeNewPassword, authConfig, logoutIdP } = useAuth();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -29,6 +29,7 @@ export function LoginPage() {
   const isExternalOIDC = authConfig?.provider_type && authConfig.provider_type !== "cognito";
   const providerLabel = PROVIDER_LABELS[authConfig?.provider_type ?? ""] ?? "Single Sign-On";
   const hasBothProviders = isExternalOIDC && authConfig?.user_pool_id;
+  const lastOidcUser = isExternalOIDC ? localStorage.getItem("loom_last_oidc_user") : null;
 
   const [selectedProvider, setSelectedProvider] = useState<"external" | "cognito">(
     isExternalOIDC ? "external" : "cognito",
@@ -154,6 +155,22 @@ export function LoginPage() {
               >
                 {loading ? "Redirecting..." : `Sign in with ${providerLabel}`}
               </Button>
+              {lastOidcUser ? (
+                <p className="text-xs text-muted-foreground text-center">
+                  Currently logged in as <span className="font-medium text-foreground">{lastOidcUser}</span>
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground text-center">
+                  You may be signed in automatically if you have an active {providerLabel} session.
+                </p>
+              )}
+              <button
+                type="button"
+                className="text-xs text-muted-foreground hover:text-foreground underline w-full text-center"
+                onClick={() => { try { localStorage.removeItem("loom_last_oidc_user"); } catch { /* ignore */ } logoutIdP(); }}
+              >
+                Sign in as a different user
+              </button>
               {error && (
                 <p className="text-sm text-destructive">{error}</p>
               )}


### PR DESCRIPTION
## Summary
- Add Okta as a supported authorizer type alongside Cognito and Entra ID, with proper `allowedClients` omission (Okta uses `cid` instead of `azp`)
- Fix stale session data on agent deletion by immediately deleting sessions/invocations before marking agent as DELETING
- Fix empty `group_mappings` (`{}`) bug where JavaScript truthiness caused all external IdP groups to be discarded
- Separate `logout()` (local only) from `logoutIdP()` (IdP redirect) to prevent double page refresh on logout
- Add activate/deactivate controls and green/gray status indicators to Identity Provider panel
- Show cached OIDC username on login page with "Sign in as a different user" option
- Filter DELETING agents from end-user chat page agent list
- Clean up localStorage connector preferences on agent deletion

## Test Plan
- [ ] Configure Okta as an authorizer — verify `allowedClients` is omitted in AgentCore deploy
- [ ] Delete an agent with sessions — verify sessions are removed immediately, not after background task
- [ ] Login via Okta with empty group_mappings — verify groups pass through correctly
- [ ] Logout from Okta session — verify single page load (no double refresh)
- [ ] Verify activate/deactivate buttons toggle IdP status correctly
- [ ] Verify cached username displays on login page after Okta login
- [ ] Verify DELETING agents don't appear in end-user chat

Closes #70

Co-Authored-By: Claude <noreply@anthropic.com>