### PR TITLE
fix: refresh auth config on logout and scope cached OIDC user to provider

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -234,7 +234,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           username: oidcUsername,
           groups,
         });
-        try { localStorage.setItem("loom_last_oidc_user", oidcUsername); } catch { /* ignore */ }
+        try {
+          localStorage.setItem("loom_last_oidc_user", oidcUsername);
+          localStorage.setItem("loom_last_oidc_provider", cfg.provider_type ?? "");
+        } catch { /* ignore */ }
       } catch {
         setUser({ sub: "unknown" });
       }
@@ -476,6 +479,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     Object.keys(sessionStorage)
       .filter((k) => k.startsWith("loom:invokePrompt:"))
       .forEach((k) => sessionStorage.removeItem(k));
+    fetchAuthConfig().then((cfg) => setConfig(cfg)).catch(() => {});
   }, []);
 
   const logoutIdP = useCallback(() => {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -29,7 +29,10 @@ export function LoginPage() {
   const isExternalOIDC = authConfig?.provider_type && authConfig.provider_type !== "cognito";
   const providerLabel = PROVIDER_LABELS[authConfig?.provider_type ?? ""] ?? "Single Sign-On";
   const hasBothProviders = isExternalOIDC && authConfig?.user_pool_id;
-  const lastOidcUser = isExternalOIDC ? localStorage.getItem("loom_last_oidc_user") : null;
+  const lastOidcProvider = isExternalOIDC ? localStorage.getItem("loom_last_oidc_provider") : null;
+  const lastOidcUser = isExternalOIDC && lastOidcProvider === authConfig?.provider_type
+    ? localStorage.getItem("loom_last_oidc_user")
+    : null;
 
   const [selectedProvider, setSelectedProvider] = useState<"external" | "cognito">(
     isExternalOIDC ? "external" : "cognito",
@@ -167,7 +170,7 @@ export function LoginPage() {
               <button
                 type="button"
                 className="text-xs text-muted-foreground hover:text-foreground underline w-full text-center"
-                onClick={() => { try { localStorage.removeItem("loom_last_oidc_user"); } catch { /* ignore */ } logoutIdP(); }}
+                onClick={() => { try { localStorage.removeItem("loom_last_oidc_user"); localStorage.removeItem("loom_last_oidc_provider"); } catch { /* ignore */ } logoutIdP(); }}
               >
                 Sign in as a different user
               </button>


### PR DESCRIPTION
## Summary
- Re-fetch `authConfig` from the backend on logout so the login page reflects the currently active IdP without a manual page refresh
- Store the provider type alongside the cached OIDC username in localStorage and only display it when it matches the active provider, preventing stale usernames from a previous IdP appearing after switching

## Test Plan
- [ ] Switch active IdP from Okta to Entra ID, log out — login page should show Entra ID button (not Okta)
- [ ] Log in via Okta, switch to Entra ID, log out — no "Currently logged in as..." message from Okta session
- [ ] Log in via Entra ID — cached username shows correctly on next logout
- [ ] "Sign in as a different user" clears both cached username and provider

Co-Authored-By: Claude <noreply@anthropic.com>