### PR TITLE
feat: add human-in-the-loop approvals and MCP elicitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Loom seamlessly weaves together agents, memory stores, MCP servers, and agent-to
 - Two-dimensional group-based authorization: Type groups (t-admin, t-user) for UI view and Resource groups (g-admins-*, g-users-*) for access control (21 scopes total)
 - IAM role, authorizer, and credential management
 - Admin user view switching to preview scoped experiences
+- Human-in-the-loop (HITL) approval policies: configurable policies for tool-level human oversight with four methods — agentic loop hooks, tool context interrupts, MCP elicitation, and harness inline functions
+- Approval audit trail with per-agent queryable log
 
 ### Platform Catalog and Tagging
 - Unified catalog view across agents, memory, MCP servers, and platform resources

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -111,6 +111,7 @@ Detailed specifications for each component are maintained in their respective di
 - The backend retrieves secrets at invocation time with in-memory caching (5-minute TTL).
 - Secrets are cleaned up from Secrets Manager when authorizer credentials or agents are deleted.
 - Security administration (roles, authorizers, credentials, permissions) is managed through a dedicated persona workflow.
+- Human-in-the-loop (HITL) approval policies enforce human oversight for sensitive tool calls. Four HITL methods are supported: agentic loop hooks (custom agents), tool context interrupts (custom agents), MCP elicitation (custom agents with MCP), and harness inline functions (managed agents).
 
 ### User Authentication
 

--- a/agents/strands_agent/src/agent.py
+++ b/agents/strands_agent/src/agent.py
@@ -7,6 +7,7 @@ from strands import Agent
 from strands.models.bedrock import BedrockModel
 
 from src.config import AgentConfig, MCPServerConfig
+from src.integrations.approval import ApprovalHook
 from src.integrations.mcp_client import build_mcp_clients, create_mcp_clients, has_oauth2_servers
 from src.integrations.a2a_client import create_a2a_clients
 from src.integrations.memory import MemoryHook
@@ -15,7 +16,7 @@ from src.telemetry import TelemetryHook
 logger = logging.getLogger(__name__)
 
 
-def build_agent(config: AgentConfig, defer_mcp: bool = False) -> Agent:
+def build_agent(config: AgentConfig, defer_mcp: bool = False) -> tuple[Agent, ApprovalHook]:
     """Build a Strands Agent from the provided configuration.
 
     Initializes the Bedrock model, loads enabled integrations
@@ -59,6 +60,12 @@ def build_agent(config: AgentConfig, defer_mcp: bool = False) -> Agent:
                 tools.extend(a2a_clients)
                 logger.info("Loaded %d A2A client(s)", len(a2a_clients))
 
+    # Approval hook (HITL Method 1) — policies injected at invocation time
+    approval_hook = ApprovalHook(agent_tags=config.tags if hasattr(config, "tags") else None)
+    hooks.append(approval_hook)
+    if approval_hook.policies:
+        logger.info("Enabled approval hook with %d static policy(ies)", len(approval_hook.policies))
+
     # Telemetry hook (R7)
     telemetry_hook = TelemetryHook()
     hooks.append(telemetry_hook)
@@ -101,7 +108,7 @@ def build_agent(config: AgentConfig, defer_mcp: bool = False) -> Agent:
         else:
             raise
     logger.info("Agent initialized with %d tool(s) and %d hook(s)", len(agent.tool_registry.registry), len(hooks))
-    return agent
+    return agent, approval_hook
 
 
 def attach_mcp_tools(agent: Agent, servers: list[MCPServerConfig]) -> None:

--- a/agents/strands_agent/src/config.py
+++ b/agents/strands_agent/src/config.py
@@ -27,6 +27,7 @@ class MCPServerConfig:
     transport: str = "streamable_http"
     endpoint_url: str = ""
     auth: Optional[AuthConfig] = None
+    dynamic_only: bool = False
 
 
 @dataclass
@@ -99,6 +100,7 @@ def _parse_mcp_servers(data: list[dict]) -> list[MCPServerConfig]:
             transport=entry.get("transport", "streamable_http"),
             endpoint_url=entry.get("endpoint_url", ""),
             auth=_parse_auth(entry.get("auth")),
+            dynamic_only=entry.get("dynamic_only", False),
         ))
     return servers
 

--- a/agents/strands_agent/src/handler.py
+++ b/agents/strands_agent/src/handler.py
@@ -10,11 +10,24 @@ manages the HTTP plumbing, health-check, and invocation lifecycle.
 The handler is async and yields streaming events via
 ``agent.stream_async()`` so partial text chunks are emitted as they are
 generated (R5).
+
+Two invocation paths are supported:
+- HTTP streaming (``@app.entrypoint``): Uses Strands interrupt mechanism
+  for HITL approval (Methods 1 & 2). Also supports MCP elicitation
+  (Method 3) via a two-invocation pattern: the first invocation blocks
+  the tool and ends the stream with an elicitation event; the second
+  invocation provides the user's response and resumes the agent task.
+- WebSocket (``@app.websocket``): Supports full MCP elicitation (Method 4)
+  via bidirectional messaging. The elicitation callback relays requests to
+  the WebSocket client and awaits the response inline.
 """
 
+import asyncio
+import json
 import logging
 import os
 import sys
+import threading
 from typing import Any, AsyncGenerator
 
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
@@ -22,8 +35,11 @@ from strands.types.exceptions import MaxTokensReachedException
 
 from strands.models.bedrock import BedrockModel
 
+from mcp.types import ElicitResult
+
 from src.config import AgentConfig, MCPServerConfig, AuthConfig, load_config
 from src.agent import attach_mcp_tools, build_agent
+from src.integrations.approval import ApprovalHook
 from src.integrations.mcp_client import has_deferred_auth_servers, _build_transport_callable
 from src.telemetry import trace_invocation
 
@@ -47,6 +63,16 @@ _mcp_attached = False
 _dynamic_mcp_clients: dict[str, Any] = {}  # keyed by (server_name, actor_id)
 _default_model: BedrockModel | None = None
 _model_cache: dict[str, BedrockModel] = {}  # keyed by model_id
+_approval_hook: ApprovalHook | None = None
+
+# Elicitation bridge state (persists across HTTP invocations on same container)
+# When a tool calls ctx.elicit(), the agent task blocks. The HTTP response ends
+# with an elicitation event. The next invocation provides the response and
+# resumes reading from the same running agent task.
+_elicit_events: dict[str, threading.Event] = {}  # session_id -> Event to unblock callback
+_elicit_responses: dict[str, dict[str, Any]] = {}  # session_id -> response from user
+_elicit_queues: dict[str, asyncio.Queue] = {}  # session_id -> event queue from agent task
+_agent_tasks: dict[str, asyncio.Task] = {}  # session_id -> background agent task
 
 
 def _get_agent():
@@ -56,13 +82,13 @@ def _get_agent():
     MCP client initialization is deferred until the first invocation
     when the workload access token is available in the request context.
     """
-    global _agent, _config, _default_model
+    global _agent, _config, _default_model, _approval_hook
     if _agent is None:
         _config = load_config()
         defer_mcp = has_deferred_auth_servers(_config.integrations.mcp_servers)
         if defer_mcp:
             logger.info("Deferring MCP client init — authenticated servers require invocation context")
-        _agent = build_agent(_config, defer_mcp=defer_mcp)
+        _agent, _approval_hook = build_agent(_config, defer_mcp=defer_mcp)
         _default_model = _agent.model
         logger.info("Agent initialized successfully")
     return _agent
@@ -75,36 +101,460 @@ def _ensure_mcp_tools(actor_id: str = ""):
         return
     _mcp_attached = True
 
-    enabled_servers = [s for s in _config.integrations.mcp_servers if s.enabled]
-    if not enabled_servers:
+    static_servers = [s for s in _config.integrations.mcp_servers if s.enabled and not s.dynamic_only]
+    if not static_servers:
         return
 
     if actor_id:
-        for server in _config.integrations.mcp_servers:
+        for server in static_servers:
             if server.auth and server.auth.type == "api_key" and "{actor_id}" in server.auth.credentials_secret_arn:
                 server.auth.credentials_secret_arn = server.auth.credentials_secret_arn.replace("{actor_id}", actor_id)
 
     logger.info("Attaching MCP tools (first invocation with context)")
     try:
-        attach_mcp_tools(_agent, _config.integrations.mcp_servers)
+        attach_mcp_tools(_agent, static_servers)
     except Exception as e:
         logger.warning("Failed to attach MCP tools: %s. Agent will continue without MCP tools.", e)
 
 
-def _attach_dynamic_mcp_servers(agent_instance, dynamic_servers: list[dict[str, Any]], actor_id: str) -> None:
+def _attach_dynamic_mcp_servers(agent_instance, dynamic_servers: list[dict[str, Any]], actor_id: str, elicitation_callback=None) -> None:
     """Attach dynamically-requested MCP servers for this invocation.
 
     Maintains a pool keyed by (server_name, actor_id). New servers are
     started and registered; previously-connected servers are reused.
+    Skips servers whose tools are already registered (e.g. from static config).
     """
     from strands.tools.mcp import MCPClient
 
     for server_data in dynamic_servers:
         name = server_data.get("name", "")
-        pool_key = f"{name}:{actor_id}"
+        suffix = ":elicit" if elicitation_callback else ""
+        pool_key = f"{name}:{actor_id}{suffix}"
 
         if pool_key in _dynamic_mcp_clients:
             logger.debug("Reusing cached dynamic MCP client for '%s'", name)
+            continue
+
+        auth_data = server_data.get("auth")
+        auth_config = None
+        if auth_data:
+            auth_config = AuthConfig(
+                type=auth_data.get("type", ""),
+                credentials_secret_arn=auth_data.get("credentials_secret_arn", ""),
+                api_key_header_name=auth_data.get("api_key_header_name", "x-api-key"),
+                well_known_endpoint=auth_data.get("well_known_endpoint", ""),
+                credential_provider_name=auth_data.get("credential_provider_name", ""),
+                scopes=auth_data.get("scopes", ""),
+            )
+
+        # Skip OAuth2 servers with no usable credentials — they would connect
+        # unauthenticated and fail.
+        if auth_config and auth_config.type == "oauth2" and not auth_config.credential_provider_name and not auth_config.credentials_secret_arn:
+            logger.info("Skipping dynamic MCP server '%s' — OAuth2 without credentials", name)
+            continue
+
+        config = MCPServerConfig(
+            name=name,
+            enabled=True,
+            transport=server_data.get("transport", "streamable_http"),
+            endpoint_url=server_data.get("endpoint_url", ""),
+            auth=auth_config,
+        )
+
+        # When attaching with elicitation, remove conflicting static tools first
+        if elicitation_callback:
+            from strands.tools.mcp.mcp_agent_tool import MCPAgentTool
+            to_remove = [
+                tname for tname, tool in agent_instance.tool_registry.registry.items()
+                if isinstance(tool, MCPAgentTool)
+            ]
+            for tname in to_remove:
+                del agent_instance.tool_registry.registry[tname]
+            if to_remove:
+                logger.info("Cleared %d static MCP tool(s) for elicitation re-attach: %s", len(to_remove), to_remove)
+
+        transport_callable = _build_transport_callable(config)
+        client = MCPClient(transport_callable, elicitation_callback=elicitation_callback)
+        try:
+            agent_instance.tool_registry.process_tools([client])
+            _dynamic_mcp_clients[pool_key] = client
+            logger.info("Attached dynamic MCP server '%s' for actor '%s' (elicit=%s)", name, actor_id, bool(elicitation_callback))
+        except BaseException as e:
+            logger.warning("Failed to attach dynamic MCP server '%s' for actor '%s': %s", name, actor_id, e)
+            try:
+                client.stop()
+            except BaseException:
+                pass
+
+
+@app.entrypoint
+async def invoke(payload: dict[str, Any]) -> AsyncGenerator[Any, None]:
+    """Handle an AgentCore Runtime invocation with streaming response.
+
+    Supports three invocation modes:
+    1. Normal prompt → stream text back
+    2. interruptResponse → resume from ApprovalHook interrupt
+    3. elicitationResponse → resume a blocked elicitation callback
+
+    When ``supports_elicitation`` is true in the payload, dynamic MCP servers
+    are attached with an elicitation callback. If the tool calls ctx.elicit(),
+    the agent task blocks while the HTTP response yields the elicitation event
+    and ends. The next invocation with ``elicitationResponse`` unblocks it.
+    """
+    agent = _get_agent()
+
+    session_id = payload.get("session_id", "")
+    actor_id = payload.get("actor_id") or "loom-agent"
+
+    _ensure_mcp_tools(actor_id)
+
+    # --- Handle elicitation response (resume a blocked tool) ---
+    elicitation_response = payload.get("elicitationResponse")
+    if elicitation_response and session_id in _elicit_events:
+        logger.info("Resuming elicitation for session_id=%s action=%s", session_id, elicitation_response.get("action"))
+        _elicit_responses[session_id] = elicitation_response
+        _elicit_events[session_id].set()
+
+        queue = _elicit_queues.get(session_id)
+        if queue:
+            async for event in _drain_queue(queue):
+                yield event
+        _cleanup_elicit_state(session_id)
+        return
+
+    # --- Determine if elicitation is enabled for this invocation ---
+    supports_elicitation = payload.get("supports_elicitation", False)
+
+    elicitation_callback = None
+    if supports_elicitation:
+        # Capture the main event loop so the callback (which runs in the
+        # MCPClient's background thread) can schedule work on it.
+        _main_loop = asyncio.get_event_loop()
+
+        async def elicitation_callback(context, params):
+            """Block until the next invocation provides the user's response.
+
+            This callback runs in the MCPClient's background thread event loop.
+            The asyncio.Queue and Event live on the main loop, so we use
+            run_coroutine_threadsafe + wrap_future to bridge the gap.
+            """
+            elicit_id = f"elicit-{session_id}-{id(params)}"
+            logger.info("Elicitation requested: id=%s message=%s", elicit_id, params.message[:100])
+
+            schema = None
+            if hasattr(params, "requestedSchema") and params.requestedSchema:
+                schema = params.requestedSchema
+
+            # Create the threading.Event BEFORE putting the elicitation on the
+            # queue, so the main loop sees it in _elicit_events when _drain_queue
+            # returns (avoids race where cleanup fires before event is stored).
+            t_event = threading.Event()
+            _elicit_events[session_id] = t_event
+
+            queue = _elicit_queues.get(session_id)
+            if queue:
+                fut = asyncio.run_coroutine_threadsafe(
+                    queue.put({"_elicitation": {"id": elicit_id, "message": params.message, "schema": schema}}),
+                    _main_loop,
+                )
+                await asyncio.wrap_future(fut)
+
+            # Block the background thread until the resume sets the event
+            await asyncio.get_event_loop().run_in_executor(None, t_event.wait, 600)
+
+            response_data = _elicit_responses.pop(session_id, {})
+            _elicit_events.pop(session_id, None)
+            action = response_data.get("action", "decline")
+            content = response_data.get("content")
+            logger.info("Elicitation response: action=%s", action)
+            return ElicitResult(action=action, content=content)
+
+    dynamic_servers = payload.get("dynamic_mcp_servers")
+    if dynamic_servers:
+        _attach_dynamic_mcp_servers(agent, dynamic_servers, actor_id, elicitation_callback=elicitation_callback)
+
+    # Inject approval policies from the invocation payload (sent by Loom)
+    invocation_policies = payload.get("approval_policies")
+    if invocation_policies and isinstance(invocation_policies, list) and _approval_hook:
+        _approval_hook.policies = invocation_policies
+        logger.info("Injected %d approval policy(ies) from payload", len(invocation_policies))
+
+    # Runtime model override
+    runtime_model_id = payload.get("model_id")
+    if runtime_model_id and _config:
+        if runtime_model_id not in _model_cache:
+            _model_cache[runtime_model_id] = BedrockModel(
+                model_id=runtime_model_id,
+                max_tokens=_config.max_tokens,
+                streaming=True,
+            )
+            logger.info("Created cached BedrockModel for runtime override: %s", runtime_model_id)
+        agent.model = _model_cache[runtime_model_id]
+    elif _default_model:
+        agent.model = _default_model
+
+    # Determine if this is a new prompt or an interrupt resume
+    interrupt_responses = payload.get("interruptResponse")
+    if interrupt_responses and isinstance(interrupt_responses, list):
+        agent_input = interrupt_responses
+        logger.info("Resuming from interrupt session_id=%s with %d response(s)", session_id, len(interrupt_responses))
+    else:
+        agent_input = payload.get("prompt", "")
+        logger.info("Processing invocation session_id=%s actor_id=%s model=%s", session_id, actor_id, runtime_model_id or _config.model_id if _config else "unknown")
+
+    # Set user_role in agent state for Method 2 tool-context approval
+    user_role = payload.get("user_role")
+    if user_role:
+        agent.state.set("user_role", user_role)
+
+    if supports_elicitation:
+        # Run agent in background task so elicitation can block without stopping the stream
+        queue: asyncio.Queue = asyncio.Queue()
+        _elicit_queues[session_id] = queue
+
+        async def _run_agent_task():
+            try:
+                with trace_invocation(invocation_id=session_id) as span:
+                    span.set_attribute("agent.session_id", session_id)
+                    result = None
+                    stream = agent.stream_async(agent_input, invocation_state={"session_id": session_id, "actor_id": actor_id})
+                    async for event in stream:
+                        if isinstance(event, dict):
+                            if "result" in event:
+                                result = event["result"]
+                                continue
+                            text = None
+                            data = event.get("data")
+                            if isinstance(data, str):
+                                text = data
+                            elif isinstance(event.get("delta"), dict):
+                                text = event["delta"].get("text")
+                            if text:
+                                await queue.put(text)
+                                continue
+                            chunk = event.get("event")
+                            if isinstance(chunk, dict):
+                                if "contentBlockStart" in chunk:
+                                    start = chunk["contentBlockStart"].get("start", {})
+                                    tool_use = start.get("toolUse")
+                                    if isinstance(tool_use, dict) and tool_use.get("name"):
+                                        logger.info("Tool call detected: %s", tool_use["name"])
+                                        await queue.put({"tool_use": {"name": tool_use["name"], "id": tool_use.get("toolUseId", "")}})
+
+                    if result and getattr(result, "stop_reason", None) == "interrupt":
+                        interrupts = getattr(result, "interrupts", [])
+                        logger.info("Agent interrupted with %d pending approval(s)", len(interrupts))
+                        await queue.put({"interrupt": {"stopReason": "interrupt", "interrupts": [{"id": i.id, "name": i.name, "reason": i.reason} for i in interrupts]}})
+            except MaxTokensReachedException:
+                await queue.put("\n\n[Response truncated: the model reached its maximum output token limit.]")
+            except Exception as e:
+                logger.error("Agent task error session_id=%s: %s", session_id, e)
+                await queue.put({"_error": str(e)})
+            finally:
+                await queue.put(None)
+
+        _agent_tasks[session_id] = asyncio.create_task(_run_agent_task())
+        async for event in _drain_queue(queue):
+            yield event
+        if session_id not in _elicit_events:
+            _cleanup_elicit_state(session_id)
+    else:
+        # Simple path: no elicitation, stream directly
+        with trace_invocation(invocation_id=session_id) as span:
+            span.set_attribute("agent.session_id", session_id)
+            try:
+                result = None
+                stream = agent.stream_async(agent_input, invocation_state={"session_id": session_id, "actor_id": actor_id})
+                async for event in stream:
+                    if isinstance(event, dict):
+                        if "result" in event:
+                            result = event["result"]
+                            continue
+                        text = None
+                        data = event.get("data")
+                        if isinstance(data, str):
+                            text = data
+                        elif isinstance(event.get("delta"), dict):
+                            text = event["delta"].get("text")
+                        if text:
+                            yield text
+                            continue
+                        event_keys = list(event.keys())
+                        logger.info("Stream event keys: %s", event_keys)
+                        chunk = event.get("event")
+                        if isinstance(chunk, dict):
+                            if "contentBlockStart" in chunk:
+                                start = chunk["contentBlockStart"].get("start", {})
+                                tool_use = start.get("toolUse")
+                                if isinstance(tool_use, dict) and tool_use.get("name"):
+                                    logger.info("Tool call detected: %s", tool_use["name"])
+                                    yield {"tool_use": {"name": tool_use["name"], "id": tool_use.get("toolUseId", "")}}
+
+                if result and getattr(result, "stop_reason", None) == "interrupt":
+                    interrupts = getattr(result, "interrupts", [])
+                    logger.info("Agent interrupted with %d pending approval(s)", len(interrupts))
+                    yield {"interrupt": {"stopReason": "interrupt", "interrupts": [{"id": i.id, "name": i.name, "reason": i.reason} for i in interrupts]}}
+            except MaxTokensReachedException:
+                logger.warning("Max tokens reached for session_id=%s", session_id)
+                yield "\n\n[Response truncated: the model reached its maximum output token limit. Try a shorter prompt or a model with a higher token limit.]"
+
+
+async def _drain_queue(queue: asyncio.Queue) -> AsyncGenerator[Any, None]:
+    """Yield events from the agent task queue until sentinel or elicitation."""
+    while True:
+        event = await queue.get()
+        if event is None:
+            break
+        if isinstance(event, dict):
+            if "_elicitation" in event:
+                yield {"elicitation": event["_elicitation"]}
+                return
+            if "_error" in event:
+                yield f"\n\nError: {event['_error']}"
+                break
+        yield event
+
+
+def _cleanup_elicit_state(session_id: str) -> None:
+    """Remove elicitation bridge state for a session."""
+    _elicit_events.pop(session_id, None)
+    _elicit_responses.pop(session_id, None)
+    _elicit_queues.pop(session_id, None)
+    _agent_tasks.pop(session_id, None)
+
+
+@app.websocket
+async def ws_invoke(websocket, context) -> None:
+    """WebSocket handler for MCP elicitation support (Method 4).
+
+    Bidirectional WebSocket enables the elicitation callback to send
+    requests to the client and await responses inline during tool execution.
+
+    Protocol:
+    - Client sends: {"type": "prompt", "prompt": "...", ...}
+    - Server sends: {"type": "text", "content": "..."}  (streaming tokens)
+    - Server sends: {"type": "tool_use", "name": "..."}  (tool call notification)
+    - Server sends: {"type": "elicitation", "message": "...", "id": "..."}
+    - Client sends: {"type": "elicitation_response", "id": "...", "action": "accept|decline"}
+    - Server sends: {"type": "result", "content": "..."}  (final result)
+    - Server sends: {"type": "error", "content": "..."}  (on failure)
+    """
+    await websocket.accept()
+
+    agent = _get_agent()
+    elicit_event = asyncio.Event()
+    elicit_response: dict[str, Any] = {}
+
+    async def elicitation_callback(ctx, params):
+        elicit_id = f"elicit-{id(params)}"
+        await websocket.send_json({
+            "type": "elicitation",
+            "id": elicit_id,
+            "message": params.message,
+        })
+        elicit_event.clear()
+        await elicit_event.wait()
+        action = elicit_response.pop("action", "decline")
+        content = elicit_response.pop("content", {})
+        return ElicitResult(action=action, content=content)
+
+    try:
+        pending_recv = None
+        while True:
+            if pending_recv is None:
+                pending_recv = asyncio.ensure_future(websocket.receive_json())
+
+            data = await pending_recv
+            pending_recv = None
+            msg_type = data.get("type", "prompt")
+
+            if msg_type == "elicitation_response":
+                elicit_response["action"] = data.get("action", "decline")
+                elicit_response["content"] = data.get("content", {})
+                elicit_event.set()
+                continue
+
+            if msg_type != "prompt":
+                continue
+
+            prompt = data.get("prompt", "")
+            session_id = data.get("session_id", "")
+            actor_id = data.get("actor_id") or "loom-agent"
+
+            _ensure_mcp_tools(actor_id)
+
+            dynamic_servers = data.get("dynamic_mcp_servers")
+            if dynamic_servers:
+                _attach_dynamic_mcp_servers(agent, dynamic_servers, actor_id)
+
+            # Attach dynamic MCP servers with elicitation support
+            dynamic_mcp_elicit = data.get("dynamic_mcp_servers_elicit")
+            if dynamic_mcp_elicit:
+                _attach_dynamic_mcp_servers_ws(agent, dynamic_mcp_elicit, actor_id, elicitation_callback)
+
+            # Runtime model override
+            runtime_model_id = data.get("model_id")
+            if runtime_model_id and _config:
+                if runtime_model_id not in _model_cache:
+                    _model_cache[runtime_model_id] = BedrockModel(
+                        model_id=runtime_model_id,
+                        max_tokens=_config.max_tokens,
+                        streaming=True,
+                    )
+                agent.model = _model_cache[runtime_model_id]
+            elif _default_model:
+                agent.model = _default_model
+
+            # Run agent in executor so we can receive messages concurrently
+            loop = asyncio.get_event_loop()
+
+            def _run_agent(p=prompt):
+                result = agent(p)
+                return str(result)
+
+            agent_task = asyncio.ensure_future(
+                loop.run_in_executor(None, _run_agent)
+            )
+
+            while not agent_task.done():
+                if pending_recv is None:
+                    pending_recv = asyncio.ensure_future(websocket.receive_json())
+                done, _ = await asyncio.wait(
+                    {agent_task, pending_recv}, return_when=asyncio.FIRST_COMPLETED,
+                )
+                if pending_recv in done:
+                    msg = pending_recv.result()
+                    pending_recv = None
+                    if msg.get("type") == "elicitation_response":
+                        elicit_response["action"] = msg.get("action", "decline")
+                        elicit_response["content"] = msg.get("content", {})
+                        elicit_event.set()
+
+            result_text = agent_task.result()
+            await websocket.send_json({"type": "result", "content": result_text})
+
+    except Exception as e:
+        logger.exception("WebSocket handler error: %s", e)
+        try:
+            await websocket.send_json({"type": "error", "content": str(e)})
+        except Exception:
+            pass
+
+
+def _attach_dynamic_mcp_servers_ws(
+    agent_instance, dynamic_servers: list[dict[str, Any]], actor_id: str, elicitation_callback
+) -> None:
+    """Attach dynamic MCP servers with elicitation callback for WebSocket path."""
+    from strands.tools.mcp import MCPClient
+    from functools import partial
+    from datetime import timedelta
+
+    for server_data in dynamic_servers:
+        name = server_data.get("name", "")
+        pool_key = f"{name}:{actor_id}:ws"
+
+        if pool_key in _dynamic_mcp_clients:
+            logger.debug("Reusing cached dynamic MCP client (ws) for '%s'", name)
             continue
 
         auth_data = server_data.get("auth")
@@ -128,94 +578,17 @@ def _attach_dynamic_mcp_servers(agent_instance, dynamic_servers: list[dict[str, 
         )
 
         transport_callable = _build_transport_callable(config)
-        client = MCPClient(transport_callable)
+        client = MCPClient(transport_callable, elicitation_callback=elicitation_callback)
         try:
             agent_instance.tool_registry.process_tools([client])
             _dynamic_mcp_clients[pool_key] = client
-            logger.info("Attached dynamic MCP server '%s' for actor '%s'", name, actor_id)
+            logger.info("Attached dynamic MCP server (ws+elicit) '%s' for actor '%s'", name, actor_id)
         except BaseException as e:
-            logger.warning("Failed to attach dynamic MCP server '%s' for actor '%s': %s", name, actor_id, e)
+            logger.warning("Failed to attach dynamic MCP server (ws) '%s': %s", name, e)
             try:
                 client.stop()
             except BaseException:
                 pass
-
-
-@app.entrypoint
-async def invoke(payload: dict[str, Any]) -> AsyncGenerator[Any, None]:
-    """Handle an AgentCore Runtime invocation with streaming response.
-
-    This is an async generator decorated with ``@app.entrypoint``.  The
-    ``BedrockAgentCoreApp`` SDK forwards ``POST /invocations`` requests
-    here and streams each yielded event back to the caller.
-
-    Using ``agent.stream_async()`` ensures partial text chunks are emitted
-    as they are generated rather than buffered (R5).
-
-    Args:
-        payload: The invocation payload containing at minimum a ``prompt`` key.
-
-    Yields:
-        Streaming events produced by the agent.
-    """
-    agent = _get_agent()
-
-    prompt = payload.get("prompt", "")
-    session_id = payload.get("session_id", "")
-    actor_id = payload.get("actor_id") or "loom-agent"
-
-    _ensure_mcp_tools(actor_id)
-
-    dynamic_servers = payload.get("dynamic_mcp_servers")
-    if dynamic_servers:
-        _attach_dynamic_mcp_servers(agent, dynamic_servers, actor_id)
-
-    # Runtime model override
-    runtime_model_id = payload.get("model_id")
-    if runtime_model_id and _config:
-        if runtime_model_id not in _model_cache:
-            _model_cache[runtime_model_id] = BedrockModel(
-                model_id=runtime_model_id,
-                max_tokens=_config.max_tokens,
-                streaming=True,
-            )
-            logger.info("Created cached BedrockModel for runtime override: %s", runtime_model_id)
-        agent.model = _model_cache[runtime_model_id]
-    elif _default_model:
-        agent.model = _default_model
-
-    logger.info("Processing invocation session_id=%s actor_id=%s model=%s", session_id, actor_id, runtime_model_id or _config.model_id if _config else "unknown")
-
-    with trace_invocation(invocation_id=session_id) as span:
-        span.set_attribute("agent.session_id", session_id)
-        try:
-            stream = agent.stream_async(prompt, invocation_state={"session_id": session_id, "actor_id": actor_id})
-            async for event in stream:
-                if isinstance(event, dict):
-                    text = None
-                    data = event.get("data")
-                    if isinstance(data, str):
-                        text = data
-                    elif isinstance(event.get("delta"), dict):
-                        text = event["delta"].get("text")
-                    if text:
-                        yield text
-                        continue
-                    # Log non-text event keys for diagnostics
-                    event_keys = list(event.keys())
-                    logger.info("Stream event keys: %s", event_keys)
-                    # Check for tool_use in contentBlockStart (Strands SDK stream event)
-                    chunk = event.get("event")
-                    if isinstance(chunk, dict):
-                        if "contentBlockStart" in chunk:
-                            start = chunk["contentBlockStart"].get("start", {})
-                            tool_use = start.get("toolUse")
-                            if isinstance(tool_use, dict) and tool_use.get("name"):
-                                logger.info("Tool call detected: %s", tool_use["name"])
-                                yield {"tool_use": {"name": tool_use["name"], "id": tool_use.get("toolUseId", "")}}
-        except MaxTokensReachedException:
-            logger.warning("Max tokens reached for session_id=%s", session_id)
-            yield "\n\n[Response truncated: the model reached its maximum output token limit. Try a shorter prompt or a model with a higher token limit.]"
 
 
 def main() -> None:

--- a/agents/strands_agent/src/integrations/approval.py
+++ b/agents/strands_agent/src/integrations/approval.py
@@ -1,0 +1,183 @@
+"""Human-in-the-loop approval integration for Strands agents.
+
+Implements HITL patterns using the Strands SDK interrupt mechanism:
+
+1. **ApprovalHook** (Method 1) — A ``HookProvider`` that registers a
+   ``BeforeToolCallEvent`` callback. When a tool call matches configured
+   approval policies, the hook calls ``event.interrupt()`` which pauses
+   the agent and returns control to the caller.
+
+2. **Tool Context** (Method 2) — Individual tools can use
+   ``tool_context.interrupt()`` directly within their implementation for
+   fine-grained, tool-specific approval logic.
+
+Both patterns produce interrupts that the entrypoint handler detects via
+``result.stop_reason == "interrupt"`` and relays to the caller as
+structured events. The caller resumes the agent by re-invoking with
+``interruptResponse`` payloads.
+
+Reference implementations:
+  - Method 1: github.com/aws-samples/sample-human-in-the-loop-patterns/method1_hook
+  - Method 2: github.com/aws-samples/sample-human-in-the-loop-patterns/method2_tool_context
+"""
+
+import fnmatch
+import json
+import logging
+import os
+from typing import Any
+
+from strands.hooks import BeforeToolCallEvent, HookProvider, HookRegistry
+
+logger = logging.getLogger(__name__)
+
+
+def _load_policies() -> list[dict[str, Any]]:
+    raw = os.environ.get("LOOM_APPROVAL_POLICIES", "[]")
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse LOOM_APPROVAL_POLICIES")
+        return []
+
+
+def _matches_tool(tool_name: str, rules: list[str]) -> bool:
+    if not rules:
+        return True
+    return any(fnmatch.fnmatch(tool_name, pattern) for pattern in rules)
+
+
+def _matches_agent(policy: dict[str, Any], agent_tags: dict[str, str] | None = None) -> bool:
+    scope = policy.get("agent_scope", {"type": "all"})
+    scope_type = scope.get("type", "all")
+    if scope_type == "all":
+        return True
+    if scope_type == "tag_filter" and agent_tags:
+        key = scope.get("tag_key", "")
+        value = scope.get("tag_value", "")
+        return agent_tags.get(key) == value
+    return True
+
+
+class ApprovalHook(HookProvider):
+    """Strands HookProvider that intercepts tool calls requiring approval.
+
+    Registered as a hook on the Agent instance. When a tool call matches
+    an approval policy, calls ``event.interrupt()`` to pause the agent.
+    The agent returns with ``result.stop_reason == "interrupt"`` and a list
+    of pending interrupts. The caller sends ``interruptResponse`` payloads
+    to resume execution.
+
+    Supports per-session "trust" caching: if the user responds "t" (trust),
+    subsequent calls to the same tool in that session are auto-approved via
+    agent state.
+
+    Usage::
+
+        agent = Agent(
+            hooks=[ApprovalHook()],
+            tools=[...],
+        )
+
+    The hook reads policies from the LOOM_APPROVAL_POLICIES environment
+    variable (JSON array) or from an explicit list passed at construction.
+    """
+
+    def __init__(
+        self,
+        policies: list[dict[str, Any]] | None = None,
+        agent_tags: dict[str, str] | None = None,
+    ):
+        self.policies = policies if policies is not None else _load_policies()
+        self.agent_tags = agent_tags or {}
+
+    def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
+        registry.add_callback(BeforeToolCallEvent, self._check_approval)
+
+    def _check_approval(self, event: BeforeToolCallEvent) -> None:
+        tool_name = event.tool_use["name"]
+        policy = self._find_matching_policy(tool_name)
+        if policy is None:
+            return
+
+        approval_mode = policy.get("approval_mode", "require_approval")
+        if approval_mode == "notify_only":
+            return
+
+        approval_key = f"{tool_name}-approval"
+        if event.agent.state.get(approval_key) == "t":
+            return
+
+        tool_input = event.tool_use.get("input", {})
+        input_summary = str(tool_input)[:500] if tool_input else ""
+
+        approval = event.interrupt(
+            approval_key,
+            reason={
+                "reason": f"Authorize {tool_name}",
+                "tool_name": tool_name,
+                "tool_input_summary": input_summary,
+                "policy_name": policy.get("name", ""),
+                "policy_type": policy.get("policy_type", "loop_hook"),
+                "approval_mode": approval_mode,
+                "timeout_seconds": policy.get("timeout_seconds", 300),
+            },
+        )
+
+        if approval.lower() not in ["y", "yes", "t", "approved"]:
+            event.cancel_tool = f"User denied permission to run {tool_name}"
+            return
+
+        if approval.lower() == "t":
+            event.agent.state.set(approval_key, "t")
+
+    def _find_matching_policy(self, tool_name: str) -> dict[str, Any] | None:
+        for policy in self.policies:
+            if not policy.get("enabled", True):
+                continue
+            if policy.get("policy_type") not in ("loop_hook", None):
+                continue
+            if not _matches_agent(policy, self.agent_tags):
+                continue
+            if _matches_tool(tool_name, policy.get("tool_match_rules", [])):
+                return policy
+        return None
+
+
+def check_access(tool_context, resource_id: str, action: str, required_role: str = ""):
+    """Role-based approval check for Method 2 (tool context interrupt).
+
+    Call this inside a ``@tool(context=True)`` function to implement
+    fine-grained, per-operation approval with role-based access control.
+
+    Returns None if approved, or a denial message string.
+
+    Usage::
+
+        @tool(context=True)
+        def sensitive_tool(tool_context, patient_id: str) -> str:
+            denial = check_access(tool_context, patient_id, "read-records", required_role="Physician")
+            if denial:
+                return denial
+            return do_sensitive_thing()
+    """
+    user_role = tool_context.agent.state.get("user_role") or ""
+
+    if required_role and user_role != required_role:
+        return f"Access denied: {action} for {resource_id} requires {required_role} role (current: {user_role or 'none'})"
+
+    approval_key = f"{action}-{resource_id}-approval"
+    if tool_context.agent.state.get(approval_key) == "t":
+        return None
+
+    approval = tool_context.interrupt(
+        approval_key,
+        reason={"reason": f"[{user_role or 'user'}] Authorize {action} for {resource_id}"},
+    )
+    if approval.lower() not in ["y", "yes", "t", "approved"]:
+        return f"User denied access to {action} for {resource_id}"
+
+    if approval.lower() == "t":
+        tool_context.agent.state.set(approval_key, "t")
+
+    return None

--- a/agents/strands_agent/tests/test_approval.py
+++ b/agents/strands_agent/tests/test_approval.py
@@ -1,0 +1,192 @@
+"""Tests for the approval integration module."""
+import json
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+from integrations.approval import (
+    ApprovalHook,
+    check_access,
+    _matches_tool,
+    _matches_agent,
+)
+
+
+class TestMatchesTool(unittest.TestCase):
+    def test_empty_rules_match_all(self):
+        self.assertTrue(_matches_tool("any_tool", []))
+
+    def test_exact_match(self):
+        self.assertTrue(_matches_tool("db_write", ["db_write"]))
+
+    def test_glob_match(self):
+        self.assertTrue(_matches_tool("db_write", ["db_*"]))
+
+    def test_no_match(self):
+        self.assertFalse(_matches_tool("file_read", ["db_*"]))
+
+    def test_multiple_rules(self):
+        self.assertTrue(_matches_tool("file_write", ["db_*", "file_*"]))
+
+
+class TestMatchesAgent(unittest.TestCase):
+    def test_scope_all(self):
+        policy = {"agent_scope": {"type": "all"}}
+        self.assertTrue(_matches_agent(policy, {"env": "prod"}))
+
+    def test_scope_tag_filter_match(self):
+        policy = {"agent_scope": {"type": "tag_filter", "tag_key": "env", "tag_value": "prod"}}
+        self.assertTrue(_matches_agent(policy, {"env": "prod"}))
+
+    def test_scope_tag_filter_no_match(self):
+        policy = {"agent_scope": {"type": "tag_filter", "tag_key": "env", "tag_value": "prod"}}
+        self.assertFalse(_matches_agent(policy, {"env": "staging"}))
+
+    def test_scope_default_all(self):
+        policy = {}
+        self.assertTrue(_matches_agent(policy, None))
+
+
+class TestApprovalHook(unittest.TestCase):
+    def _make_hook(self, policies):
+        return ApprovalHook(policies=policies)
+
+    def test_find_matching_policy(self):
+        hook = self._make_hook([
+            {"name": "Guard DB", "policy_type": "loop_hook", "tool_match_rules": ["db_*"], "enabled": True},
+            {"name": "Disabled", "policy_type": "loop_hook", "tool_match_rules": ["*"], "enabled": False},
+            {"name": "Tool Context Only", "policy_type": "tool_context", "tool_match_rules": ["*"], "enabled": True},
+        ])
+        policy = hook._find_matching_policy("db_write")
+        self.assertIsNotNone(policy)
+        self.assertEqual(policy["name"], "Guard DB")
+
+    def test_no_match_for_unrelated_tool(self):
+        hook = self._make_hook([
+            {"name": "Guard", "policy_type": "loop_hook", "tool_match_rules": ["db_*"], "enabled": True},
+        ])
+        self.assertIsNone(hook._find_matching_policy("file_read"))
+
+    def test_empty_policies(self):
+        hook = self._make_hook([])
+        self.assertIsNone(hook._find_matching_policy("anything"))
+
+    def test_notify_only_does_not_interrupt(self):
+        hook = self._make_hook([
+            {"name": "Notify", "policy_type": "loop_hook", "tool_match_rules": ["*"],
+             "approval_mode": "notify_only", "enabled": True},
+        ])
+        event = MagicMock()
+        event.tool_use = {"name": "some_tool", "input": {}}
+        event.agent.state.get.return_value = None
+        hook._check_approval(event)
+        event.interrupt.assert_not_called()
+
+    def test_interrupt_called_for_matching_tool(self):
+        hook = self._make_hook([
+            {"name": "Guard", "policy_type": "loop_hook", "tool_match_rules": ["db_*"],
+             "approval_mode": "require_approval", "timeout_seconds": 60, "enabled": True},
+        ])
+        event = MagicMock()
+        event.tool_use = {"name": "db_write", "input": {"table": "users"}}
+        event.agent.state.get.return_value = None
+        event.interrupt.return_value = "y"
+
+        hook._check_approval(event)
+        event.interrupt.assert_called_once()
+        call_args = event.interrupt.call_args
+        self.assertEqual(call_args[0][0], "db_write-approval")
+        reason = call_args[1]["reason"]
+        self.assertEqual(reason["tool_name"], "db_write")
+
+    def test_denied_sets_cancel_tool(self):
+        hook = self._make_hook([
+            {"name": "Guard", "policy_type": "loop_hook", "tool_match_rules": ["*"],
+             "approval_mode": "require_approval", "enabled": True},
+        ])
+        event = MagicMock()
+        event.tool_use = {"name": "dangerous_tool", "input": {}}
+        event.agent.state.get.return_value = None
+        event.interrupt.return_value = "n"
+
+        hook._check_approval(event)
+        self.assertIn("denied", event.cancel_tool)
+
+    def test_trust_caches_in_state(self):
+        hook = self._make_hook([
+            {"name": "Guard", "policy_type": "loop_hook", "tool_match_rules": ["*"],
+             "approval_mode": "require_approval", "enabled": True},
+        ])
+        event = MagicMock()
+        event.tool_use = {"name": "my_tool", "input": {}}
+        event.agent.state.get.return_value = None
+        event.interrupt.return_value = "t"
+
+        hook._check_approval(event)
+        event.agent.state.set.assert_called_once_with("my_tool-approval", "t")
+
+    def test_cached_approval_skips_interrupt(self):
+        hook = self._make_hook([
+            {"name": "Guard", "policy_type": "loop_hook", "tool_match_rules": ["*"],
+             "approval_mode": "require_approval", "enabled": True},
+        ])
+        event = MagicMock()
+        event.tool_use = {"name": "my_tool", "input": {}}
+        event.agent.state.get.return_value = "t"
+
+        hook._check_approval(event)
+        event.interrupt.assert_not_called()
+
+    @patch.dict(os.environ, {"LOOM_APPROVAL_POLICIES": json.dumps([
+        {"name": "Env", "policy_type": "loop_hook", "tool_match_rules": ["*"], "enabled": True}
+    ])})
+    def test_loads_from_env(self):
+        hook = ApprovalHook()
+        self.assertEqual(len(hook.policies), 1)
+        self.assertEqual(hook.policies[0]["name"], "Env")
+
+
+class TestCheckAccess(unittest.TestCase):
+    def _make_context(self, user_role=None, state_overrides=None):
+        ctx = MagicMock()
+        state = state_overrides or {}
+        ctx.agent.state.get.side_effect = lambda k: state.get(k, user_role if k == "user_role" else None)
+        ctx.interrupt.return_value = "y"
+        return ctx
+
+    def test_wrong_role_denied(self):
+        ctx = self._make_context(user_role="Nurse")
+        result = check_access(ctx, "patient-123", "read-records", required_role="Physician")
+        self.assertIsNotNone(result)
+        self.assertIn("Access denied", result)
+        ctx.interrupt.assert_not_called()
+
+    def test_correct_role_prompts_interrupt(self):
+        ctx = self._make_context(user_role="Physician")
+        result = check_access(ctx, "patient-123", "read-records", required_role="Physician")
+        self.assertIsNone(result)
+        ctx.interrupt.assert_called_once()
+
+    def test_denied_by_user(self):
+        ctx = self._make_context(user_role="Physician")
+        ctx.interrupt.return_value = "n"
+        result = check_access(ctx, "patient-123", "read-records", required_role="Physician")
+        self.assertIsNotNone(result)
+        self.assertIn("denied", result)
+
+    def test_trust_caches(self):
+        ctx = self._make_context(user_role="Physician")
+        ctx.interrupt.return_value = "t"
+        result = check_access(ctx, "patient-123", "read-records", required_role="Physician")
+        self.assertIsNone(result)
+        ctx.agent.state.set.assert_called_once_with("read-records-patient-123-approval", "t")
+
+    def test_no_role_required(self):
+        ctx = self._make_context(user_role="")
+        result = check_access(ctx, "res-1", "action", required_role="")
+        self.assertIsNone(result)
+        ctx.interrupt.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/SPECIFICATIONS.md
+++ b/backend/SPECIFICATIONS.md
@@ -1431,7 +1431,56 @@ Entra ID v2.0 token endpoints issue access tokens with a v1.0 issuer (`https://s
 
 ---
 
-## 13. Makefile Targets
+## 13. Human-in-the-Loop (HITL) Approvals
+
+Loom supports three HITL patterns for pausing agent execution at sensitive tool calls and requiring human approval:
+
+### 13.1 Agentic Loop Hook (Custom Agents — Method 1)
+
+The Strands Agent framework `before_tool_call` hook intercepts tool calls. When a matching approval policy exists:
+1. The hook emits an `approval_request` SSE event via the streaming queue.
+2. The backend (`invocations.py`) detects the interrupt, calls `create_approval_request()` and `wait_for_approval()`.
+3. The user's decision is submitted via `POST /api/approvals/{request_id}/decision`.
+4. The agent is resumed with `interruptResponse` containing the decision.
+
+### 13.2 Tool Context Interrupt (Custom Agents — Method 2)
+
+Individual tools embed approval logic using `agents/strands_agent/src/integrations/approval.py`. Tools call `require_approval()` to pause and wait for human input. Approval decisions can be cached per session via `approval_cache_ttl`.
+
+### 13.3 MCP Elicitation (Custom Agents — Method 3)
+
+MCP servers use `ctx.elicit()` to request structured input. The handler (`handler.py`) uses a `threading.Event` for cross-thread synchronization:
+1. The elicitation request is put on the streaming queue as an `elicitation_request` SSE event.
+2. The backend waits on the event until the user submits a response via `POST /api/approvals/{request_id}/decision`.
+3. The response content is passed back to the MCP server's elicitation callback.
+
+### 13.4 Harness Inline Function (Managed Agents — Method 4)
+
+Managed harness agents use an `inline_function` tool (`user_confirmation`) defined at deploy time. When the agent calls this tool:
+1. The harness stream stops with `stopReason: "tool_use"`.
+2. `invoke_harness_agent_stream` detects the `tool_use_stop` event and emits `approval_request` SSE.
+3. After user decision, the backend calls `resume_harness_stream()` with both the assistant `toolUse` turn and user `toolResult` turn.
+4. Multiple consecutive HITL rounds are supported via a loop.
+
+### 13.5 Approval Policies
+
+Stored in `approval_policies` table. Fields: `name`, `policy_type` (loop_hook/tool_context/mcp_elicitation), `tool_pattern` (glob), `approval_mode` (require_approval/notify_only), `timeout_seconds`, `agent_filter`. CRUD via `/api/settings/approval-policies`.
+
+### 13.6 Approval Audit Log
+
+All approval events are recorded in `approval_logs` table: `request_id`, `session_id`, `agent_id`, `tool_name`, `policy_name`, `pattern_type`, `status`, timestamps, `decided_by`, `reason`. Queryable via `GET /api/agents/{agent_id}/approvals`.
+
+### 13.7 SSE Event Types
+
+| Event | Description |
+|-------|-------------|
+| `approval_request` | Agent paused — awaiting user decision. Contains `request_id`, `tool_name`, `tool_input_summary`, `timeout_seconds`. |
+| `approval_resolved` | Decision made. Contains `request_id`, `status` (approved/rejected/timeout), `decided_by`, `reason`. |
+| `elicitation_request` | MCP server requesting structured input. Contains `elicitation_id`, `server_name`, `schema`, `message`. |
+
+---
+
+## 14. Makefile Targets
 
 The backend `makefile` sources `etc/environment.sh` and provides:
 

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -134,6 +134,8 @@ def _migrate_add_columns(eng) -> None:
         ("identity_providers", "authorization_endpoint", "VARCHAR"),
         ("identity_providers", "token_endpoint", "VARCHAR"),
         ("identity_providers", "discovery_scopes", "TEXT"),
+        ("mcp_servers", "supports_elicitation", "VARCHAR"),
+        ("mcp_servers", "runtime_endpoint_url", "VARCHAR"),
     ]
 
     is_postgres = eng.dialect.name == "postgresql"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.db import init_db
-from app.routers import a2a, admin, agents, auth, costs, credentials, identity_providers, integrations, invocations, logs, mcp, memories, registry, security, settings, traces
+from app.routers import a2a, admin, agents, approvals, auth, costs, credentials, identity_providers, integrations, invocations, logs, mcp, memories, registry, security, settings, traces
 
 # Configure logging
 LOG_LEVEL = os.getenv("LOG_LEVEL", "info").upper()
@@ -90,6 +90,7 @@ app.add_middleware(
 app.include_router(a2a.router)
 app.include_router(admin.router)
 app.include_router(agents.router)
+app.include_router(approvals.router)
 app.include_router(auth.router)
 app.include_router(costs.router)
 app.include_router(credentials.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -15,6 +15,8 @@ from app.models.tag_profile import TagProfile
 from app.models.mcp import McpServer, McpTool, McpServerAccess
 from app.models.site_setting import SiteSetting
 from app.models.audit import AuditLogin, AuditAction, AuditPageView
+from app.models.approval_policy import ApprovalPolicy
+from app.models.approval_log import ApprovalLog
 
 __all__ = [
     "Agent", "InvocationSession", "Invocation", "ConfigEntry",
@@ -23,4 +25,5 @@ __all__ = [
     "AuthorizerCredential", "Memory", "TagPolicy", "TagProfile",
     "McpServer", "McpTool", "McpServerAccess", "SiteSetting",
     "AuditLogin", "AuditAction", "AuditPageView",
+    "ApprovalPolicy", "ApprovalLog",
 ]

--- a/backend/app/models/approval_log.py
+++ b/backend/app/models/approval_log.py
@@ -1,0 +1,37 @@
+from sqlalchemy import Column, Integer, String, Text, DateTime
+from sqlalchemy.sql import func
+from app.db import Base
+
+
+class ApprovalLog(Base):
+    __tablename__ = "approval_logs"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    request_id = Column(String, nullable=False, index=True)
+    session_id = Column(String, nullable=True, index=True)
+    agent_id = Column(Integer, nullable=True, index=True)
+    tool_name = Column(String, nullable=False)
+    tool_input_summary = Column(Text, nullable=True)
+    policy_name = Column(String, nullable=True)
+    pattern_type = Column(String, nullable=False)  # loop_hook, tool_context, mcp_elicitation
+    status = Column(String, nullable=False, default="pending")  # pending, approved, rejected, timeout
+    requested_at = Column(DateTime, server_default=func.now())
+    decided_at = Column(DateTime, nullable=True)
+    decided_by = Column(String, nullable=True)
+    reason = Column(Text, nullable=True)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "request_id": self.request_id,
+            "session_id": self.session_id,
+            "agent_id": self.agent_id,
+            "tool_name": self.tool_name,
+            "tool_input_summary": self.tool_input_summary,
+            "policy_name": self.policy_name,
+            "pattern_type": self.pattern_type,
+            "status": self.status,
+            "requested_at": self.requested_at.isoformat() if self.requested_at else None,
+            "decided_at": self.decided_at.isoformat() if self.decided_at else None,
+            "decided_by": self.decided_by,
+            "reason": self.reason,
+        }

--- a/backend/app/models/approval_policy.py
+++ b/backend/app/models/approval_policy.py
@@ -1,0 +1,45 @@
+import json
+
+from sqlalchemy import Column, Integer, String, Text, Boolean, DateTime
+from sqlalchemy.sql import func
+from app.db import Base
+
+
+class ApprovalPolicy(Base):
+    __tablename__ = "approval_policies"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String, nullable=False, unique=True)
+    policy_type = Column(String, nullable=False)  # loop_hook, tool_context, mcp_elicitation
+    tool_match_rules = Column(Text, default="[]")  # JSON array of patterns
+    approval_mode = Column(String, nullable=False, default="require_approval")  # require_approval, notify_only
+    timeout_seconds = Column(Integer, nullable=False, default=300)
+    agent_scope = Column(Text, default='{"type": "all"}')  # JSON: {type: "all"} | {type: "specific", agent_ids: [...]} | {type: "tag_filter", tag_key: ..., tag_value: ...}
+    approval_cache_ttl = Column(Integer, nullable=False, default=0)
+    enabled = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+
+    def get_tool_match_rules(self) -> list[str]:
+        if not self.tool_match_rules:
+            return []
+        return json.loads(self.tool_match_rules)
+
+    def get_agent_scope(self) -> dict:
+        if not self.agent_scope:
+            return {"type": "all"}
+        return json.loads(self.agent_scope)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "policy_type": self.policy_type,
+            "tool_match_rules": self.get_tool_match_rules(),
+            "approval_mode": self.approval_mode,
+            "timeout_seconds": self.timeout_seconds,
+            "agent_scope": self.get_agent_scope(),
+            "approval_cache_ttl": self.approval_cache_ttl,
+            "enabled": self.enabled,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/backend/app/models/mcp.py
+++ b/backend/app/models/mcp.py
@@ -22,6 +22,8 @@ class McpServer(Base):
     oauth2_scopes = Column(String, nullable=True)  # space-separated
     api_key_header_name = Column(String, nullable=True)  # e.g. 'x-api-key', 'Authorization'
     has_admin_api_key = Column(String, nullable=True)  # 'true' or 'false'
+    supports_elicitation = Column(String, nullable=True, default="false")  # 'true' or 'false'
+    runtime_endpoint_url = Column(String, nullable=True)  # direct runtime URL for WebSocket (bypasses Gateway)
     registry_record_id = Column(String, nullable=True)
     registry_status = Column(String, nullable=True)  # DRAFT, PENDING_APPROVAL, APPROVED, REJECTED, DEPRECATED
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
@@ -45,6 +47,8 @@ class McpServer(Base):
             "has_oauth2_secret": self.oauth2_client_secret is not None and self.oauth2_client_secret != "",
             "api_key_header_name": self.api_key_header_name,
             "has_admin_api_key": self.has_admin_api_key == "true",
+            "supports_elicitation": self.supports_elicitation == "true",
+            "runtime_endpoint_url": self.runtime_endpoint_url,
             "registry_record_id": self.registry_record_id,
             "registry_status": self.registry_status,
             "created_at": (self.created_at.isoformat() + "Z") if self.created_at else None,

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -756,6 +756,7 @@ def _deploy_agent(request: AgentCreateRequest, db: Session, background_tasks: Ba
             "oauth2_client_secret": s.oauth2_client_secret,
             "oauth2_scopes": s.oauth2_scopes,
             "api_key_header_name": s.api_key_header_name,
+            "supports_elicitation": s.supports_elicitation == "true",
         }
         for s in mcp_records
     ]
@@ -928,6 +929,8 @@ def _deploy_agent_background(
                 "transport": server["transport_type"],
                 "endpoint_url": server["endpoint_url"],
             }
+            if server.get("supports_elicitation"):
+                entry["dynamic_only"] = True
             if server["auth_type"] == "oauth2":
                 cp_name = f"loom-{request.name}-mcp-{server['name']}"
                 try:
@@ -1302,11 +1305,14 @@ def _deploy_harness(request: AgentCreateRequest, db: Session, background_tasks: 
             mcp_snapshots.append({
                 "name": server.name,
                 "endpoint_url": server.endpoint_url,
+                "transport_type": server.transport_type,
                 "auth_type": server.auth_type,
                 "oauth2_client_id": server.oauth2_client_id,
                 "oauth2_client_secret": server.oauth2_client_secret,
                 "oauth2_well_known_url": server.oauth2_well_known_url,
                 "oauth2_scopes": server.oauth2_scopes,
+                "api_key_header_name": server.api_key_header_name,
+                "supports_elicitation": server.supports_elicitation == "true",
             })
 
     extra_harness_tools = request.harness_tools or []
@@ -1487,6 +1493,8 @@ def _deploy_harness_background(
                 "endpoint_url": server["endpoint_url"],
                 "auth_type": server["auth_type"],
             }
+            if server.get("supports_elicitation"):
+                mcp_entry["dynamic_only"] = True
             if cp_name:
                 mcp_entry["auth"] = {"type": "oauth2", "credential_provider_name": cp_name}
             mcp_server_configs.append(mcp_entry)

--- a/backend/app/routers/approvals.py
+++ b/backend/app/routers/approvals.py
@@ -1,0 +1,277 @@
+"""Approval policy CRUD and human-in-the-loop approval coordination."""
+import asyncio
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.db import get_db
+from app.dependencies.auth import UserInfo, get_current_user, require_scopes
+from app.models.approval_policy import ApprovalPolicy
+from app.models.approval_log import ApprovalLog
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/settings", tags=["approvals"])
+
+
+# ---------------------------------------------------------------------------
+# In-memory approval coordination store
+# ---------------------------------------------------------------------------
+# Maps request_id -> {event: asyncio.Event, decision: str | None, reason: str | None, decided_by: str | None}
+_pending_approvals: dict[str, dict[str, Any]] = {}
+
+
+def create_approval_request(request_id: str | None = None) -> str:
+    """Register a pending approval and return its request_id."""
+    rid = request_id or str(uuid.uuid4())
+    _pending_approvals[rid] = {
+        "event": asyncio.Event(),
+        "decision": None,
+        "reason": None,
+        "decided_by": None,
+    }
+    return rid
+
+
+def resolve_approval(request_id: str, decision: str, decided_by: str | None = None, reason: str | None = None, content: dict | None = None) -> bool:
+    """Resolve a pending approval. Returns True if the request was found."""
+    entry = _pending_approvals.get(request_id)
+    if not entry:
+        return False
+    entry["decision"] = decision
+    entry["decided_by"] = decided_by
+    entry["reason"] = reason
+    if content is not None:
+        entry["content"] = content
+    entry["event"].set()
+    return True
+
+
+async def wait_for_approval(request_id: str, timeout: float = 300.0) -> dict[str, Any]:
+    """Wait for an approval decision. Returns the decision dict or timeout."""
+    entry = _pending_approvals.get(request_id)
+    if not entry:
+        return {"decision": "timeout", "reason": "Request not found"}
+    try:
+        await asyncio.wait_for(entry["event"].wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        entry["decision"] = "timeout"
+        entry["reason"] = "Approval timed out"
+    finally:
+        result = {
+            "decision": entry.get("decision", "timeout"),
+            "reason": entry.get("reason"),
+            "decided_by": entry.get("decided_by"),
+            "content": entry.get("content"),
+        }
+        _pending_approvals.pop(request_id, None)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+class ApprovalPolicyCreateRequest(BaseModel):
+    name: str
+    policy_type: str = Field(..., description="loop_hook, tool_context, or mcp_elicitation")
+    tool_match_rules: list[str] = Field(default_factory=list, description="Tool name patterns (glob)")
+    approval_mode: str = Field(default="require_approval", description="require_approval or notify_only")
+    timeout_seconds: int = Field(default=300)
+    agent_scope: dict = Field(default_factory=lambda: {"type": "all"})
+    approval_cache_ttl: int = Field(default=0)
+    enabled: bool = Field(default=True)
+
+
+class ApprovalPolicyUpdateRequest(BaseModel):
+    name: str | None = None
+    policy_type: str | None = None
+    tool_match_rules: list[str] | None = None
+    approval_mode: str | None = None
+    timeout_seconds: int | None = None
+    agent_scope: dict | None = None
+    approval_cache_ttl: int | None = None
+    enabled: bool | None = None
+
+
+class ApprovalDecisionRequest(BaseModel):
+    decision: str = Field(..., description="approved or rejected")
+    reason: str | None = None
+    content: dict | None = Field(default=None, description="Structured content for elicitation responses")
+
+
+# ---------------------------------------------------------------------------
+# Approval Policy CRUD
+# ---------------------------------------------------------------------------
+@router.post(
+    "/approval-policies",
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_scopes("security:write"))],
+)
+def create_approval_policy(
+    request: ApprovalPolicyCreateRequest,
+    db: Session = Depends(get_db),
+    user: UserInfo = Depends(get_current_user),
+):
+    valid_types = ("loop_hook", "tool_context", "mcp_elicitation")
+    if request.policy_type not in valid_types:
+        raise HTTPException(400, f"policy_type must be one of {valid_types}")
+    valid_modes = ("require_approval", "notify_only")
+    if request.approval_mode not in valid_modes:
+        raise HTTPException(400, f"approval_mode must be one of {valid_modes}")
+
+    existing = db.query(ApprovalPolicy).filter(ApprovalPolicy.name == request.name).first()
+    if existing:
+        raise HTTPException(409, f"Approval policy '{request.name}' already exists")
+
+    policy = ApprovalPolicy(
+        name=request.name,
+        policy_type=request.policy_type,
+        tool_match_rules=json.dumps(request.tool_match_rules),
+        approval_mode=request.approval_mode,
+        timeout_seconds=request.timeout_seconds,
+        agent_scope=json.dumps(request.agent_scope),
+        approval_cache_ttl=request.approval_cache_ttl,
+        enabled=request.enabled,
+    )
+    db.add(policy)
+    db.commit()
+    db.refresh(policy)
+    return policy.to_dict()
+
+
+@router.get(
+    "/approval-policies",
+    dependencies=[Depends(require_scopes("security:read"))],
+)
+def list_approval_policies(db: Session = Depends(get_db)):
+    policies = db.query(ApprovalPolicy).order_by(ApprovalPolicy.name).all()
+    return [p.to_dict() for p in policies]
+
+
+@router.get(
+    "/approval-policies/{policy_id}",
+    dependencies=[Depends(require_scopes("security:read"))],
+)
+def get_approval_policy(policy_id: int, db: Session = Depends(get_db)):
+    policy = db.query(ApprovalPolicy).filter(ApprovalPolicy.id == policy_id).first()
+    if not policy:
+        raise HTTPException(404, "Approval policy not found")
+    return policy.to_dict()
+
+
+@router.put(
+    "/approval-policies/{policy_id}",
+    dependencies=[Depends(require_scopes("security:write"))],
+)
+def update_approval_policy(
+    policy_id: int,
+    request: ApprovalPolicyUpdateRequest,
+    db: Session = Depends(get_db),
+):
+    policy = db.query(ApprovalPolicy).filter(ApprovalPolicy.id == policy_id).first()
+    if not policy:
+        raise HTTPException(404, "Approval policy not found")
+
+    if request.name is not None:
+        policy.name = request.name
+    if request.policy_type is not None:
+        valid_types = ("loop_hook", "tool_context", "mcp_elicitation")
+        if request.policy_type not in valid_types:
+            raise HTTPException(400, f"policy_type must be one of {valid_types}")
+        policy.policy_type = request.policy_type
+    if request.tool_match_rules is not None:
+        policy.tool_match_rules = json.dumps(request.tool_match_rules)
+    if request.approval_mode is not None:
+        policy.approval_mode = request.approval_mode
+    if request.timeout_seconds is not None:
+        policy.timeout_seconds = request.timeout_seconds
+    if request.agent_scope is not None:
+        policy.agent_scope = json.dumps(request.agent_scope)
+    if request.approval_cache_ttl is not None:
+        policy.approval_cache_ttl = request.approval_cache_ttl
+    if request.enabled is not None:
+        policy.enabled = request.enabled
+
+    db.commit()
+    db.refresh(policy)
+    return policy.to_dict()
+
+
+@router.delete(
+    "/approval-policies/{policy_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(require_scopes("security:write"))],
+)
+def delete_approval_policy(policy_id: int, db: Session = Depends(get_db)):
+    policy = db.query(ApprovalPolicy).filter(ApprovalPolicy.id == policy_id).first()
+    if not policy:
+        raise HTTPException(404, "Approval policy not found")
+    db.delete(policy)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Approval Decision Endpoint (used by frontend during streaming)
+# ---------------------------------------------------------------------------
+@router.post(
+    "/approvals/{request_id}/decide",
+    dependencies=[Depends(require_scopes("invoke"))],
+)
+def decide_approval(
+    request_id: str,
+    body: ApprovalDecisionRequest,
+    db: Session = Depends(get_db),
+    user: UserInfo = Depends(get_current_user),
+):
+    if body.decision not in ("approved", "rejected"):
+        raise HTTPException(400, "decision must be 'approved' or 'rejected'")
+
+    found = resolve_approval(
+        request_id,
+        decision=body.decision,
+        decided_by=user.sub,
+        reason=body.reason,
+        content=body.content,
+    )
+    if not found:
+        raise HTTPException(404, "Approval request not found or already resolved")
+
+    log_entry = db.query(ApprovalLog).filter(ApprovalLog.request_id == request_id).first()
+    if log_entry:
+        log_entry.status = body.decision
+        log_entry.decided_at = datetime.now(timezone.utc)
+        log_entry.decided_by = user.sub
+        log_entry.reason = body.reason
+        db.commit()
+
+    return {"request_id": request_id, "status": body.decision}
+
+
+# ---------------------------------------------------------------------------
+# Approval Log Query
+# ---------------------------------------------------------------------------
+@router.get(
+    "/approvals/logs",
+    dependencies=[Depends(require_scopes("agent:read"))],
+)
+def list_approval_logs(
+    agent_id: int | None = Query(None),
+    session_id: str | None = Query(None),
+    status_filter: str | None = Query(None, alias="status"),
+    db: Session = Depends(get_db),
+):
+    query = db.query(ApprovalLog).order_by(ApprovalLog.requested_at.desc())
+    if agent_id is not None:
+        query = query.filter(ApprovalLog.agent_id == agent_id)
+    if session_id is not None:
+        query = query.filter(ApprovalLog.session_id == session_id)
+    if status_filter is not None:
+        query = query.filter(ApprovalLog.status == status_filter)
+    logs = query.limit(500).all()
+    return [log.to_dict() for log in logs]

--- a/backend/app/routers/invocations.py
+++ b/backend/app/routers/invocations.py
@@ -503,6 +503,7 @@ async def invoke_agent_stream(
         "session_id": session_id,
         "invocation_id": invocation_id,
         "client_invoke_time": client_invoke_time,
+        "user_id": session.user_id,
     }
     if token_source:
         session_start_data["token_source"] = token_source
@@ -994,6 +995,7 @@ async def invoke_harness_agent_stream(
         "session_id": session_id,
         "invocation_id": invocation_id,
         "client_invoke_time": client_invoke_time,
+        "user_id": session.user_id,
         "has_token": bool(access_token),
         "token_source": token_source,
     })
@@ -1621,7 +1623,10 @@ def list_sessions(
         InvocationSession.agent_id == agent_id,
         InvocationSession.hidden_at.is_(None),
     ]
-    if user_id:
+    # Non-admin users always see only their own sessions (server-side enforcement)
+    if "t-admin" not in user.groups:
+        filters.append(InvocationSession.user_id == user.username)
+    elif user_id:
         filters.append(InvocationSession.user_id == user_id)
 
     sessions = db.query(InvocationSession).filter(

--- a/backend/app/routers/invocations.py
+++ b/backend/app/routers/invocations.py
@@ -7,7 +7,7 @@ import time
 import uuid
 from datetime import datetime
 from typing import Any, List, AsyncGenerator, Optional
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket, WebSocketDisconnect, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from sqlalchemy import func
@@ -25,8 +25,9 @@ from app.models.invocation import Invocation
 from app.models.authorizer_config import AuthorizerConfig
 from app.models.authorizer_credential import AuthorizerCredential
 from app.models.mcp import McpServer
+from app.models.approval_policy import ApprovalPolicy
 
-from app.services.agentcore import invoke_agent
+from app.services.agentcore import invoke_agent, invoke_agent_ws
 from app.services.harness import invoke_harness_stream
 from app.services.cloudwatch import (
     get_log_events, get_usage_log_events,
@@ -454,6 +455,8 @@ async def invoke_agent_stream(
     actor_id: str | None = None,
     runtime_model_id: str | None = None,
     dynamic_mcp_servers: list[dict[str, Any]] | None = None,
+    approval_policies: list[dict[str, Any]] | None = None,
+    supports_elicitation: bool = False,
 ) -> AsyncGenerator[str, None]:
     """
     Invoke the agent and yield SSE events as the response streams.
@@ -526,6 +529,8 @@ async def invoke_agent_stream(
             actor_id=actor_id,
             dynamic_mcp_servers=dynamic_mcp_servers,
             runtime_model_id=runtime_model_id,
+            approval_policies=approval_policies,
+            supports_elicitation=supports_elicitation,
         )
 
         # Stream chunks to frontend. Each next() call on the synchronous
@@ -549,11 +554,164 @@ async def invoke_agent_stream(
             elif chunk.get("type") == "structured":
                 structured = chunk["content"]
                 if isinstance(structured, dict):
+                    logger.info("Structured event keys: %s", list(structured.keys()))
                     # Tool use event forwarded from the agent handler
                     tool_use = structured.get("tool_use")
                     if isinstance(tool_use, dict) and tool_use.get("name"):
                         logger.info("Tool use event: %s", tool_use["name"])
                         yield format_sse_event("tool_use", {"name": tool_use["name"]})
+                        continue
+                    # MCP elicitation: tool paused waiting for user input
+                    elicitation_data = structured.get("elicitation")
+                    if isinstance(elicitation_data, dict):
+                        elicit_id = elicitation_data.get("id", "")
+                        logger.info("MCP elicitation request: id=%s", elicit_id)
+
+                        from app.routers.approvals import create_approval_request, wait_for_approval
+                        request_id = create_approval_request()
+
+                        yield format_sse_event("elicitation_request", {
+                            "elicitation_id": elicit_id,
+                            "request_id": request_id,
+                            "message": elicitation_data.get("message", ""),
+                            "schema": elicitation_data.get("schema"),
+                        })
+
+                        decision = await wait_for_approval(request_id, timeout=300.0)
+                        decision_str = decision.get("decision", "timeout")
+
+                        if decision_str == "approved":
+                            elicit_action = "accept"
+                            elicit_content = decision.get("content", {})
+                        else:
+                            elicit_action = "decline"
+                            elicit_content = None
+
+                        # Re-invoke agent to unblock the elicitation callback
+                        resume_generator = invoke_agent(
+                            arn=agent.arn,
+                            qualifier=qualifier,
+                            session_id=session_id,
+                            prompt="",
+                            region=region,
+                            access_token=access_token,
+                            actor_id=actor_id,
+                            dynamic_mcp_servers=None,
+                            runtime_model_id=runtime_model_id,
+                            supports_elicitation=True,
+                            elicitation_response={"action": elicit_action, "content": elicit_content},
+                        )
+
+                        def _next_elicit_resume():
+                            return next(resume_generator, _sentinel)
+
+                        while True:
+                            rchunk = await asyncio.to_thread(_next_elicit_resume)
+                            if rchunk is _sentinel:
+                                break
+                            if rchunk.get("type") == "text":
+                                text_c = rchunk["content"]
+                                response_chunks.append(text_c)
+                                yield format_sse_event("chunk", {"text": text_c})
+                            elif rchunk.get("type") == "structured":
+                                rs = rchunk["content"]
+                                if isinstance(rs, dict):
+                                    rtool = rs.get("tool_use")
+                                    if isinstance(rtool, dict) and rtool.get("name"):
+                                        yield format_sse_event("tool_use", {"name": rtool["name"]})
+                                    rdata = rs.get("data")
+                                    if isinstance(rdata, str) and rdata:
+                                        response_chunks.append(rdata)
+                                        yield format_sse_event("chunk", {"text": rdata})
+                        continue
+                    # Strands interrupt: agent paused waiting for approval
+                    interrupt_data = structured.get("interrupt")
+                    if isinstance(interrupt_data, dict):
+                        interrupts = interrupt_data.get("interrupts", [])
+                        logger.info("Agent interrupted with %d pending approval(s)", len(interrupts))
+                        for intr in interrupts:
+                            from app.routers.approvals import create_approval_request, wait_for_approval
+                            request_id = create_approval_request()
+                            approval_event = {
+                                "request_id": request_id,
+                                "interrupt_id": intr.get("id", ""),
+                                "interrupt_name": intr.get("name", ""),
+                                "tool_name": intr.get("reason", {}).get("tool_name", intr.get("name", "")),
+                                "tool_input_summary": intr.get("reason", {}).get("tool_input_summary", ""),
+                                "policy_name": intr.get("reason", {}).get("policy_name", ""),
+                                "policy_type": intr.get("reason", {}).get("policy_type", "loop_hook"),
+                                "approval_mode": intr.get("reason", {}).get("approval_mode", "require_approval"),
+                                "timeout_seconds": intr.get("reason", {}).get("timeout_seconds", 300),
+                                "session_id": session_id,
+                            }
+                            yield format_sse_event("approval_request", approval_event)
+
+                            timeout = intr.get("reason", {}).get("timeout_seconds", 300)
+                            decision = await wait_for_approval(request_id, timeout=float(timeout))
+                            decision_str = decision.get("decision", "timeout")
+                            yield format_sse_event("approval_resolved", {
+                                "request_id": request_id,
+                                "status": decision_str,
+                                "decided_by": decision.get("decided_by"),
+                                "reason": decision.get("reason"),
+                            })
+
+                            # Map decision to interrupt response value
+                            if decision_str == "approved":
+                                response_value = "y"
+                            elif decision_str == "trusted":
+                                response_value = "t"
+                            else:
+                                response_value = "n"
+
+                            # Re-invoke agent with interruptResponse to resume
+                            interrupt_response_payload = [
+                                {"interruptResponse": {"interruptId": intr["id"], "name": intr["name"], "response": response_value}}
+                            ]
+                            resume_generator = invoke_agent(
+                                arn=agent.arn,
+                                qualifier=qualifier,
+                                session_id=session_id,
+                                prompt="",
+                                region=region,
+                                access_token=access_token,
+                                actor_id=actor_id,
+                                dynamic_mcp_servers=None,
+                                runtime_model_id=runtime_model_id,
+                                interrupt_response=interrupt_response_payload,
+                            )
+
+                            def _next_resume():
+                                return next(resume_generator, _sentinel)
+
+                            while True:
+                                rchunk = await asyncio.to_thread(_next_resume)
+                                if rchunk is _sentinel:
+                                    break
+                                if rchunk.get("type") == "text":
+                                    text_c = rchunk["content"]
+                                    response_chunks.append(text_c)
+                                    yield format_sse_event("chunk", {"text": text_c})
+                                elif rchunk.get("type") == "structured":
+                                    rs = rchunk["content"]
+                                    if isinstance(rs, dict):
+                                        rtool = rs.get("tool_use")
+                                        if isinstance(rtool, dict) and rtool.get("name"):
+                                            yield format_sse_event("tool_use", {"name": rtool["name"]})
+                                        rdata = rs.get("data")
+                                        if isinstance(rdata, str) and rdata:
+                                            response_chunks.append(rdata)
+                                            yield format_sse_event("chunk", {"text": rdata})
+                        continue
+                    # Legacy: direct approval_request events (harness mode)
+                    approval_req = structured.get("approval_request")
+                    if isinstance(approval_req, dict):
+                        logger.info("Approval request: %s", approval_req.get("request_id"))
+                        yield format_sse_event("approval_request", approval_req)
+                        continue
+                    approval_res = structured.get("approval_resolved")
+                    if isinstance(approval_res, dict):
+                        yield format_sse_event("approval_resolved", approval_res)
                         continue
                     # Strands SDK text delta: {"data": "token"}
                     data = structured.get("data")
@@ -876,6 +1034,15 @@ async def invoke_harness_agent_stream(
                     tool_use = structured.get("tool_use")
                     if isinstance(tool_use, dict) and tool_use.get("name"):
                         yield format_sse_event("tool_use", {"name": tool_use["name"]})
+                    approval_req = structured.get("approval_request")
+                    if isinstance(approval_req, dict):
+                        yield format_sse_event("approval_request", approval_req)
+                    approval_res = structured.get("approval_resolved")
+                    if isinstance(approval_res, dict):
+                        yield format_sse_event("approval_resolved", approval_res)
+                    elicitation_req = structured.get("elicitation_request")
+                    if isinstance(elicitation_req, dict):
+                        yield format_sse_event("elicitation_request", elicitation_req)
             elif chunk.get("type") == "metadata":
                 meta = chunk.get("content", {})
                 harness_input_tokens = meta.get("input_tokens", 0)
@@ -1202,10 +1369,12 @@ async def invoke_agent_endpoint(
 
     # Resolve dynamic MCP connector configs for user-enabled connectors
     dynamic_mcp_servers: list[dict[str, Any]] | None = None
+    has_elicitation_connector = False
     if request_body.connector_ids:
         actor_id = user.username or user.sub or "loom-agent"
         mcp_records = db.query(McpServer).filter(McpServer.id.in_(request_body.connector_ids)).all()
         dynamic_mcp_servers = []
+
         for server in mcp_records:
             entry: dict[str, Any] = {
                 "name": server.name,
@@ -1221,12 +1390,24 @@ async def invoke_agent_endpoint(
                     "api_key_header_name": server.api_key_header_name or "x-api-key",
                 }
             elif server.auth_type == "oauth2":
-                entry["auth"] = {
+                auth_entry: dict[str, str] = {
                     "type": "oauth2",
                     "well_known_endpoint": server.oauth2_well_known_url or "",
+                    "credential_provider_name": f"loom-{agent.name}-mcp-{server.name}",
                 }
+                if server.oauth2_scopes:
+                    auth_entry["scopes"] = server.oauth2_scopes
+                entry["auth"] = auth_entry
             dynamic_mcp_servers.append(entry)
-        logger.info("Resolved %d dynamic MCP connectors for invocation", len(dynamic_mcp_servers))
+            if server.supports_elicitation == "true":
+                has_elicitation_connector = True
+        logger.info("Resolved %d dynamic MCP connectors for invocation (elicitation=%s)", len(dynamic_mcp_servers), has_elicitation_connector)
+
+    # Resolve active approval policies for the agent
+    approval_policies_payload: list[dict[str, Any]] | None = None
+    active_policies = db.query(ApprovalPolicy).filter(ApprovalPolicy.enabled == True).all()  # noqa: E712
+    if active_policies:
+        approval_policies_payload = [p.to_dict() for p in active_policies]
 
     # Dispatch to harness or standard invoke path
     if agent.source == "harness" and agent.harness_id:
@@ -1254,6 +1435,8 @@ async def invoke_agent_endpoint(
             request_body.prompt, access_token, token_source,
             user.username or user.sub or "loom-agent",
             runtime_model_id, dynamic_mcp_servers,
+            approval_policies=approval_policies_payload,
+            supports_elicitation=has_elicitation_connector,
         )
 
     return StreamingResponse(
@@ -1265,6 +1448,107 @@ async def invoke_agent_endpoint(
             "X-Accel-Buffering": "no",
         }
     )
+
+
+@router.websocket("/{agent_id}/ws")
+async def invoke_agent_websocket(
+    websocket: WebSocket,
+    agent_id: int,
+):
+    """WebSocket endpoint for agent invocation with MCP elicitation support.
+
+    Enables bidirectional communication so MCP elicitation requests from the
+    agent can be relayed to the frontend and responses sent back inline.
+
+    Protocol:
+    - Client sends: {"type": "prompt", "prompt": "...", "session_id": "...", ...}
+    - Server sends: {"type": "text", "content": "..."}
+    - Server sends: {"type": "elicitation", "id": "...", "message": "..."}
+    - Client sends: {"type": "elicitation_response", "id": "...", "action": "accept|decline", "content": {...}}
+    - Server sends: {"type": "result", "content": "..."}
+    - Server sends: {"type": "error", "content": "..."}
+    """
+    await websocket.accept()
+
+    db = SessionLocal()
+    try:
+        agent = db.query(Agent).filter(Agent.id == agent_id).first()
+        if not agent:
+            await websocket.send_json({"type": "error", "content": f"Agent {agent_id} not found"})
+            await websocket.close()
+            return
+
+        region = agent.region or os.environ.get("AWS_REGION", "us-east-1")
+
+        while True:
+            data = await websocket.receive_json()
+            msg_type = data.get("type", "prompt")
+
+            if msg_type != "prompt":
+                continue
+
+            prompt = data.get("prompt", "")
+            qualifier = data.get("qualifier", "DEFAULT")
+            session_id = data.get("session_id") or str(uuid.uuid4())
+            actor_id = data.get("actor_id", "loom-agent")
+
+            # Resolve dynamic MCP servers for elicitation
+            connector_ids = data.get("connector_ids")
+            dynamic_mcp_servers = None
+            if connector_ids:
+                mcp_servers = db.query(McpServer).filter(McpServer.id.in_(connector_ids)).all()
+                dynamic_mcp_servers = []
+                for s in mcp_servers:
+                    server_data: dict[str, Any] = {
+                        "name": s.name,
+                        "transport": s.transport_type,
+                        "endpoint_url": s.endpoint_url,
+                    }
+                    dynamic_mcp_servers.append(server_data)
+
+            # Resolve access token (simplified — reuses same logic as HTTP path)
+            access_token = data.get("bearer_token")
+
+            await websocket.send_json({"type": "session_start", "session_id": session_id})
+
+            gen = invoke_agent_ws(
+                arn=agent.arn,
+                qualifier=qualifier,
+                session_id=session_id,
+                prompt=prompt,
+                region=region,
+                access_token=access_token,
+                actor_id=actor_id,
+                dynamic_mcp_servers=dynamic_mcp_servers,
+                runtime_model_id=data.get("model_id"),
+            )
+
+            try:
+                event = await gen.__anext__()
+                while True:
+                    await websocket.send_json(event)
+
+                    if event.get("type") == "elicitation":
+                        # Wait for client to send elicitation response
+                        response_data = await websocket.receive_json()
+                        response_json = json.dumps(response_data)
+                        event = await gen.asend(response_json)
+                    elif event.get("type") in ("result", "error"):
+                        break
+                    else:
+                        event = await gen.__anext__()
+            except StopAsyncIteration:
+                pass
+            except Exception as e:
+                logger.error("WebSocket invocation error: %s", e)
+                await websocket.send_json({"type": "error", "content": str(e)})
+
+    except WebSocketDisconnect:
+        logger.info("WebSocket disconnected for agent %d", agent_id)
+    except Exception as e:
+        logger.error("WebSocket handler error: %s", e)
+    finally:
+        db.close()
 
 
 @router.post("/{agent_id}/token")

--- a/backend/app/routers/invocations.py
+++ b/backend/app/routers/invocations.py
@@ -983,8 +983,10 @@ async def invoke_harness_agent_stream(
     if dynamic_tools:
         if invoke_tools is None:
             invoke_tools = []
+        existing_names = {t.get("name") for t in invoke_tools}
         for tool in dynamic_tools:
-            invoke_tools.append(_json.loads(_json.dumps(tool)))
+            if tool.get("name") not in existing_names:
+                invoke_tools.append(_json.loads(_json.dumps(tool)))
 
     invocation.client_invoke_time = client_invoke_time
     invocation.status = "streaming"
@@ -1030,6 +1032,89 @@ async def invoke_harness_agent_stream(
                 text_content = chunk["content"]
                 response_chunks.append(text_content)
                 yield format_sse_event("chunk", {"text": text_content})
+            elif chunk.get("type") == "tool_use_stop":
+                # Inline function HITL: the harness paused waiting for a tool result.
+                # Loop to handle multiple consecutive HITL rounds.
+                from app.routers.approvals import create_approval_request, wait_for_approval
+                from app.services.harness import resume_harness_stream
+
+                pending_tool_stop = chunk["content"]
+
+                while pending_tool_stop is not None:
+                    tool_use_id = pending_tool_stop["tool_use_id"]
+                    tool_name = pending_tool_stop.get("tool_name") or "user_confirmation"
+                    tool_input = pending_tool_stop.get("tool_input", {})
+                    pending_tool_stop = None
+
+                    request_id = create_approval_request()
+                    approval_event = {
+                        "request_id": request_id,
+                        "tool_name": tool_name,
+                        "tool_input_summary": tool_input.get("action_summary") or tool_input.get("message") or json.dumps(tool_input)[:200],
+                        "policy_name": tool_input.get("risk_level", ""),
+                        "policy_type": "inline_function",
+                        "approval_mode": "require_approval",
+                        "timeout_seconds": 300,
+                        "session_id": session_id,
+                    }
+                    yield format_sse_event("approval_request", approval_event)
+
+                    decision = await wait_for_approval(request_id, timeout=300.0)
+                    decision_str = decision.get("decision", "timeout")
+                    yield format_sse_event("approval_resolved", {
+                        "request_id": request_id,
+                        "status": decision_str,
+                        "decided_by": decision.get("decided_by"),
+                        "reason": decision.get("reason"),
+                    })
+
+                    if decision_str == "approved":
+                        tool_result_content = json.dumps({"approved": True, "message": "User approved the action."})
+                        tool_result_status = "success"
+                    else:
+                        reason = decision.get("reason", "User denied the action.")
+                        tool_result_content = json.dumps({"approved": False, "message": reason})
+                        tool_result_status = "error"
+
+                    resume_generator = resume_harness_stream(
+                        harness_arn=agent.arn,
+                        session_id=session_id,
+                        tool_use_id=tool_use_id,
+                        tool_name=tool_name,
+                        tool_input=tool_input,
+                        tool_result_content=tool_result_content,
+                        tool_result_status=tool_result_status,
+                        region=agent.region,
+                        tools=invoke_tools,
+                        access_token=access_token,
+                        actor_id=actor_id,
+                    )
+
+                    def _next_resume():
+                        return next(resume_generator, _sentinel)
+
+                    while True:
+                        rchunk = await asyncio.to_thread(_next_resume)
+                        if rchunk is _sentinel:
+                            break
+                        if rchunk.get("type") == "text":
+                            text_c = rchunk["content"]
+                            response_chunks.append(text_c)
+                            yield format_sse_event("chunk", {"text": text_c})
+                        elif rchunk.get("type") == "structured":
+                            rs = rchunk["content"]
+                            if isinstance(rs, dict):
+                                rtool = rs.get("tool_use")
+                                if isinstance(rtool, dict) and rtool.get("name"):
+                                    yield format_sse_event("tool_use", {"name": rtool["name"]})
+                        elif rchunk.get("type") == "metadata":
+                            rmeta = rchunk.get("content", {})
+                            harness_input_tokens += rmeta.get("input_tokens", 0)
+                            harness_output_tokens += rmeta.get("output_tokens", 0)
+                        elif rchunk.get("type") == "tool_use_stop":
+                            pending_tool_stop = rchunk["content"]
+                            break
+
             elif chunk.get("type") == "structured":
                 structured = chunk["content"]
                 if isinstance(structured, dict):

--- a/backend/app/routers/mcp.py
+++ b/backend/app/routers/mcp.py
@@ -40,6 +40,8 @@ class McpServerCreateRequest(BaseModel):
     oauth2_scopes: str | None = Field(None, description="OAuth2 scopes (space-separated)")
     api_key_header_name: str | None = Field(None, description="Header name for API key auth")
     api_key: str | None = Field(None, description="Admin API key (stored in Secrets Manager)")
+    supports_elicitation: bool = Field(default=False, description="Whether this server supports MCP elicitation")
+    runtime_endpoint_url: str | None = Field(None, description="Direct runtime URL for WebSocket elicitation (bypasses Gateway)")
 
     @model_validator(mode="after")
     def validate_auth_fields(self):
@@ -67,6 +69,8 @@ class McpServerUpdateRequest(BaseModel):
     oauth2_scopes: str | None = None
     api_key_header_name: str | None = None
     api_key: str | None = None
+    supports_elicitation: bool | None = None
+    runtime_endpoint_url: str | None = None
 
 
 class McpServerResponse(BaseModel):
@@ -83,6 +87,8 @@ class McpServerResponse(BaseModel):
     has_oauth2_secret: bool = False
     api_key_header_name: str | None = None
     has_admin_api_key: bool = False
+    supports_elicitation: bool = False
+    runtime_endpoint_url: str | None = None
     registry_record_id: str | None = None
     registry_status: str | None = None
     created_at: str | None = None
@@ -104,6 +110,7 @@ class ConnectorInfo(BaseModel):
     description: str | None = None
     auth_type: str
     has_user_api_key: bool = False
+    supports_elicitation: bool = False
 
 
 class McpAccessRuleResponse(BaseModel):
@@ -177,6 +184,8 @@ def create_mcp_server(
         oauth2_scopes=request.oauth2_scopes,
     )
     server.api_key_header_name = request.api_key_header_name
+    server.supports_elicitation = "true" if request.supports_elicitation else "false"
+    server.runtime_endpoint_url = request.runtime_endpoint_url
     if request.auth_type == "api_key" and request.api_key:
         region = os.getenv("AWS_REGION", "us-east-1")
         store_secret(f"loom/mcp/{request.name}/admin-api-key", request.api_key, region, description=f"Admin API key for MCP server {request.name}")
@@ -227,6 +236,7 @@ def list_connectors(
             description=server.description,
             auth_type=server.auth_type,
             has_user_api_key=has_key,
+            supports_elicitation=server.supports_elicitation == "true",
         ))
     return results
 
@@ -252,6 +262,8 @@ def update_mcp_server(
 
     update_data = request.model_dump(exclude_unset=True)
     new_api_key = update_data.pop("api_key", None)
+    if "supports_elicitation" in update_data:
+        update_data["supports_elicitation"] = "true" if update_data["supports_elicitation"] else "false"
     for field, value in update_data.items():
         setattr(server, field, value)
 

--- a/backend/app/services/agentcore.py
+++ b/backend/app/services/agentcore.py
@@ -3,11 +3,13 @@ Bedrock AgentCore Runtime API wrapper.
 
 This module provides functions to interact with AWS Bedrock AgentCore Runtime API
 for describing runtimes, listing endpoints, and invoking agents with streaming responses.
+Supports both HTTP streaming (for hook-based HITL) and WebSocket (for MCP elicitation).
 """
 
+import asyncio
 import json
 import logging
-from typing import Any, Generator
+from typing import Any, AsyncGenerator, Generator
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +86,10 @@ def invoke_agent(
     actor_id: str | None = None,
     dynamic_mcp_servers: list[dict[str, Any]] | None = None,
     runtime_model_id: str | None = None,
+    interrupt_response: list[dict[str, Any]] | None = None,
+    approval_policies: list[dict[str, Any]] | None = None,
+    supports_elicitation: bool = False,
+    elicitation_response: dict[str, Any] | None = None,
 ) -> Generator[dict[str, Any], None, None]:
     """
     Invoke an AgentCore Runtime agent and stream the response.
@@ -113,10 +119,18 @@ def invoke_agent(
     from botocore.config import Config
 
     payload: dict[str, Any] = {"prompt": prompt, "session_id": session_id, "actor_id": actor_id or "loom-agent"}
+    if interrupt_response:
+        payload["interruptResponse"] = interrupt_response
     if dynamic_mcp_servers:
         payload["dynamic_mcp_servers"] = dynamic_mcp_servers
     if runtime_model_id:
         payload["model_id"] = runtime_model_id
+    if approval_policies:
+        payload["approval_policies"] = approval_policies
+    if supports_elicitation:
+        payload["supports_elicitation"] = True
+    if elicitation_response:
+        payload["elicitationResponse"] = elicitation_response
     payload_bytes = json.dumps(payload).encode('utf-8')
 
     params: dict[str, Any] = {
@@ -160,7 +174,7 @@ def invoke_agent(
         if not decoded:
             continue
         line_count += 1
-        if line_count <= 10:
+        if line_count <= 10 or "elicitation" in decoded.lower() or "interrupt" in decoded.lower():
             logger.info("Stream line %d: %s", line_count, decoded[:500])
         if not decoded.startswith('data:'):
             logger.info("Non-data stream line: %s", decoded[:500])
@@ -178,3 +192,97 @@ def invoke_agent(
             if payload:
                 yield {"type": "text", "content": payload}
     logger.info("Stream completed: %d total lines received", line_count)
+
+
+async def invoke_agent_ws(
+    arn: str,
+    qualifier: str,
+    session_id: str,
+    prompt: str,
+    region: str,
+    access_token: str | None = None,
+    actor_id: str | None = None,
+    dynamic_mcp_servers: list[dict[str, Any]] | None = None,
+    runtime_model_id: str | None = None,
+) -> AsyncGenerator[dict[str, Any], str | None]:
+    """Invoke an AgentCore Runtime agent via WebSocket for MCP elicitation support.
+
+    Uses a bidirectional WebSocket connection so elicitation requests from the
+    agent can be relayed to the caller and responses sent back inline.
+
+    This is an async generator that yields events. The caller can send
+    elicitation responses back via generator.asend(response_json).
+
+    Args:
+        arn: AgentCore Runtime ARN
+        qualifier: Endpoint qualifier
+        session_id: Session ID for this invocation
+        prompt: Input prompt
+        region: AWS region
+        access_token: Optional OAuth Bearer token
+        actor_id: Actor identity
+        dynamic_mcp_servers: MCP servers to attach with elicitation support
+        runtime_model_id: Optional model override
+
+    Yields:
+        Structured dicts with "type" field:
+        - {"type": "text", "content": str}
+        - {"type": "elicitation", "id": str, "message": str}
+        - {"type": "result", "content": str}
+        - {"type": "error", "content": str}
+
+    Send:
+        JSON string with elicitation response to resume tool execution
+    """
+    import websockets
+    from botocore.auth import SigV4Auth
+    from botocore.credentials import Credentials
+    import boto3
+
+    runtime_id = arn.split('/')[-1]
+    encoded_arn = arn.replace(":", "%3A").replace("/", "%2F")
+    ws_url = f"wss://bedrock-agentcore.{region}.amazonaws.com/runtimes/{encoded_arn}/ws?qualifier={qualifier}"
+
+    headers = {}
+    if access_token:
+        headers["Authorization"] = f"Bearer {access_token}"
+
+    try:
+        async with websockets.connect(ws_url, additional_headers=headers) as ws:
+            payload: dict[str, Any] = {
+                "type": "prompt",
+                "prompt": prompt,
+                "session_id": session_id,
+                "actor_id": actor_id or "loom-agent",
+            }
+            if dynamic_mcp_servers:
+                payload["dynamic_mcp_servers_elicit"] = dynamic_mcp_servers
+            if runtime_model_id:
+                payload["model_id"] = runtime_model_id
+
+            await ws.send(json.dumps(payload))
+            logger.info("WebSocket prompt sent session_id=%s", session_id)
+
+            while True:
+                msg = await ws.recv()
+                data = json.loads(msg)
+                msg_type = data.get("type", "")
+
+                if msg_type == "elicitation":
+                    response = yield data
+                    if response:
+                        await ws.send(response)
+                elif msg_type == "result":
+                    yield data
+                    return
+                elif msg_type == "error":
+                    yield data
+                    return
+                elif msg_type == "text":
+                    yield data
+                else:
+                    yield {"type": "structured", "content": data}
+
+    except Exception as e:
+        logger.error("WebSocket invocation failed: %s", e)
+        yield {"type": "error", "content": str(e)}

--- a/backend/app/services/harness.py
+++ b/backend/app/services/harness.py
@@ -178,6 +178,9 @@ def invoke_harness_stream(
     total_input_tokens = 0
     total_output_tokens = 0
     current_tool_name: str | None = None
+    current_tool_use_id: str | None = None
+    current_tool_input_chunks: list[str] = []
+    stop_reason: str | None = None
 
     for event in stream:
         if "contentBlockStart" in event:
@@ -185,6 +188,8 @@ def invoke_harness_stream(
             tool_use = start.get("toolUse")
             if tool_use:
                 current_tool_name = tool_use.get("name")
+                current_tool_use_id = tool_use.get("toolUseId")
+                current_tool_input_chunks = []
                 if current_tool_name:
                     yield {"type": "structured", "content": {"tool_use": {"name": current_tool_name}}}
 
@@ -193,6 +198,11 @@ def invoke_harness_stream(
             text = delta.get("text")
             if text:
                 yield {"type": "text", "content": text}
+            tool_use_delta = delta.get("toolUse")
+            if tool_use_delta:
+                input_chunk = tool_use_delta.get("input", "")
+                if input_chunk:
+                    current_tool_input_chunks.append(input_chunk)
 
         elif "contentBlockStop" in event:
             current_tool_name = None
@@ -201,7 +211,7 @@ def invoke_harness_stream(
             pass
 
         elif "messageStop" in event:
-            pass
+            stop_reason = event["messageStop"].get("stopReason")
 
         elif "metadata" in event:
             meta = event["metadata"]
@@ -216,5 +226,177 @@ def invoke_harness_stream(
                 "input_tokens": total_input_tokens,
                 "output_tokens": total_output_tokens,
                 "total_tokens": total_input_tokens + total_output_tokens,
+            },
+        }
+
+    # When the stream stops for an inline tool_use, yield a special event
+    # so the caller can handle the HITL loop (wait for user, then resume).
+    if stop_reason == "tool_use" and current_tool_use_id:
+        tool_input_str = "".join(current_tool_input_chunks)
+        tool_input: dict[str, Any] = {}
+        if tool_input_str:
+            try:
+                tool_input = json.loads(tool_input_str)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        yield {
+            "type": "tool_use_stop",
+            "content": {
+                "tool_use_id": current_tool_use_id,
+                "tool_name": current_tool_name,
+                "tool_input": tool_input,
+            },
+        }
+
+
+def resume_harness_stream(
+    harness_arn: str,
+    session_id: str,
+    tool_use_id: str,
+    tool_name: str,
+    tool_input: dict[str, Any],
+    tool_result_content: str,
+    tool_result_status: str = "success",
+    region: str = "us-east-1",
+    tools: list[dict[str, Any]] | None = None,
+    access_token: str | None = None,
+    actor_id: str | None = None,
+) -> Generator[dict[str, Any], None, None]:
+    """Re-invoke a harness with a toolResult to resume after an inline function call.
+
+    Sends the assistant toolUse turn followed by the user toolResult turn so the
+    Converse API sees a matching pair.
+
+    Yields the same event format as invoke_harness_stream.
+    """
+    import boto3
+
+    if access_token:
+        from botocore import UNSIGNED
+        from botocore.config import Config
+
+        client = boto3.client(
+            "bedrock-agentcore",
+            region_name=region,
+            config=Config(signature_version=UNSIGNED),
+        )
+
+        def _add_auth_header(request, **kwargs):
+            request.headers["Authorization"] = f"Bearer {access_token}"
+
+        client.meta.events.register("before-send.bedrock-agentcore.InvokeHarness", _add_auth_header)
+    else:
+        client = boto3.client("bedrock-agentcore", region_name=region)
+
+    params: dict[str, Any] = {
+        "harnessArn": harness_arn,
+        "runtimeSessionId": session_id,
+        "messages": [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "toolUse": {
+                            "toolUseId": tool_use_id,
+                            "name": tool_name,
+                            "input": tool_input,
+                        }
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "toolResult": {
+                            "toolUseId": tool_use_id,
+                            "content": [{"text": tool_result_content}],
+                            "status": tool_result_status,
+                        }
+                    }
+                ],
+            },
+        ],
+    }
+
+    if tools:
+        params["tools"] = tools
+    if actor_id:
+        params["actorId"] = actor_id
+
+    response = client.invoke_harness(**params)
+
+    stream = response.get("stream") or response.get("body") or response.get("response")
+    if stream is None:
+        return
+
+    total_input_tokens = 0
+    total_output_tokens = 0
+    current_tool_name_r: str | None = None
+    current_tool_use_id_r: str | None = None
+    current_tool_input_chunks_r: list[str] = []
+    stop_reason_r: str | None = None
+
+    for event in stream:
+        if "contentBlockStart" in event:
+            start = event["contentBlockStart"].get("start", {})
+            tool_use = start.get("toolUse")
+            if tool_use:
+                current_tool_name_r = tool_use.get("name")
+                current_tool_use_id_r = tool_use.get("toolUseId")
+                current_tool_input_chunks_r = []
+                if current_tool_name_r:
+                    yield {"type": "structured", "content": {"tool_use": {"name": current_tool_name_r}}}
+
+        elif "contentBlockDelta" in event:
+            delta = event["contentBlockDelta"].get("delta", {})
+            text = delta.get("text")
+            if text:
+                yield {"type": "text", "content": text}
+            tool_use_delta = delta.get("toolUse")
+            if tool_use_delta:
+                input_chunk = tool_use_delta.get("input", "")
+                if input_chunk:
+                    current_tool_input_chunks_r.append(input_chunk)
+
+        elif "contentBlockStop" in event:
+            current_tool_name_r = None
+
+        elif "messageStart" in event:
+            pass
+
+        elif "messageStop" in event:
+            stop_reason_r = event["messageStop"].get("stopReason")
+
+        elif "metadata" in event:
+            meta = event["metadata"]
+            usage = meta.get("usage", {})
+            total_input_tokens += usage.get("inputTokens", 0)
+            total_output_tokens += usage.get("outputTokens", 0)
+
+    if total_input_tokens > 0 or total_output_tokens > 0:
+        yield {
+            "type": "metadata",
+            "content": {
+                "input_tokens": total_input_tokens,
+                "output_tokens": total_output_tokens,
+                "total_tokens": total_input_tokens + total_output_tokens,
+            },
+        }
+
+    if stop_reason_r == "tool_use" and current_tool_use_id_r:
+        tool_input_str = "".join(current_tool_input_chunks_r)
+        tool_input: dict[str, Any] = {}
+        if tool_input_str:
+            try:
+                tool_input = json.loads(tool_input_str)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        yield {
+            "type": "tool_use_stop",
+            "content": {
+                "tool_use_id": current_tool_use_id_r,
+                "tool_name": current_tool_name_r,
+                "tool_input": tool_input,
             },
         }

--- a/backend/app/services/mcp.py
+++ b/backend/app/services/mcp.py
@@ -102,12 +102,23 @@ def _jsonrpc_request(method: str, params: dict | None = None, req_id: int = 1) -
 
 
 def _call_streamable_http(server: Any, method: str, params: dict | None = None, api_key: str | None = None) -> dict | None:
-    """Call an MCP server using Streamable HTTP (POST JSON-RPC)."""
+    """Call an MCP server using Streamable HTTP (POST JSON-RPC).
+
+    Always initializes a session first (works for both stateless and stateful
+    servers). Stateless servers accept initialize but don't return a session ID.
+    Stateful servers require it and return a Mcp-Session-Id header.
+    """
     headers = _build_headers(server, api_key)
     headers["Accept"] = "application/json, text/event-stream"
-    body = _jsonrpc_request(method, params)
 
     try:
+        # Initialize session (no-op for stateless servers, required for stateful)
+        if method != "initialize":
+            session_id = _initialize_session(server, headers)
+            if session_id:
+                headers["Mcp-Session-Id"] = session_id
+
+        body = _jsonrpc_request(method, params)
         resp = httpx.post(
             server.endpoint_url,
             json=body,
@@ -118,12 +129,35 @@ def _call_streamable_http(server: Any, method: str, params: dict | None = None, 
 
         content_type = resp.headers.get("content-type", "")
         if "text/event-stream" in content_type:
-            # Server responded with SSE — parse the stream for JSON-RPC result
             return _parse_sse_response(resp.text)
         else:
             return resp.json()
     except Exception as e:
         logger.error("Streamable HTTP call to %s failed: %s", server.endpoint_url, e)
+        return None
+
+
+def _initialize_session(server: Any, headers: dict[str, str]) -> str | None:
+    """Send MCP initialize and return the session ID if the server is stateful."""
+    init_body = _jsonrpc_request("initialize", {
+        "protocolVersion": "2025-03-26",
+        "capabilities": {},
+        "clientInfo": {"name": "loom", "version": "1.0.0"},
+    })
+
+    try:
+        resp = httpx.post(
+            server.endpoint_url,
+            json=init_body,
+            headers=headers,
+            timeout=MCP_REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+        session_id = resp.headers.get("mcp-session-id")
+        if session_id:
+            logger.debug("MCP session established: %s", session_id)
+        return session_id
+    except Exception:
         return None
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "boto3>=1.34.0",
     "pydantic>=2.6.0",
     "python-multipart>=0.0.9",
+    "websockets>=13.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/test_approvals.py
+++ b/backend/tests/test_approvals.py
@@ -1,0 +1,312 @@
+"""Tests for approval policy CRUD and approval coordination endpoints."""
+import unittest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.db import Base, get_db
+from app.dependencies.auth import UserInfo, get_current_user
+from app.models.approval_policy import ApprovalPolicy
+from app.models.approval_log import ApprovalLog
+
+
+def _admin_user():
+    return UserInfo(
+        sub="admin",
+        username="admin",
+        groups=["g-admins-super"],
+        scopes={
+            "security:read", "security:write", "invoke",
+            "agent:read", "agent:write",
+        },
+    )
+
+
+class TestApprovalPolicyCRUD(unittest.TestCase):
+    """Test cases for approval policy CRUD endpoints."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(bind=cls.engine)
+        cls.TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=cls.engine)
+
+    def setUp(self):
+        self.session = self.TestingSessionLocal()
+
+        def override_get_db():
+            try:
+                yield self.session
+            finally:
+                pass
+
+        app.dependency_overrides[get_db] = override_get_db
+        app.dependency_overrides[get_current_user] = _admin_user
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        self.session.rollback()
+        self.session.close()
+        app.dependency_overrides.clear()
+
+    @classmethod
+    def tearDownClass(cls):
+        Base.metadata.drop_all(bind=cls.engine)
+
+    def test_create_approval_policy(self) -> None:
+        response = self.client.post("/api/settings/approval-policies", json={
+            "name": "Test Policy",
+            "policy_type": "loop_hook",
+            "tool_match_rules": ["db_*", "file_write"],
+            "approval_mode": "require_approval",
+            "timeout_seconds": 120,
+        })
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertEqual(data["name"], "Test Policy")
+        self.assertEqual(data["policy_type"], "loop_hook")
+        self.assertEqual(data["tool_match_rules"], ["db_*", "file_write"])
+        self.assertEqual(data["timeout_seconds"], 120)
+        self.assertTrue(data["enabled"])
+
+    def test_create_duplicate_policy_returns_409(self) -> None:
+        self.client.post("/api/settings/approval-policies", json={
+            "name": "Unique Policy",
+            "policy_type": "loop_hook",
+        })
+        response = self.client.post("/api/settings/approval-policies", json={
+            "name": "Unique Policy",
+            "policy_type": "loop_hook",
+        })
+        self.assertEqual(response.status_code, 409)
+
+    def test_create_invalid_policy_type_returns_400(self) -> None:
+        response = self.client.post("/api/settings/approval-policies", json={
+            "name": "Bad Type",
+            "policy_type": "invalid",
+        })
+        self.assertEqual(response.status_code, 400)
+
+    def test_list_approval_policies(self) -> None:
+        self.client.post("/api/settings/approval-policies", json={
+            "name": "Policy A",
+            "policy_type": "loop_hook",
+        })
+        response = self.client.get("/api/settings/approval-policies")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIsInstance(data, list)
+        self.assertGreaterEqual(len(data), 1)
+
+    def test_get_approval_policy(self) -> None:
+        create_resp = self.client.post("/api/settings/approval-policies", json={
+            "name": "Policy B",
+            "policy_type": "tool_context",
+        })
+        policy_id = create_resp.json()["id"]
+        response = self.client.get(f"/api/settings/approval-policies/{policy_id}")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["name"], "Policy B")
+
+    def test_update_approval_policy(self) -> None:
+        create_resp = self.client.post("/api/settings/approval-policies", json={
+            "name": "Policy C",
+            "policy_type": "loop_hook",
+            "timeout_seconds": 300,
+        })
+        policy_id = create_resp.json()["id"]
+        response = self.client.put(f"/api/settings/approval-policies/{policy_id}", json={
+            "timeout_seconds": 60,
+            "enabled": False,
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["timeout_seconds"], 60)
+        self.assertFalse(response.json()["enabled"])
+
+    def test_delete_approval_policy(self) -> None:
+        create_resp = self.client.post("/api/settings/approval-policies", json={
+            "name": "Policy D",
+            "policy_type": "mcp_elicitation",
+        })
+        policy_id = create_resp.json()["id"]
+        response = self.client.delete(f"/api/settings/approval-policies/{policy_id}")
+        self.assertEqual(response.status_code, 204)
+        get_resp = self.client.get(f"/api/settings/approval-policies/{policy_id}")
+        self.assertEqual(get_resp.status_code, 404)
+
+    def test_get_nonexistent_policy_returns_404(self) -> None:
+        response = self.client.get("/api/settings/approval-policies/99999")
+        self.assertEqual(response.status_code, 404)
+
+
+class TestApprovalDecision(unittest.TestCase):
+    """Test cases for approval decision endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(bind=cls.engine)
+        cls.TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=cls.engine)
+
+    def setUp(self):
+        self.session = self.TestingSessionLocal()
+
+        def override_get_db():
+            try:
+                yield self.session
+            finally:
+                pass
+
+        app.dependency_overrides[get_db] = override_get_db
+        app.dependency_overrides[get_current_user] = _admin_user
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        self.session.rollback()
+        self.session.close()
+        app.dependency_overrides.clear()
+
+    @classmethod
+    def tearDownClass(cls):
+        Base.metadata.drop_all(bind=cls.engine)
+
+    def test_decide_nonexistent_request_returns_404(self) -> None:
+        response = self.client.post("/api/settings/approvals/nonexistent-id/decide", json={
+            "decision": "approved",
+        })
+        self.assertEqual(response.status_code, 404)
+
+
+class TestApprovalLogs(unittest.TestCase):
+    """Test cases for approval log query endpoint."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = create_engine(
+            "sqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(bind=cls.engine)
+        cls.TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=cls.engine)
+
+    def setUp(self):
+        self.session = self.TestingSessionLocal()
+
+        def override_get_db():
+            try:
+                yield self.session
+            finally:
+                pass
+
+        app.dependency_overrides[get_db] = override_get_db
+        app.dependency_overrides[get_current_user] = _admin_user
+        self.client = TestClient(app)
+
+    def tearDown(self):
+        self.session.rollback()
+        self.session.close()
+        app.dependency_overrides.clear()
+
+    @classmethod
+    def tearDownClass(cls):
+        Base.metadata.drop_all(bind=cls.engine)
+
+    def test_list_approval_logs_empty(self) -> None:
+        response = self.client.get("/api/settings/approvals/logs")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+
+    def test_list_approval_logs_with_data(self) -> None:
+        self.session.query(ApprovalLog).delete()
+        self.session.commit()
+        log = ApprovalLog(
+            request_id="req-123",
+            session_id="sess-456",
+            agent_id=1,
+            tool_name="db_write",
+            pattern_type="loop_hook",
+            status="approved",
+        )
+        self.session.add(log)
+        self.session.commit()
+
+        response = self.client.get("/api/settings/approvals/logs")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["request_id"], "req-123")
+        self.assertEqual(data[0]["tool_name"], "db_write")
+
+    def test_list_approval_logs_filter_by_status(self) -> None:
+        self.session.add(ApprovalLog(request_id="a", tool_name="t1", pattern_type="loop_hook", status="approved"))
+        self.session.add(ApprovalLog(request_id="b", tool_name="t2", pattern_type="loop_hook", status="rejected"))
+        self.session.commit()
+
+        response = self.client.get("/api/settings/approvals/logs?status=approved")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["request_id"], "a")
+
+
+class TestApprovalPolicyModel(unittest.TestCase):
+    """Unit tests for ApprovalPolicy model methods."""
+
+    def test_to_dict_serialization(self) -> None:
+        policy = ApprovalPolicy(
+            id=1,
+            name="Test",
+            policy_type="loop_hook",
+            tool_match_rules='["db_*", "write_*"]',
+            approval_mode="require_approval",
+            timeout_seconds=120,
+            agent_scope='{"type": "all"}',
+            approval_cache_ttl=60,
+            enabled=True,
+        )
+        d = policy.to_dict()
+        self.assertEqual(d["name"], "Test")
+        self.assertEqual(d["tool_match_rules"], ["db_*", "write_*"])
+        self.assertEqual(d["agent_scope"], {"type": "all"})
+
+    def test_get_tool_match_rules_empty(self) -> None:
+        policy = ApprovalPolicy(tool_match_rules="[]")
+        self.assertEqual(policy.get_tool_match_rules(), [])
+
+    def test_get_agent_scope_default(self) -> None:
+        policy = ApprovalPolicy(agent_scope=None)
+        self.assertEqual(policy.get_agent_scope(), {"type": "all"})
+
+
+class TestApprovalLogModel(unittest.TestCase):
+    """Unit tests for ApprovalLog model methods."""
+
+    def test_to_dict_serialization(self) -> None:
+        log = ApprovalLog(
+            id=1,
+            request_id="req-1",
+            session_id="sess-1",
+            agent_id=5,
+            tool_name="deploy",
+            pattern_type="loop_hook",
+            status="pending",
+        )
+        d = log.to_dict()
+        self.assertEqual(d["request_id"], "req-1")
+        self.assertEqual(d["agent_id"], 5)
+        self.assertEqual(d["status"], "pending")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/SPECIFICATIONS.md
+++ b/frontend/SPECIFICATIONS.md
@@ -929,7 +929,49 @@ When no external IdP is configured, the entire authentication flow remains uncha
 
 ---
 
-## 15. Future Work
+## 15. Human-in-the-Loop (HITL) Approvals
+
+### 15.1 SSE Event Handling
+
+The `useInvoke` hook handles three HITL-related SSE event types:
+- `approval_request` — Adds an `ApprovalRequestBubble` segment to the stream.
+- `approval_resolved` — Triggers `flushTools()` (no separate bubble — status shown inline).
+- `elicitation_request` — Adds an `ElicitationRequestBubble` segment to the stream.
+
+The `StreamSegment` union type includes these variants with typed data payloads. Elicitation segments also carry an optional `resolvedSummary` field persisted when the user responds.
+
+### 15.2 Approval Dialog (`ApprovalDialog.tsx`)
+
+- `ApprovalRequestBubble`: Displays tool name, input summary, policy name, countdown timer, Approve/Reject buttons. Supports `resolved` prop for post-stream re-rendering.
+- `notify_only` mode renders as an informational blue bubble without action buttons.
+- Buttons are disabled after interaction to prevent double-submission.
+
+### 15.3 Elicitation Dialog (`ElicitationDialog.tsx`)
+
+- `ElicitationRequestBubble`: Renders dynamic forms from JSON Schema (text inputs, enum selectors, boolean yes/no).
+- After submission, displays the actual response value (not generic "Response submitted").
+- Accepts `resolvedSummary` prop for consistent display after stream completion.
+
+### 15.4 HITL Segment Persistence
+
+HITL segments are persisted in a `hitlSegmentsMap` ref (keyed by invocation ID) so they survive message re-fetches after stream completion. When messages are rendered from history, `hitlSegments` are passed to `MessageBubble` and displayed with `resolved={true}`.
+
+### 15.5 Approval Policy Administration
+
+The Security Admin page includes an "Approval Policies" section (`ApprovalPolicyPanel.tsx`) with:
+- Card-based list of configured policies.
+- Create/edit form with fields: name, type, tool pattern (glob), mode, timeout, agent filter.
+
+### 15.6 Harness Human Confirmation
+
+The Agent Registration Form includes a "Enable human confirmation (inline function HITL)" checkbox under Harness Parameters. When enabled:
+- A customizable "Confirmation Policy" textarea defines when the agent should seek confirmation.
+- The policy text becomes the `description` of the `user_confirmation` inline function tool deployed with the harness.
+- The JSON config export/import includes `human_confirmation` and `confirmation_policy` fields.
+
+---
+
+## 16. Future Work
 
 - **VPC network mode** support
 - **Operate Tab** — aggregate dashboard with summary cards, per-agent latency charts

--- a/frontend/src/api/approvals.ts
+++ b/frontend/src/api/approvals.ts
@@ -1,0 +1,79 @@
+import { apiFetch } from "./client";
+import type { ApprovalPolicy, ApprovalLog } from "./types";
+
+export function listApprovalPolicies(): Promise<ApprovalPolicy[]> {
+  return apiFetch<ApprovalPolicy[]>("/api/settings/approval-policies");
+}
+
+export function getApprovalPolicy(id: number): Promise<ApprovalPolicy> {
+  return apiFetch<ApprovalPolicy>(`/api/settings/approval-policies/${id}`);
+}
+
+export function createApprovalPolicy(data: {
+  name: string;
+  policy_type: string;
+  tool_match_rules?: string[];
+  approval_mode?: string;
+  timeout_seconds?: number;
+  agent_scope?: Record<string, unknown>;
+  approval_cache_ttl?: number;
+  enabled?: boolean;
+}): Promise<ApprovalPolicy> {
+  return apiFetch<ApprovalPolicy>("/api/settings/approval-policies", {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export function updateApprovalPolicy(
+  id: number,
+  data: Partial<{
+    name: string;
+    policy_type: string;
+    tool_match_rules: string[];
+    approval_mode: string;
+    timeout_seconds: number;
+    agent_scope: Record<string, unknown>;
+    approval_cache_ttl: number;
+    enabled: boolean;
+  }>,
+): Promise<ApprovalPolicy> {
+  return apiFetch<ApprovalPolicy>(`/api/settings/approval-policies/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteApprovalPolicy(id: number): Promise<void> {
+  return apiFetch<void>(`/api/settings/approval-policies/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export function submitApprovalDecision(
+  requestId: string,
+  decision: "approved" | "rejected",
+  reason?: string,
+  content?: Record<string, unknown>,
+): Promise<{ request_id: string; status: string }> {
+  return apiFetch<{ request_id: string; status: string }>(
+    `/api/settings/approvals/${requestId}/decide`,
+    {
+      method: "POST",
+      body: JSON.stringify({ decision, reason, content }),
+    },
+  );
+}
+
+export function listApprovalLogs(params?: {
+  agent_id?: number;
+  session_id?: string;
+  status?: string;
+}): Promise<ApprovalLog[]> {
+  const searchParams = new URLSearchParams();
+  if (params?.agent_id) searchParams.set("agent_id", String(params.agent_id));
+  if (params?.session_id) searchParams.set("session_id", params.session_id);
+  if (params?.status) searchParams.set("status", params.status);
+  const qs = searchParams.toString();
+  return apiFetch<ApprovalLog[]>(`/api/settings/approvals/logs${qs ? `?${qs}` : ""}`);
+}

--- a/frontend/src/api/invocations.ts
+++ b/frontend/src/api/invocations.ts
@@ -8,6 +8,9 @@ import type {
   SSEToolUse,
   SSESessionEnd,
   SSEError,
+  SSEApprovalRequest,
+  SSEApprovalResolved,
+  SSEElicitationRequest,
 } from "./types";
 
 export function listSessions(agentId: number, userId?: string): Promise<SessionResponse[]> {
@@ -46,6 +49,9 @@ export interface StreamCallbacks {
   onToolUse?: (data: SSEToolUse) => void;
   onSessionEnd?: (data: SSESessionEnd) => void;
   onError?: (data: SSEError) => void;
+  onApprovalRequest?: (data: SSEApprovalRequest) => void;
+  onApprovalResolved?: (data: SSEApprovalResolved) => void;
+  onElicitationRequest?: (data: SSEElicitationRequest) => void;
 }
 
 export async function invokeAgentStream(
@@ -148,6 +154,15 @@ export async function invokeAgentStream(
             case "error":
               callbacks.onError?.(parsed as SSEError);
               break;
+            case "approval_request":
+              callbacks.onApprovalRequest?.(parsed as SSEApprovalRequest);
+              break;
+            case "approval_resolved":
+              callbacks.onApprovalResolved?.(parsed as SSEApprovalResolved);
+              break;
+            case "elicitation_request":
+              callbacks.onElicitationRequest?.(parsed as SSEElicitationRequest);
+              break;
           }
         } catch {
           // Skip malformed JSON
@@ -157,4 +172,98 @@ export async function invokeAgentStream(
   } finally {
     reader.releaseLock();
   }
+}
+
+/**
+ * WebSocket-based agent invocation for MCP elicitation support.
+ *
+ * Returns a controller object that allows sending elicitation responses
+ * back to the agent while it's running.
+ */
+export interface WsInvokeCallbacks {
+  onSessionStart?: (data: { session_id: string }) => void;
+  onText?: (text: string) => void;
+  onToolUse?: (data: SSEToolUse) => void;
+  onElicitation?: (data: { id: string; message: string }) => void;
+  onResult?: (content: string) => void;
+  onError?: (message: string) => void;
+  onClose?: () => void;
+}
+
+export interface WsInvokeController {
+  sendElicitationResponse: (id: string, action: "accept" | "decline" | "cancel", content?: Record<string, unknown>) => void;
+  close: () => void;
+}
+
+export function invokeAgentWs(
+  agentId: number,
+  request: InvokeRequest & { connector_ids?: number[] },
+  callbacks: WsInvokeCallbacks,
+): WsInvokeController {
+  const token = getAuthToken();
+  const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const wsBase = BASE_URL.replace(/^http/, "ws");
+  const wsUrl = `${wsBase || `${wsProtocol}//${window.location.host}`}/api/agents/${agentId}/ws`;
+
+  const ws = new WebSocket(wsUrl);
+
+  ws.onopen = () => {
+    // Send auth + prompt as first message
+    ws.send(JSON.stringify({
+      type: "prompt",
+      token,
+      prompt: request.prompt,
+      qualifier: request.qualifier,
+      session_id: request.session_id,
+      model_id: request.model_id,
+      connector_ids: request.connector_ids,
+    }));
+  };
+
+  ws.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      switch (data.type) {
+        case "session_start":
+          callbacks.onSessionStart?.(data);
+          break;
+        case "text":
+          callbacks.onText?.(data.content);
+          break;
+        case "tool_use":
+          callbacks.onToolUse?.(data);
+          break;
+        case "elicitation":
+          callbacks.onElicitation?.(data);
+          break;
+        case "result":
+          callbacks.onResult?.(data.content);
+          break;
+        case "error":
+          callbacks.onError?.(data.content);
+          break;
+      }
+    } catch {
+      // Skip malformed messages
+    }
+  };
+
+  ws.onerror = () => {
+    callbacks.onError?.("WebSocket connection error");
+  };
+
+  ws.onclose = () => {
+    callbacks.onClose?.();
+  };
+
+  return {
+    sendElicitationResponse(id, action, content) {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: "elicitation_response", id, action, content: content ?? {} }));
+      }
+    },
+    close() {
+      ws.close();
+    },
+  };
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -560,6 +560,63 @@ export interface SSEError {
   message: string;
 }
 
+export interface SSEApprovalRequest {
+  request_id: string;
+  tool_name: string;
+  tool_input_summary: string;
+  policy_name: string;
+  policy_type: string;
+  approval_mode: string;
+  timeout_seconds: number;
+  session_id?: string;
+}
+
+export interface SSEApprovalResolved {
+  request_id: string;
+  status: string;
+  decided_by?: string;
+  reason?: string;
+}
+
+export interface SSEElicitationRequest {
+  elicitation_id: string;
+  request_id?: string;
+  server_name?: string;
+  tool_name?: string;
+  schema?: Record<string, unknown>;
+  message: string;
+}
+
+export interface ApprovalPolicy {
+  id: number;
+  name: string;
+  policy_type: string;
+  tool_match_rules: string[];
+  approval_mode: string;
+  timeout_seconds: number;
+  agent_scope: Record<string, unknown>;
+  approval_cache_ttl: number;
+  enabled: boolean;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface ApprovalLog {
+  id: number;
+  request_id: string;
+  session_id: string | null;
+  agent_id: number | null;
+  tool_name: string;
+  tool_input_summary: string | null;
+  policy_name: string | null;
+  pattern_type: string;
+  status: string;
+  requested_at: string | null;
+  decided_at: string | null;
+  decided_by: string | null;
+  reason: string | null;
+}
+
 // Tag policy types
 export interface TagPolicy {
   id: number;
@@ -606,6 +663,7 @@ export interface ConnectorInfo {
   description: string | null;
   auth_type: "none" | "oauth2" | "api_key";
   has_user_api_key: boolean;
+  supports_elicitation: boolean;
 }
 
 // MCP Server types
@@ -623,6 +681,8 @@ export interface McpServer {
   has_oauth2_secret: boolean;
   api_key_header_name: string | null;
   has_admin_api_key: boolean;
+  supports_elicitation: boolean;
+  runtime_endpoint_url: string | null;
   created_at: string | null;
   updated_at: string | null;
   registry_record_id: string | null;
@@ -641,6 +701,8 @@ export interface McpServerCreateRequest {
   oauth2_scopes?: string;
   api_key_header_name?: string;
   api_key?: string;
+  supports_elicitation?: boolean;
+  runtime_endpoint_url?: string;
 }
 
 export interface McpServerUpdateRequest {
@@ -656,6 +718,8 @@ export interface McpServerUpdateRequest {
   oauth2_scopes?: string;
   api_key_header_name?: string;
   api_key?: string;
+  supports_elicitation?: boolean;
+  runtime_endpoint_url?: string;
 }
 
 export interface McpTool {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -69,6 +69,7 @@ export interface AgentHarnessDeployRequest {
   tags?: Record<string, string>;
   harness_max_iterations: number | null;
   harness_max_tokens: number | null;
+  harness_tools?: Record<string, unknown>[];
 }
 
 export interface AgentRegisterRequest {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -518,6 +518,7 @@ export interface SSESessionStart {
   session_id: string;
   invocation_id: string;
   client_invoke_time: number;
+  user_id?: string;
   token_source?: string;
   has_token?: boolean;
 }

--- a/frontend/src/components/AgentRegistrationForm.tsx
+++ b/frontend/src/components/AgentRegistrationForm.tsx
@@ -148,6 +148,8 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
   // Harness-specific state
   const [harnessMaxIterations, setHarnessMaxIterations] = useState("");
   const [harnessMaxTokens, setHarnessMaxTokens] = useState("");
+  const [enableHumanConfirmation, setEnableHumanConfirmation] = useState(false);
+  const [confirmationPolicy, setConfirmationPolicy] = useState("Ask the user to confirm before performing any destructive, irreversible, or high-impact action. Always call this tool before deleting data, modifying production resources, or executing financial transactions.");
 
   // Discovery data
   const [models, setModels] = useState<ModelOption[]>([]);
@@ -258,6 +260,24 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
         ),
         harness_max_iterations: harnessMaxIterations ? parseInt(harnessMaxIterations, 10) : null,
         harness_max_tokens: harnessMaxTokens ? parseInt(harnessMaxTokens, 10) : null,
+        harness_tools: enableHumanConfirmation ? [{
+          name: "user_confirmation",
+          type: "inline_function",
+          config: {
+            inlineFunction: {
+              description: confirmationPolicy,
+              inputSchema: {
+                type: "object",
+                properties: {
+                  action_summary: { type: "string", description: "Brief description of what you are about to do" },
+                  risk_level: { type: "string", enum: ["low", "medium", "high"], description: "Risk level of the action" },
+                  details: { type: "string", description: "Additional context about impact and scope" },
+                },
+                required: ["action_summary"],
+              },
+            },
+          },
+        }] : undefined,
       };
       await onDeployHarness(request);
     } else {
@@ -430,6 +450,8 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                     }
                     if (parsed.max_iterations != null) setHarnessMaxIterations(String(parsed.max_iterations));
                     if (parsed.max_tokens != null) setHarnessMaxTokens(String(parsed.max_tokens));
+                    if (parsed.human_confirmation != null) setEnableHumanConfirmation(!!parsed.human_confirmation);
+                    if (parsed.confirmation_policy != null) setConfirmationPolicy(parsed.confirmation_policy);
                     return null;
                   } catch {
                     return "Invalid JSON. Please check the format and try again.";
@@ -483,10 +505,14 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                   if (deploymentType === "managed") {
                     if (harnessMaxIterations) result.max_iterations = parseInt(harnessMaxIterations, 10);
                     if (harnessMaxTokens) result.max_tokens = parseInt(harnessMaxTokens, 10);
+                    if (enableHumanConfirmation) {
+                      result.human_confirmation = true;
+                      result.confirmation_policy = confirmationPolicy;
+                    }
                   }
                   return JSON.stringify(result, null, 2);
                 }}
-                placeholder='{"deployment_type": "custom|managed", "name": "...", "description": "...", "persona": "...", "instructions": "...", "behavior": "...", "model": "... (default)", "allowed_models": ["..."], "role": "...", "authorizer": "...", "tags": "...", "mcp_servers": ["..."], "a2a_agents": ["..."], "memories": ["..."], "max_iterations": 75, "max_tokens": 4096}'
+                placeholder='{"deployment_type": "custom|managed", "name": "...", "description": "...", "persona": "...", "instructions": "...", "behavior": "...", "model": "... (default)", "allowed_models": ["..."], "role": "...", "authorizer": "...", "tags": "...", "mcp_servers": ["..."], "a2a_agents": ["..."], "memories": ["..."], "max_iterations": 75, "max_tokens": 4096, "human_confirmation": true, "confirmation_policy": "..."}'
               />
 
               {/* Deployment Type Selector */}
@@ -814,6 +840,32 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                         min={1}
                       />
                     </div>
+                  </div>
+                  <div className="space-y-2 pt-2">
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        id="enable-human-confirmation"
+                        checked={enableHumanConfirmation}
+                        onChange={(e) => setEnableHumanConfirmation(e.target.checked)}
+                        className="h-4 w-4 rounded border-border"
+                      />
+                      <label htmlFor="enable-human-confirmation" className="text-xs text-muted-foreground">
+                        Enable human confirmation (inline function HITL)
+                      </label>
+                    </div>
+                    {enableHumanConfirmation && (
+                      <div className="space-y-1">
+                        <label className="text-xs text-muted-foreground">Confirmation Policy</label>
+                        <Textarea
+                          placeholder="Describe when the agent should ask for human confirmation..."
+                          value={confirmationPolicy}
+                          onChange={(e) => setConfirmationPolicy(e.target.value)}
+                          rows={3}
+                          className="text-xs"
+                        />
+                      </div>
+                    )}
                   </div>
                 </section>
               )}

--- a/frontend/src/components/ApprovalDialog.tsx
+++ b/frontend/src/components/ApprovalDialog.tsx
@@ -1,0 +1,182 @@
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ShieldCheck, ShieldX, Clock, CheckCircle, XCircle } from "lucide-react";
+import { submitApprovalDecision } from "@/api/approvals";
+import type { SSEApprovalRequest, SSEApprovalResolved } from "@/api/types";
+
+export function ApprovalRequestBubble({
+  data,
+  onDecided,
+}: {
+  data: SSEApprovalRequest;
+  onDecided?: (requestId: string, decision: string) => void;
+}) {
+  const [decision, setDecision] = useState<string | null>(null);
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [showReason, setShowReason] = useState(false);
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    if (decision) return;
+    const start = Date.now();
+    const id = setInterval(() => setElapsed(Math.floor((Date.now() - start) / 1000)), 1000);
+    return () => clearInterval(id);
+  }, [decision]);
+
+  const isNotifyOnly = data.approval_mode === "notify_only";
+
+  const handleDecision = async (d: "approved" | "rejected") => {
+    setSubmitting(true);
+    try {
+      await submitApprovalDecision(data.request_id, d, reason || undefined);
+      setDecision(d);
+      onDecided?.(data.request_id, d);
+    } catch {
+      // Decision submit failed — let user retry
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (isNotifyOnly) {
+    return (
+      <div className="flex justify-start">
+        <div className="max-w-[84%] rounded-2xl px-4 py-3 text-sm bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800">
+          <div className="flex items-center gap-2 text-blue-700 dark:text-blue-300 mb-1">
+            <ShieldCheck className="h-4 w-4 shrink-0" />
+            <span className="font-medium text-xs uppercase tracking-wide">Tool Notification</span>
+          </div>
+          <p className="text-xs">
+            <span className="font-medium">{data.tool_name}</span>
+            {data.policy_name && (
+              <span className="text-muted-foreground ml-1">({data.policy_name})</span>
+            )}
+          </p>
+          {data.tool_input_summary && (
+            <p className="text-xs text-muted-foreground mt-1 font-mono break-all line-clamp-3">
+              {data.tool_input_summary}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-[84%] rounded-2xl px-4 py-3 text-sm bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800">
+        <div className="flex items-center gap-2 text-amber-700 dark:text-amber-300 mb-1">
+          <ShieldCheck className="h-4 w-4 shrink-0" />
+          <span className="font-medium text-xs uppercase tracking-wide">Approval Required</span>
+          {!decision && (
+            <span className="text-xs text-muted-foreground ml-auto flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              {elapsed}s / {data.timeout_seconds}s
+            </span>
+          )}
+        </div>
+        <p className="text-xs">
+          <span className="font-medium">{data.tool_name}</span>
+          {data.policy_name && (
+            <span className="text-muted-foreground ml-1">({data.policy_name})</span>
+          )}
+        </p>
+        {data.tool_input_summary && (
+          <p className="text-xs text-muted-foreground mt-1 font-mono break-all line-clamp-3">
+            {data.tool_input_summary}
+          </p>
+        )}
+
+        {decision ? (
+          <div className={`mt-2 flex items-center gap-1.5 text-xs font-medium ${
+            decision === "approved"
+              ? "text-green-700 dark:text-green-400"
+              : "text-red-700 dark:text-red-400"
+          }`}>
+            {decision === "approved" ? (
+              <CheckCircle className="h-3.5 w-3.5" />
+            ) : (
+              <XCircle className="h-3.5 w-3.5" />
+            )}
+            {decision === "approved" ? "Approved" : "Rejected"}
+          </div>
+        ) : (
+          <div className="mt-2 space-y-2">
+            {showReason && (
+              <Input
+                placeholder="Reason (optional)"
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                className="text-xs h-7"
+              />
+            )}
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 text-xs border-green-300 dark:border-green-700 text-green-700 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/30"
+                onClick={() => void handleDecision("approved")}
+                disabled={submitting}
+              >
+                <CheckCircle className="h-3 w-3 mr-1" />
+                Approve
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 text-xs border-red-300 dark:border-red-700 text-red-700 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30"
+                onClick={() => {
+                  if (!showReason) {
+                    setShowReason(true);
+                  } else {
+                    void handleDecision("rejected");
+                  }
+                }}
+                disabled={submitting}
+              >
+                <XCircle className="h-3 w-3 mr-1" />
+                Reject
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ApprovalResolvedBubble({ data }: { data: SSEApprovalResolved }) {
+  const isApproved = data.status === "approved";
+  return (
+    <div className="flex justify-start">
+      <div className={`rounded-2xl px-4 py-2 text-xs border ${
+        isApproved
+          ? "bg-green-50 dark:bg-green-950/30 border-green-200 dark:border-green-800"
+          : "bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-800"
+      }`}>
+        <div className="flex items-center gap-1.5">
+          {isApproved ? (
+            <CheckCircle className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
+          ) : (
+            <ShieldX className="h-3.5 w-3.5 text-red-600 dark:text-red-400" />
+          )}
+          <span className={`font-medium ${
+            isApproved
+              ? "text-green-700 dark:text-green-400"
+              : "text-red-700 dark:text-red-400"
+          }`}>
+            {isApproved ? "Approved" : data.status === "timeout" ? "Timed out" : "Rejected"}
+          </span>
+          {data.decided_by && (
+            <span className="text-muted-foreground">by {data.decided_by}</span>
+          )}
+        </div>
+        {data.reason && (
+          <p className="text-muted-foreground mt-0.5">{data.reason}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ApprovalDialog.tsx
+++ b/frontend/src/components/ApprovalDialog.tsx
@@ -8,11 +8,13 @@ import type { SSEApprovalRequest, SSEApprovalResolved } from "@/api/types";
 export function ApprovalRequestBubble({
   data,
   onDecided,
+  resolved,
 }: {
   data: SSEApprovalRequest;
   onDecided?: (requestId: string, decision: string) => void;
+  resolved?: boolean;
 }) {
-  const [decision, setDecision] = useState<string | null>(null);
+  const [decision, setDecision] = useState<string | null>(resolved ? "approved" : null);
   const [reason, setReason] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [showReason, setShowReason] = useState(false);

--- a/frontend/src/components/ApprovalPolicyPanel.tsx
+++ b/frontend/src/components/ApprovalPolicyPanel.tsx
@@ -1,0 +1,373 @@
+import { useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Plus, Pencil, Trash2, X } from "lucide-react";
+import { toast } from "sonner";
+import {
+  listApprovalPolicies,
+  createApprovalPolicy,
+  updateApprovalPolicy,
+  deleteApprovalPolicy,
+} from "@/api/approvals";
+import type { ApprovalPolicy } from "@/api/types";
+
+interface PolicyFormData {
+  name: string;
+  policy_type: string;
+  tool_match_rules: string;
+  approval_mode: string;
+  timeout_seconds: number;
+  approval_cache_ttl: number;
+  enabled: boolean;
+}
+
+const EMPTY_FORM: PolicyFormData = {
+  name: "",
+  policy_type: "loop_hook",
+  tool_match_rules: "",
+  approval_mode: "require_approval",
+  timeout_seconds: 300,
+  approval_cache_ttl: 0,
+  enabled: true,
+};
+
+export function ApprovalPolicyPanel({ readOnly }: { readOnly?: boolean }) {
+  const [policies, setPolicies] = useState<ApprovalPolicy[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+  const [form, setForm] = useState<PolicyFormData>(EMPTY_FORM);
+  const [submitting, setSubmitting] = useState(false);
+
+  const loadPolicies = useCallback(async () => {
+    try {
+      const data = await listApprovalPolicies();
+      setPolicies(data);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load policies");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadPolicies();
+  }, [loadPolicies]);
+
+  const handleCreate = async () => {
+    if (!form.name.trim()) return;
+    setSubmitting(true);
+    try {
+      const rules = form.tool_match_rules
+        .split(",")
+        .map((r) => r.trim())
+        .filter(Boolean);
+      await createApprovalPolicy({
+        name: form.name,
+        policy_type: form.policy_type,
+        tool_match_rules: rules.length > 0 ? rules : undefined,
+        approval_mode: form.approval_mode,
+        timeout_seconds: form.timeout_seconds,
+        approval_cache_ttl: form.approval_cache_ttl || undefined,
+        enabled: form.enabled,
+      });
+      toast.success("Approval policy created");
+      setShowCreate(false);
+      setForm(EMPTY_FORM);
+      await loadPolicies();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to create policy");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleUpdate = async () => {
+    if (editingId === null || !form.name.trim()) return;
+    setSubmitting(true);
+    try {
+      const rules = form.tool_match_rules
+        .split(",")
+        .map((r) => r.trim())
+        .filter(Boolean);
+      await updateApprovalPolicy(editingId, {
+        name: form.name,
+        policy_type: form.policy_type,
+        tool_match_rules: rules,
+        approval_mode: form.approval_mode,
+        timeout_seconds: form.timeout_seconds,
+        approval_cache_ttl: form.approval_cache_ttl,
+        enabled: form.enabled,
+      });
+      toast.success("Approval policy updated");
+      setEditingId(null);
+      setForm(EMPTY_FORM);
+      await loadPolicies();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to update policy");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteApprovalPolicy(id);
+      toast.success("Approval policy deleted");
+      await loadPolicies();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to delete policy");
+    }
+  };
+
+  const startEdit = (policy: ApprovalPolicy) => {
+    setEditingId(policy.id);
+    setShowCreate(false);
+    setForm({
+      name: policy.name,
+      policy_type: policy.policy_type,
+      tool_match_rules: policy.tool_match_rules.join(", "),
+      approval_mode: policy.approval_mode,
+      timeout_seconds: policy.timeout_seconds,
+      approval_cache_ttl: policy.approval_cache_ttl,
+      enabled: policy.enabled,
+    });
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setShowCreate(false);
+    setForm(EMPTY_FORM);
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-12" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="text-sm text-destructive">{error}</p>;
+  }
+
+  const isFormOpen = showCreate || editingId !== null;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium">Approval Policies</h3>
+        {!readOnly && !isFormOpen && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              setShowCreate(true);
+              setEditingId(null);
+              setForm(EMPTY_FORM);
+            }}
+          >
+            <Plus className="h-3.5 w-3.5 mr-1" />
+            Add Policy
+          </Button>
+        )}
+      </div>
+
+      {isFormOpen && (
+        <div className="rounded-lg border p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium">
+              {showCreate ? "New Approval Policy" : "Edit Approval Policy"}
+            </span>
+            <Button size="sm" variant="ghost" onClick={cancelEdit}>
+              <X className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label className="text-xs">Name</Label>
+              <Input
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                placeholder="e.g. Sensitive Tool Guard"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Policy Type</Label>
+              <Select
+                value={form.policy_type}
+                onValueChange={(v) => setForm({ ...form, policy_type: v })}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="loop_hook">Loop Hook</SelectItem>
+                  <SelectItem value="tool_context">Tool Context</SelectItem>
+                  <SelectItem value="mcp_elicitation">MCP Elicitation</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Approval Mode</Label>
+              <Select
+                value={form.approval_mode}
+                onValueChange={(v) => setForm({ ...form, approval_mode: v })}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="require_approval">Require Approval</SelectItem>
+                  <SelectItem value="notify_only">Notify Only</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Timeout (seconds)</Label>
+              <Input
+                type="number"
+                value={form.timeout_seconds}
+                onChange={(e) =>
+                  setForm({ ...form, timeout_seconds: Number(e.target.value) })
+                }
+              />
+            </div>
+            <div className="col-span-2 space-y-1">
+              <Label className="text-xs">Tool Match Rules (comma-separated glob patterns)</Label>
+              <Input
+                value={form.tool_match_rules}
+                onChange={(e) =>
+                  setForm({ ...form, tool_match_rules: e.target.value })
+                }
+                placeholder="e.g. db_*, file_write, deploy_*"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Cache TTL (seconds, 0 = no cache)</Label>
+              <Input
+                type="number"
+                value={form.approval_cache_ttl}
+                onChange={(e) =>
+                  setForm({ ...form, approval_cache_ttl: Number(e.target.value) })
+                }
+              />
+            </div>
+            <div className="flex items-end pb-1">
+              <label className="flex items-center gap-2 text-sm cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={form.enabled}
+                  onChange={(e) => setForm({ ...form, enabled: e.target.checked })}
+                  className="rounded"
+                />
+                Enabled
+              </label>
+            </div>
+          </div>
+          <div className="flex justify-end gap-2 pt-1">
+            <Button size="sm" variant="ghost" onClick={cancelEdit}>
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={showCreate ? handleCreate : handleUpdate}
+              disabled={!form.name.trim() || submitting}
+            >
+              {submitting ? "Saving..." : showCreate ? "Create" : "Save"}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {policies.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-8">
+          No approval policies configured.
+        </p>
+      ) : (
+        <div className="grid gap-2 md:grid-cols-2 lg:grid-cols-3">
+          {policies.map((policy) => (
+            <div key={policy.id} className="rounded-lg border p-3 space-y-2">
+              <div className="flex items-start justify-between gap-2">
+                <div className="flex-1 min-w-0 space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">{policy.name}</span>
+                    <span
+                      className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-medium ${
+                        policy.enabled
+                          ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                          : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                      }`}
+                    >
+                      {policy.enabled ? "enabled" : "disabled"}
+                    </span>
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    <span className="font-medium">Type: </span>
+                    {policy.policy_type.replace("_", " ")}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    <span className="font-medium">Mode: </span>
+                    {policy.approval_mode.replace("_", " ")}
+                  </div>
+                  {policy.tool_match_rules.length > 0 && (
+                    <div className="text-xs text-muted-foreground">
+                      <span className="font-medium">Rules: </span>
+                      <span className="font-mono">
+                        {policy.tool_match_rules.join(", ")}
+                      </span>
+                    </div>
+                  )}
+                  <div className="text-xs text-muted-foreground">
+                    <span className="font-medium">Timeout: </span>
+                    {policy.timeout_seconds}s
+                    {policy.approval_cache_ttl > 0 && (
+                      <span className="ml-2">
+                        <span className="font-medium">Cache: </span>
+                        {policy.approval_cache_ttl}s
+                      </span>
+                    )}
+                  </div>
+                </div>
+                {!readOnly && (
+                  <div className="flex gap-1 shrink-0">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => startEdit(policy)}
+                      title="Edit"
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => void handleDelete(policy.id)}
+                      title="Delete"
+                    >
+                      <Trash2 className="h-3.5 w-3.5 text-destructive" />
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ElicitationDialog.tsx
+++ b/frontend/src/components/ElicitationDialog.tsx
@@ -10,16 +10,18 @@ interface ElicitationRequestBubbleProps {
   data: SSEElicitationRequest;
   onRespond?: (elicitationId: string, action: "accept" | "decline", content?: Record<string, unknown>) => void;
   resolved?: boolean;
+  resolvedSummary?: string;
 }
 
 export function ElicitationRequestBubble({
   data,
   onRespond,
   resolved,
+  resolvedSummary,
 }: ElicitationRequestBubbleProps) {
   const [response, setResponse] = useState<Record<string, string>>({});
   const [submitted, setSubmitted] = useState(resolved ?? false);
-  const [submittedSummary, setSubmittedSummary] = useState<string | null>(null);
+  const [submittedSummary, setSubmittedSummary] = useState<string | null>(resolvedSummary ?? null);
   const [selectedChoice, setSelectedChoice] = useState<string | null>(null);
 
   const properties = (data.schema?.properties ?? {}) as Record<

--- a/frontend/src/components/ElicitationDialog.tsx
+++ b/frontend/src/components/ElicitationDialog.tsx
@@ -9,14 +9,17 @@ import type { SSEElicitationRequest } from "@/api/types";
 interface ElicitationRequestBubbleProps {
   data: SSEElicitationRequest;
   onRespond?: (elicitationId: string, action: "accept" | "decline", content?: Record<string, unknown>) => void;
+  resolved?: boolean;
 }
 
 export function ElicitationRequestBubble({
   data,
   onRespond,
+  resolved,
 }: ElicitationRequestBubbleProps) {
   const [response, setResponse] = useState<Record<string, string>>({});
-  const [submitted, setSubmitted] = useState(false);
+  const [submitted, setSubmitted] = useState(resolved ?? false);
+  const [submittedSummary, setSubmittedSummary] = useState<string | null>(null);
   const [selectedChoice, setSelectedChoice] = useState<string | null>(null);
 
   const properties = (data.schema?.properties ?? {}) as Record<
@@ -30,6 +33,14 @@ export function ElicitationRequestBubble({
 
   const handleAccept = (content?: Record<string, unknown>) => {
     setSubmitted(true);
+    if (content) {
+      const summary = Object.entries(content)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join(", ");
+      setSubmittedSummary(summary);
+    } else {
+      setSubmittedSummary("Approved");
+    }
     if (data.request_id) {
       submitApprovalDecision(data.request_id, "approved", undefined, content);
     }
@@ -38,6 +49,7 @@ export function ElicitationRequestBubble({
 
   const handleDecline = () => {
     setSubmitted(true);
+    setSubmittedSummary("Declined");
     if (data.request_id) {
       submitApprovalDecision(data.request_id, "rejected");
     }
@@ -51,6 +63,7 @@ export function ElicitationRequestBubble({
   const handleChoiceSubmit = (choice: string) => {
     setSelectedChoice(choice);
     setSubmitted(true);
+    setSubmittedSummary(choice === "yes" ? "Yes" : "No");
     if (data.request_id) {
       if (choice === "yes") {
         submitApprovalDecision(data.request_id, "approved", undefined, { approved: true });
@@ -76,13 +89,14 @@ export function ElicitationRequestBubble({
         {submitted ? (
           <div className="flex items-center gap-1.5 text-xs text-purple-700 dark:text-purple-400 font-medium">
             <CheckCircle className="h-3.5 w-3.5" />
-            {selectedChoice ? `Responded: ${selectedChoice}` : "Response submitted"}
+            {submittedSummary ?? (selectedChoice ? `Responded: ${selectedChoice}` : "Response submitted")}
           </div>
         ) : isSimpleChoice ? (
           <div className="flex items-center gap-2 mt-2">
             <Button
               size="sm"
               className="h-7 text-xs"
+              disabled={submitted}
               onClick={() => handleChoiceSubmit("yes")}
             >
               Yes
@@ -91,6 +105,7 @@ export function ElicitationRequestBubble({
               size="sm"
               variant="outline"
               className="h-7 text-xs"
+              disabled={submitted}
               onClick={() => handleChoiceSubmit("no")}
             >
               No
@@ -99,6 +114,7 @@ export function ElicitationRequestBubble({
               size="sm"
               variant="ghost"
               className="h-7 text-xs text-muted-foreground"
+              disabled={submitted}
               onClick={handleDecline}
             >
               <XCircle className="h-3 w-3 mr-1" />
@@ -140,6 +156,7 @@ export function ElicitationRequestBubble({
               <Button
                 size="sm"
                 className="h-7 text-xs"
+                disabled={submitted}
                 onClick={handleSubmitFields}
               >
                 Submit
@@ -148,6 +165,7 @@ export function ElicitationRequestBubble({
                 size="sm"
                 variant="ghost"
                 className="h-7 text-xs text-muted-foreground"
+                disabled={submitted}
                 onClick={handleDecline}
               >
                 Cancel
@@ -159,6 +177,7 @@ export function ElicitationRequestBubble({
             <Button
               size="sm"
               className="h-7 text-xs"
+              disabled={submitted}
               onClick={() => handleAccept()}
             >
               Approve
@@ -167,6 +186,7 @@ export function ElicitationRequestBubble({
               size="sm"
               variant="ghost"
               className="h-7 text-xs text-muted-foreground"
+              disabled={submitted}
               onClick={handleDecline}
             >
               Decline

--- a/frontend/src/components/ElicitationDialog.tsx
+++ b/frontend/src/components/ElicitationDialog.tsx
@@ -1,0 +1,179 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { MessageSquare, CheckCircle, XCircle } from "lucide-react";
+import { submitApprovalDecision } from "@/api/approvals";
+import type { SSEElicitationRequest } from "@/api/types";
+
+interface ElicitationRequestBubbleProps {
+  data: SSEElicitationRequest;
+  onRespond?: (elicitationId: string, action: "accept" | "decline", content?: Record<string, unknown>) => void;
+}
+
+export function ElicitationRequestBubble({
+  data,
+  onRespond,
+}: ElicitationRequestBubbleProps) {
+  const [response, setResponse] = useState<Record<string, string>>({});
+  const [submitted, setSubmitted] = useState(false);
+  const [selectedChoice, setSelectedChoice] = useState<string | null>(null);
+
+  const properties = (data.schema?.properties ?? {}) as Record<
+    string,
+    { type?: string; description?: string; enum?: string[] }
+  >;
+  const fields = Object.entries(properties);
+
+  const isSingleBoolApproval = fields.length === 1 && fields[0]![1].type === "boolean";
+  const isSimpleChoice = (!data.schema && data.message) || isSingleBoolApproval;
+
+  const handleAccept = (content?: Record<string, unknown>) => {
+    setSubmitted(true);
+    if (data.request_id) {
+      submitApprovalDecision(data.request_id, "approved", undefined, content);
+    }
+    onRespond?.(data.elicitation_id, "accept", content);
+  };
+
+  const handleDecline = () => {
+    setSubmitted(true);
+    if (data.request_id) {
+      submitApprovalDecision(data.request_id, "rejected");
+    }
+    onRespond?.(data.elicitation_id, "decline");
+  };
+
+  const handleSubmitFields = () => {
+    handleAccept(response);
+  };
+
+  const handleChoiceSubmit = (choice: string) => {
+    setSelectedChoice(choice);
+    setSubmitted(true);
+    if (data.request_id) {
+      if (choice === "yes") {
+        submitApprovalDecision(data.request_id, "approved", undefined, { approved: true });
+      } else {
+        submitApprovalDecision(data.request_id, "rejected");
+      }
+    }
+    onRespond?.(data.elicitation_id, choice === "yes" ? "accept" : "decline", { response: choice });
+  };
+
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-[84%] rounded-2xl px-4 py-3 text-sm bg-purple-50 dark:bg-purple-950/30 border border-purple-200 dark:border-purple-800">
+        <div className="flex items-center gap-2 text-purple-700 dark:text-purple-300 mb-1">
+          <MessageSquare className="h-4 w-4 shrink-0" />
+          <span className="font-medium text-xs uppercase tracking-wide">Input Required</span>
+          {data.server_name && (
+            <span className="text-xs text-muted-foreground">{data.server_name}</span>
+          )}
+        </div>
+        {data.message && <p className="text-xs mb-2 whitespace-pre-wrap">{data.message}</p>}
+
+        {submitted ? (
+          <div className="flex items-center gap-1.5 text-xs text-purple-700 dark:text-purple-400 font-medium">
+            <CheckCircle className="h-3.5 w-3.5" />
+            {selectedChoice ? `Responded: ${selectedChoice}` : "Response submitted"}
+          </div>
+        ) : isSimpleChoice ? (
+          <div className="flex items-center gap-2 mt-2">
+            <Button
+              size="sm"
+              className="h-7 text-xs"
+              onClick={() => handleChoiceSubmit("yes")}
+            >
+              Yes
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 text-xs"
+              onClick={() => handleChoiceSubmit("no")}
+            >
+              No
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 text-xs text-muted-foreground"
+              onClick={handleDecline}
+            >
+              <XCircle className="h-3 w-3 mr-1" />
+              Cancel
+            </Button>
+          </div>
+        ) : fields.length > 0 ? (
+          <div className="space-y-2">
+            {fields.map(([key, prop]) => (
+              <div key={key} className="space-y-0.5">
+                <Label className="text-xs">{prop.description ?? key}</Label>
+                {prop.enum ? (
+                  <div className="flex gap-1.5">
+                    {prop.enum.map((opt) => (
+                      <Button
+                        key={opt}
+                        size="sm"
+                        variant={response[key] === opt ? "default" : "outline"}
+                        className="h-7 text-xs"
+                        onClick={() => setResponse({ ...response, [key]: opt })}
+                      >
+                        {opt}
+                      </Button>
+                    ))}
+                  </div>
+                ) : (
+                  <Input
+                    className="text-xs h-7"
+                    placeholder={key}
+                    value={response[key] ?? ""}
+                    onChange={(e) =>
+                      setResponse({ ...response, [key]: e.target.value })
+                    }
+                  />
+                )}
+              </div>
+            ))}
+            <div className="flex gap-2 pt-1">
+              <Button
+                size="sm"
+                className="h-7 text-xs"
+                onClick={handleSubmitFields}
+              >
+                Submit
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 text-xs text-muted-foreground"
+                onClick={handleDecline}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-center gap-2 mt-2">
+            <Button
+              size="sm"
+              className="h-7 text-xs"
+              onClick={() => handleAccept()}
+            >
+              Approve
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-7 text-xs text-muted-foreground"
+              onClick={handleDecline}
+            >
+              Decline
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/InvokePanel.tsx
+++ b/frontend/src/components/InvokePanel.tsx
@@ -31,6 +31,7 @@ interface InvokePanelProps {
   isStreaming: boolean;
   modelId?: string | null;
   allowedModelIds?: string[];
+  mcpNames?: string[];
   authorizerName?: string;
   authorizerId?: number;
   authorizerPoolId?: string;
@@ -52,7 +53,7 @@ function issuerMatchesDiscovery(issuerUrl?: string, discoveryUrl?: string): bool
   return base.toLowerCase() === issuerUrl.replace(/\/+$/, "").toLowerCase();
 }
 
-export function InvokePanel({ agentId, qualifiers, sessions, isStreaming, modelId, allowedModelIds = [], authorizerName, authorizerId, authorizerPoolId, authorizerDiscoveryUrl, isExternalIdp, loginIssuerUrl, currentUserId, onInvoke, onCancel }: InvokePanelProps) {
+export function InvokePanel({ agentId, qualifiers, sessions, isStreaming, modelId, allowedModelIds = [], mcpNames = [], authorizerName, authorizerId, authorizerPoolId, authorizerDiscoveryUrl, isExternalIdp, loginIssuerUrl, currentUserId, onInvoke, onCancel }: InvokePanelProps) {
   const promptKey = `loom:invokePrompt:${agentId}`;
   const [prompt, setPrompt] = useState(() => sessionStorage.getItem(promptKey) ?? "");
 
@@ -107,12 +108,14 @@ export function InvokePanel({ agentId, qualifiers, sessions, isStreaming, modelI
       .catch(() => setLinkStatus("unknown"));
   }, [resolvedAuthorizerId, sameIdp]);
 
-  // Auto-select linked token when linked
+  // Auto-select credential based on link status
   useEffect(() => {
     if (linkStatus === "linked") {
       setSelectedCredential(LINKED_TOKEN);
+    } else if (linkStatus === "unlinked" && credentialsLoaded && allCredentials.length > 0) {
+      setSelectedCredential(String(allCredentials[0]!.id));
     }
-  }, [linkStatus]);
+  }, [linkStatus, credentialsLoaded, allCredentials]);
 
   // Complete pending link exchange after redirect
   useEffect(() => {
@@ -225,13 +228,22 @@ export function InvokePanel({ agentId, qualifiers, sessions, isStreaming, modelI
     listConnectors().then(setConnectors).catch(() => {});
   }, []);
 
-  // Restore enabled connectors from localStorage
+  // Restore enabled connectors from localStorage, or pre-enable from agent config
   useEffect(() => {
-    try {
-      const stored = JSON.parse(localStorage.getItem(connectorStorageKey) || "[]") as number[];
-      setEnabledConnectors(new Set(stored));
-    } catch { setEnabledConnectors(new Set()); }
-  }, [connectorStorageKey]);
+    const stored = localStorage.getItem(connectorStorageKey);
+    if (stored) {
+      try {
+        setEnabledConnectors(new Set(JSON.parse(stored) as number[]));
+      } catch { setEnabledConnectors(new Set()); }
+    } else if (mcpNames.length > 0 && connectors.length > 0) {
+      const preEnabled = connectors
+        .filter((c) => mcpNames.includes(c.name))
+        .map((c) => c.id);
+      setEnabledConnectors(new Set(preEnabled));
+    } else {
+      setEnabledConnectors(new Set());
+    }
+  }, [connectorStorageKey, connectors, mcpNames]);
 
   // Close connector popover on outside click
   useEffect(() => {

--- a/frontend/src/components/McpServerForm.tsx
+++ b/frontend/src/components/McpServerForm.tsx
@@ -35,6 +35,7 @@ export function McpServerForm({ onSubmit, onCancel, initialData }: McpServerForm
   const [scopes, setScopes] = useState(initialData?.oauth2_scopes ?? "");
   const [apiKeyHeaderName, setApiKeyHeaderName] = useState(initialData?.api_key_header_name ?? "x-api-key");
   const [apiKey, setApiKey] = useState("");
+  const [supportsElicitation, setSupportsElicitation] = useState(initialData?.supports_elicitation ?? false);
   const [submitting, setSubmitting] = useState(false);
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<TestConnectionResult | null>(null);
@@ -60,6 +61,7 @@ export function McpServerForm({ onSubmit, onCancel, initialData }: McpServerForm
         request.api_key_header_name = apiKeyHeaderName;
         if (apiKey) request.api_key = apiKey;
       }
+      request.supports_elicitation = supportsElicitation;
       await onSubmit(request);
     } finally {
       setSubmitting(false);
@@ -121,6 +123,7 @@ export function McpServerForm({ onSubmit, onCancel, initialData }: McpServerForm
             if (parsed.oauth2_scopes !== undefined) setScopes(parsed.oauth2_scopes);
             if (parsed.api_key_header_name !== undefined) setApiKeyHeaderName(parsed.api_key_header_name);
             if (parsed.api_key !== undefined) setApiKey(parsed.api_key);
+            if (parsed.supports_elicitation !== undefined) setSupportsElicitation(!!parsed.supports_elicitation);
             return null;
           } catch {
             return "Invalid JSON. Please check the format and try again.";
@@ -143,6 +146,7 @@ export function McpServerForm({ onSubmit, onCancel, initialData }: McpServerForm
             result.api_key_header_name = apiKeyHeaderName;
             result.api_key = "(redacted)";
           }
+          if (supportsElicitation) result.supports_elicitation = true;
           return JSON.stringify(result, null, 2);
         }}
         placeholder={'{"name": "...", "endpoint_url": "https://...", "transport_type": "sse", "auth_type": "oauth2|api_key", "oauth2_well_known_url": "https://...", "oauth2_client_id": "...", "oauth2_client_secret": "...", "oauth2_scopes": "...", "api_key_header_name": "x-api-key", "api_key": "..."}'}
@@ -278,6 +282,18 @@ export function McpServerForm({ onSubmit, onCancel, initialData }: McpServerForm
             </div>
           </div>
         )}
+      </div>
+
+      <div className="space-y-2">
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={supportsElicitation}
+            onChange={(e) => setSupportsElicitation(e.target.checked)}
+            className="h-3.5 w-3.5"
+          />
+          Supports MCP elicitation (requires WebSocket invocation)
+        </label>
       </div>
 
       <div className="flex items-center gap-2">

--- a/frontend/src/hooks/useInvoke.ts
+++ b/frontend/src/hooks/useInvoke.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import type { SSESessionStart, SSESessionEnd } from "@/api/types";
-import { invokeAgentStream } from "@/api/invocations";
+import type { SSESessionStart, SSESessionEnd, SSEApprovalRequest, SSEApprovalResolved, SSEElicitationRequest } from "@/api/types";
+import { invokeAgentStream, invokeAgentWs, type WsInvokeController } from "@/api/invocations";
 import { friendlyInvokeError } from "@/lib/errors";
 
 /**
@@ -11,7 +11,10 @@ import { friendlyInvokeError } from "@/lib/errors";
 
 export type StreamSegment =
   | { type: "text"; content: string }
-  | { type: "tool_use"; name: string; index: number; total: number; timestamp: number };
+  | { type: "tool_use"; name: string; index: number; total: number; timestamp: number }
+  | { type: "approval_request"; data: SSEApprovalRequest }
+  | { type: "approval_resolved"; data: SSEApprovalResolved }
+  | { type: "elicitation_request"; data: SSEElicitationRequest };
 
 interface InvokeSnapshot {
   streamedText: string;
@@ -41,6 +44,7 @@ type Listener = () => void;
 
 const _state = new Map<number, InvokeSnapshot>();
 const _controllers = new Map<number, AbortController>();
+const _wsControllers = new Map<number, WsInvokeController>();
 const _listeners = new Map<number, Set<Listener>>();
 
 function _get(agentId: number): InvokeSnapshot {
@@ -72,9 +76,11 @@ async function _startInvoke(
   modelId?: string,
   connectorIds?: number[],
   useLinkedToken?: boolean,
+  useWebSocket?: boolean,
 ) {
-  // Abort any in-flight stream for this agent
+  // Abort any in-flight stream/ws for this agent
   _controllers.get(agentId)?.abort();
+  _wsControllers.get(agentId)?.close();
   const controller = new AbortController();
   _controllers.set(agentId, controller);
 
@@ -89,6 +95,11 @@ async function _startInvoke(
     error: null,
     rawError: null,
   });
+
+  if (useWebSocket) {
+    _startInvokeWs(agentId, prompt, qualifier, authorizerName, sessionId, modelId, connectorIds);
+    return;
+  }
 
   try {
     await invokeAgentStream(
@@ -126,6 +137,21 @@ async function _startInvoke(
           segs.push({ type: "tool_use", name: data.name, index: newTotal, total: newTotal, timestamp: Date.now() });
           _update(agentId, { currentToolName: data.name, toolNames: newToolNames, segments: segs });
         },
+        onApprovalRequest: (data) => {
+          const cur = _get(agentId);
+          const segs = [...cur.segments, { type: "approval_request" as const, data }];
+          _update(agentId, { segments: segs });
+        },
+        onApprovalResolved: (data) => {
+          const cur = _get(agentId);
+          const segs = [...cur.segments, { type: "approval_resolved" as const, data }];
+          _update(agentId, { segments: segs });
+        },
+        onElicitationRequest: (data) => {
+          const cur = _get(agentId);
+          const segs = [...cur.segments, { type: "elicitation_request" as const, data }];
+          _update(agentId, { segments: segs });
+        },
         onSessionEnd: (data) => {
           _update(agentId, { sessionEnd: data, isStreaming: false, currentToolName: null });
         },
@@ -153,14 +179,139 @@ async function _startInvoke(
   }
 }
 
+function _startInvokeWs(
+  agentId: number,
+  prompt: string,
+  qualifier: string,
+  authorizerName: string | undefined,
+  sessionId?: string,
+  modelId?: string,
+  connectorIds?: number[],
+) {
+  const wsCtrl = invokeAgentWs(
+    agentId,
+    {
+      prompt,
+      qualifier,
+      ...(sessionId ? { session_id: sessionId } : {}),
+      ...(modelId ? { model_id: modelId } : {}),
+      ...(connectorIds && connectorIds.length > 0 ? { connector_ids: connectorIds } : {}),
+    },
+    {
+      onSessionStart: (data) => {
+        _update(agentId, { sessionStart: { session_id: data.session_id, invocation_id: "", client_invoke_time: Date.now() } });
+      },
+      onText: (text) => {
+        const cur = _get(agentId);
+        const segs = [...cur.segments];
+        const last = segs[segs.length - 1];
+        if (last && last.type === "text") {
+          segs[segs.length - 1] = { type: "text", content: last.content + text };
+        } else {
+          segs.push({ type: "text", content: text });
+        }
+        _update(agentId, { streamedText: cur.streamedText + text, segments: segs, currentToolName: null });
+      },
+      onToolUse: (data) => {
+        const cur = _get(agentId);
+        const newToolNames = [...cur.toolNames, data.name];
+        const newTotal = newToolNames.length;
+        const segs: StreamSegment[] = cur.segments.map((s) =>
+          s.type === "tool_use" ? { ...s, total: newTotal } : s,
+        );
+        segs.push({ type: "tool_use", name: data.name, index: newTotal, total: newTotal, timestamp: Date.now() });
+        _update(agentId, { currentToolName: data.name, toolNames: newToolNames, segments: segs });
+      },
+      onElicitation: (data) => {
+        const cur = _get(agentId);
+        const elicitData: SSEElicitationRequest = {
+          elicitation_id: data.id,
+          message: data.message,
+        };
+        const segs = [...cur.segments, { type: "elicitation_request" as const, data: elicitData }];
+        _update(agentId, { segments: segs });
+      },
+      onResult: (content) => {
+        const cur = _get(agentId);
+        const segs = [...cur.segments];
+        const last = segs[segs.length - 1];
+        if (last && last.type === "text") {
+          segs[segs.length - 1] = { type: "text", content: last.content + content };
+        } else {
+          segs.push({ type: "text", content });
+        }
+        const now = Date.now();
+        const startTime = cur.sessionStart?.client_invoke_time ?? now;
+        const sessionId = cur.sessionStart?.session_id ?? "";
+        _update(agentId, {
+          streamedText: cur.streamedText + content,
+          segments: segs,
+          sessionEnd: {
+            session_id: sessionId,
+            invocation_id: "",
+            request_id: null,
+            qualifier: "DEFAULT",
+            client_invoke_time: startTime,
+            client_done_time: now,
+            client_duration_ms: now - startTime,
+            cold_start_latency_ms: null,
+            agent_start_time: null,
+            input_tokens: null,
+            output_tokens: null,
+            estimated_cost: null,
+            compute_cost: null,
+            compute_cpu_cost: null,
+            compute_memory_cost: null,
+            idle_timeout_cost: null,
+            idle_cpu_cost: null,
+            idle_memory_cost: null,
+            memory_retrievals: null,
+            memory_events_sent: null,
+            memory_estimated_cost: null,
+            stm_cost: null,
+            ltm_cost: null,
+          },
+          isStreaming: false,
+          currentToolName: null,
+        });
+      },
+      onError: (message) => {
+        _update(agentId, {
+          error: friendlyInvokeError(message, authorizerName),
+          rawError: message,
+          isStreaming: false,
+          currentToolName: null,
+        });
+      },
+      onClose: () => {
+        const cur = _get(agentId);
+        if (cur.isStreaming) {
+          _update(agentId, { isStreaming: false, currentToolName: null });
+        }
+      },
+    },
+  );
+  _wsControllers.set(agentId, wsCtrl);
+}
+
+export function sendElicitationResponse(agentId: number, id: string, action: "accept" | "decline" | "cancel", content?: Record<string, unknown>) {
+  const wsCtrl = _wsControllers.get(agentId);
+  if (wsCtrl) {
+    wsCtrl.sendElicitationResponse(id, action, content);
+  }
+}
+
 function _cancel(agentId: number) {
   _controllers.get(agentId)?.abort();
+  _wsControllers.get(agentId)?.close();
   _update(agentId, { isStreaming: false });
 }
 
 export function clearInvokeState(agentId: number) {
   _controllers.get(agentId)?.abort();
+  _wsControllers.get(agentId)?.close();
   _controllers.delete(agentId);
+  _wsControllers.delete(agentId);
   // Reset state to EMPTY and notify subscribers — do NOT delete listeners so
   // the component stays subscribed and sees subsequent invocations.
   _update(agentId, { ...EMPTY });
@@ -188,8 +339,8 @@ export function useInvoke(agentId: number, authorizerName?: string) {
   }, [agentId]);
 
   const invoke = useCallback(
-    async (prompt: string, qualifier: string, sessionId?: string, credentialId?: number, bearerToken?: string, modelId?: string, connectorIds?: number[], useLinkedToken?: boolean) => {
-      await _startInvoke(agentId, prompt, qualifier, authorizerRef.current, sessionId, credentialId, bearerToken, modelId, connectorIds, useLinkedToken);
+    async (prompt: string, qualifier: string, sessionId?: string, credentialId?: number, bearerToken?: string, modelId?: string, connectorIds?: number[], useLinkedToken?: boolean, useWebSocket?: boolean) => {
+      await _startInvoke(agentId, prompt, qualifier, authorizerRef.current, sessionId, credentialId, bearerToken, modelId, connectorIds, useLinkedToken, useWebSocket);
     },
     [agentId],
   );

--- a/frontend/src/hooks/useInvoke.ts
+++ b/frontend/src/hooks/useInvoke.ts
@@ -14,7 +14,7 @@ export type StreamSegment =
   | { type: "tool_use"; name: string; index: number; total: number; timestamp: number }
   | { type: "approval_request"; data: SSEApprovalRequest }
   | { type: "approval_resolved"; data: SSEApprovalResolved }
-  | { type: "elicitation_request"; data: SSEElicitationRequest };
+  | { type: "elicitation_request"; data: SSEElicitationRequest; resolvedSummary?: string };
 
 interface InvokeSnapshot {
   streamedText: string;

--- a/frontend/src/pages/AgentDetailPage.tsx
+++ b/frontend/src/pages/AgentDetailPage.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Key, Pencil, Check, X, Wrench } from "lucide-react";
-import { ApprovalRequestBubble, ApprovalResolvedBubble } from "@/components/ApprovalDialog";
+import { ApprovalRequestBubble } from "@/components/ApprovalDialog";
 import { ElicitationRequestBubble } from "@/components/ElicitationDialog";
 import { fetchModels } from "@/api/agents";
 import type { ModelOption } from "@/api/types";
@@ -321,7 +321,7 @@ export function AgentDetailPage({
                       blocks.push(<ApprovalRequestBubble key={`approval-${i}`} data={seg.data} />);
                     } else if (seg.type === "approval_resolved") {
                       flushTools();
-                      blocks.push(<ApprovalResolvedBubble key={`resolved-${i}`} data={seg.data} />);
+                      // Skip render — approval status is already shown inline in the ApprovalRequestBubble
                     } else if (seg.type === "elicitation_request") {
                       flushTools();
                       blocks.push(<ElicitationRequestBubble key={`elicit-${i}`} data={seg.data} onRespond={(id, action, content) => sendElicitationResponse(agent.id, id, action, content)} />);

--- a/frontend/src/pages/AgentDetailPage.tsx
+++ b/frontend/src/pages/AgentDetailPage.tsx
@@ -5,6 +5,8 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Key, Pencil, Check, X, Wrench } from "lucide-react";
+import { ApprovalRequestBubble, ApprovalResolvedBubble } from "@/components/ApprovalDialog";
+import { ElicitationRequestBubble } from "@/components/ElicitationDialog";
 import { fetchModels } from "@/api/agents";
 import type { ModelOption } from "@/api/types";
 import { groupModels } from "@/lib/models";
@@ -18,7 +20,7 @@ import { DeploymentPanel } from "@/components/DeploymentPanel";
 import { RegistryStatusBadge } from "@/components/RegistryStatusBadge";
 import { RegistryActions } from "@/components/RegistryActions";
 import { ExternalIntegrationSection } from "@/components/ExternalIntegrationSection";
-import { useInvoke } from "@/hooks/useInvoke";
+import { useInvoke, sendElicitationResponse } from "@/hooks/useInvoke";
 import { useAuth } from "@/contexts/AuthContext";
 import { trackAction } from "@/api/audit";
 import type { AgentResponse, SessionResponse } from "@/api/types";
@@ -214,6 +216,7 @@ export function AgentDetailPage({
             isStreaming={isStreaming}
             modelId={agent.model_id}
             allowedModelIds={agent.allowed_model_ids}
+            mcpNames={agent.mcp_names}
             authorizerName={agent.authorizer_config?.name}
             authorizerPoolId={agent.authorizer_config?.pool_id}
             authorizerDiscoveryUrl={agent.authorizer_config?.discovery_url}
@@ -313,6 +316,15 @@ export function AgentDetailPage({
                     if (seg.type === "tool_use") {
                       if (toolGroup.length === 0) toolGroupStart = i;
                       toolGroup.push({ name: seg.name, index: seg.index, total: seg.total, timestamp: seg.timestamp });
+                    } else if (seg.type === "approval_request") {
+                      flushTools();
+                      blocks.push(<ApprovalRequestBubble key={`approval-${i}`} data={seg.data} />);
+                    } else if (seg.type === "approval_resolved") {
+                      flushTools();
+                      blocks.push(<ApprovalResolvedBubble key={`resolved-${i}`} data={seg.data} />);
+                    } else if (seg.type === "elicitation_request") {
+                      flushTools();
+                      blocks.push(<ElicitationRequestBubble key={`elicit-${i}`} data={seg.data} onRespond={(id, action, content) => sendElicitationResponse(agent.id, id, action, content)} />);
                     } else {
                       flushTools();
                       blocks.push(<MarkdownBlock key={i} text={seg.content} />);

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1057,7 +1057,30 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
                         isStreaming={isCurrentlyStreaming}
                         onElicitationRespond={
                           selectedAgentId != null
-                            ? (id, action, content) => sendElicitationResponse(selectedAgentId, id, action, content)
+                            ? (id, action, content) => {
+                                // Annotate the segment with the user's response for persistence
+                                const seg = segments.find(
+                                  (s) => s.type === "elicitation_request" && s.data.elicitation_id === id
+                                );
+                                if (seg && seg.type === "elicitation_request") {
+                                  if (action === "decline") {
+                                    seg.resolvedSummary = "Declined";
+                                  } else if (content) {
+                                    // Match display format: yes/no choices show as "Yes"/"No"
+                                    const keys = Object.keys(content);
+                                    if (keys.length === 1 && keys[0] === "response") {
+                                      seg.resolvedSummary = content.response === "yes" ? "Yes" : "No";
+                                    } else if (keys.length === 1 && keys[0] === "approved") {
+                                      seg.resolvedSummary = content.approved ? "Yes" : "No";
+                                    } else {
+                                      seg.resolvedSummary = Object.entries(content).map(([k, v]) => `${k}: ${v}`).join(", ");
+                                    }
+                                  } else {
+                                    seg.resolvedSummary = "Approved";
+                                  }
+                                }
+                                sendElicitationResponse(selectedAgentId, id, action, content);
+                              }
                             : undefined
                         }
                       />
@@ -1562,7 +1585,7 @@ function MessageBubble({
             <div className="mb-2 space-y-2">
               {hitlSegments.map((seg, i) => {
                 if (seg.type === "approval_request") return <ApprovalRequestBubble key={`h-approval-${i}`} data={seg.data} resolved />;
-                if (seg.type === "elicitation_request") return <ElicitationRequestBubble key={`h-elicit-${i}`} data={seg.data} resolved />;
+                if (seg.type === "elicitation_request") return <ElicitationRequestBubble key={`h-elicit-${i}`} data={seg.data} resolved resolvedSummary={seg.resolvedSummary} />;
                 return null;
               })}
             </div>

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { Send, Plus, Brain, LogOut, Bot, User, X, Loader2, Palette, RefreshCw, ChevronDown, Wrench, Plug, KeyRound, Unplug, Link2 } from "lucide-react";
-import { ApprovalRequestBubble, ApprovalResolvedBubble } from "@/components/ApprovalDialog";
+import { ApprovalRequestBubble } from "@/components/ApprovalDialog";
 import { ElicitationRequestBubble } from "@/components/ElicitationDialog";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -26,6 +26,7 @@ interface ChatMessage {
   role: "user" | "assistant";
   text: string;
   toolNames?: string[];
+  hitlSegments?: StreamSegment[];
 }
 
 interface ChatPageProps {
@@ -44,7 +45,10 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
     .filter((g) => g.startsWith("g-users-"))
     .map((g) => g.replace("g-users-", ""));
 
-  const currentUserId = user?.username ?? user?.sub;
+  const currentUserIdLocal = user?.username ?? user?.sub;
+  // Backend-authoritative user_id: set from session_start to ensure consistency
+  const [backendUserId, setBackendUserId] = useState<string | null>(null);
+  const currentUserId = backendUserId ?? currentUserIdLocal;
 
   // Agent state
   const [agents, setAgents] = useState<AgentResponse[]>([]);
@@ -78,6 +82,8 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
   const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
   const [queuedPrompt, setQueuedPrompt] = useState<string | null>(null);
   const [input, setInput] = useState("");
+  // Persist HITL segments per invocation ID so they survive re-fetches
+  const hitlSegmentsMap = useRef<Map<string, StreamSegment[]>>(new Map());
 
   // Memory panel state
   const [showMemory, setShowMemory] = useState(false);
@@ -120,7 +126,15 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
     if (!authConfig?.type) { setResolvedAuthorizerId(null); setLinkStatus("not-configured"); return; }
 
     // Same-IdP detection: login issuer matches agent's authorizer discovery URL
+    // Only applies when user logged in via Cognito directly (not external IdP),
+    // since an Entra user's token is NOT valid for a Cognito authorizer.
     const isExternalLogin = loginAuthConfig?.provider_type && loginAuthConfig.provider_type !== "cognito";
+    if (!isExternalLogin && loginAuthConfig?.user_pool_id && authConfig.pool_id &&
+        loginAuthConfig.user_pool_id === authConfig.pool_id) {
+      setLinkStatus("same-idp");
+      setResolvedAuthorizerId(null);
+      return;
+    }
     if (isExternalLogin && authConfig.discovery_url && loginAuthConfig?.issuer_url) {
       const entraPattern = /login\.microsoftonline\.com\/([^/]+)/i;
       const issuerMatch = entraPattern.exec(loginAuthConfig.issuer_url);
@@ -463,13 +477,17 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
     if (sessionStart && sessionStart !== lastSessionStartRef.current && selectedAgentId !== null) {
       lastSessionStartRef.current = sessionStart;
       setCurrentSessionId(sessionStart.session_id);
-      listSessions(selectedAgentId, currentUserId ?? undefined)
+      // Use the backend's authoritative user_id for future session queries
+      if (sessionStart.user_id && sessionStart.user_id !== backendUserId) {
+        setBackendUserId(sessionStart.user_id);
+      }
+      listSessions(selectedAgentId, sessionStart.user_id ?? currentUserId ?? undefined)
         .then((data) => {
           setSessions(data);
         })
         .catch(() => {});
     }
-  }, [sessionStart, selectedAgentId, currentUserId]);
+  }, [sessionStart, selectedAgentId, currentUserId, backendUserId]);
 
   // When invocation completes, load the authoritative session from the backend
   // and use it to populate the chat history. setPendingPrompt(null) is deferred
@@ -480,6 +498,8 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
   pendingPromptRef.current = pendingPrompt;
   const toolNamesRef = useRef<string[]>([]);
   toolNamesRef.current = toolNames;
+  const segmentsRef = useRef<StreamSegment[]>([]);
+  segmentsRef.current = segments;
   const streamedTextRef = useRef<string>("");
   streamedTextRef.current = streamedText;
 
@@ -499,16 +519,29 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
         // the async fetch completes.
         const capturedPending = pendingPromptRef.current;
         const capturedToolNames = toolNamesRef.current.length > 0 ? [...toolNamesRef.current] : undefined;
+        const capturedHitlSegments = segmentsRef.current.filter(
+          s => s.type === "approval_request" || s.type === "approval_resolved" || s.type === "elicitation_request"
+        );
         getSession(selectedAgentId, sessionId)
           .then((session) => {
             const msgs: ChatMessage[] = [];
+            const lastInv = session.invocations[session.invocations.length - 1];
+            // Store HITL segments for this invocation
+            if (lastInv && capturedHitlSegments.length > 0) {
+              hitlSegmentsMap.current.set(lastInv.invocation_id, capturedHitlSegments);
+            }
             for (const inv of session.invocations) {
               if (inv.prompt_text)
                 msgs.push({ id: `user-${inv.invocation_id}`, role: "user", text: inv.prompt_text });
               if (inv.response_text)
-                msgs.push({ id: `assistant-${inv.invocation_id}`, role: "assistant", text: inv.response_text });
+                msgs.push({
+                  id: `assistant-${inv.invocation_id}`,
+                  role: "assistant",
+                  text: inv.response_text,
+                  hitlSegments: hitlSegmentsMap.current.get(inv.invocation_id),
+                });
             }
-            // Attach tool names from the just-completed stream to the last assistant message
+            // Attach tool names to the last assistant message
             if (capturedToolNames) {
               for (let i = msgs.length - 1; i >= 0; i--) {
                 if (msgs[i]!.role === "assistant") { msgs[i]!.toolNames = capturedToolNames; break; }
@@ -667,6 +700,7 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
               id: `assistant-${inv.invocation_id}`,
               role: "assistant",
               text: inv.response_text,
+              hitlSegments: hitlSegmentsMap.current.get(inv.invocation_id),
             });
           }
         }
@@ -1004,7 +1038,7 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
                 ) : (
                   <div className="max-w-3xl mx-auto px-6 py-6 space-y-4">
                     {messages.map((msg) => (
-                      <MessageBubble key={msg.id} role={msg.role} text={msg.text} toolNames={msg.toolNames} />
+                      <MessageBubble key={msg.id} role={msg.role} text={msg.text} toolNames={msg.toolNames} hitlSegments={msg.hitlSegments} />
                     ))}
 
                     {/* In-flight user message */}
@@ -1017,7 +1051,7 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
 
                     {/* Streaming bubble — renders segments inline (text + tool calls) */}
                     {((isCurrentlyStreaming && segments.length > 0) ||
-                      (!isCurrentlyStreaming && pendingPrompt !== null && !!streamedText)) && (
+                      (!isCurrentlyStreaming && pendingPrompt !== null && (!!streamedText || segments.length > 0))) && (
                       <StreamingBubble
                         segments={segments}
                         isStreaming={isCurrentlyStreaming}
@@ -1428,7 +1462,7 @@ function StreamingBubble({
               blocks.push(<ApprovalRequestBubble key={`approval-${i}`} data={seg.data} />);
             } else if (seg.type === "approval_resolved") {
               flushTools();
-              blocks.push(<ApprovalResolvedBubble key={`resolved-${i}`} data={seg.data} />);
+              // Skip render — approval status is already shown inline in the ApprovalRequestBubble
             } else if (seg.type === "elicitation_request") {
               flushTools();
               blocks.push(<ElicitationRequestBubble key={`elicit-${i}`} data={seg.data} onRespond={onElicitationRespond} />);
@@ -1497,11 +1531,13 @@ function MessageBubble({
   text,
   isStreaming,
   toolNames,
+  hitlSegments,
 }: {
   role: "user" | "assistant";
   text: string;
   isStreaming?: boolean;
   toolNames?: string[];
+  hitlSegments?: StreamSegment[];
 }) {
   const isUser = role === "user";
   return (
@@ -1520,6 +1556,15 @@ function MessageBubble({
               {toolNames.map((name, i) => (
                 <div key={i} className="pl-[18px] font-medium text-foreground/70">{formatToolName(name)}</div>
               ))}
+            </div>
+          )}
+          {hitlSegments && hitlSegments.length > 0 && (
+            <div className="mb-2 space-y-2">
+              {hitlSegments.map((seg, i) => {
+                if (seg.type === "approval_request") return <ApprovalRequestBubble key={`h-approval-${i}`} data={seg.data} resolved />;
+                if (seg.type === "elicitation_request") return <ElicitationRequestBubble key={`h-elicit-${i}`} data={seg.data} resolved />;
+                return null;
+              })}
             </div>
           )}
           <ReactMarkdown

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { Send, Plus, Brain, LogOut, Bot, User, X, Loader2, Palette, RefreshCw, ChevronDown, Wrench, Plug, KeyRound, Unplug, Link2 } from "lucide-react";
+import { ApprovalRequestBubble, ApprovalResolvedBubble } from "@/components/ApprovalDialog";
+import { ElicitationRequestBubble } from "@/components/ElicitationDialog";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import ReactMarkdown from "react-markdown";
@@ -10,7 +12,7 @@ import { listAgents, fetchModels } from "@/api/agents";
 import { listSessions, getSession, hideSession } from "@/api/invocations";
 import { listMemories, getMemoryRecords } from "@/api/memories";
 import { trackAction } from "@/api/audit";
-import { useInvoke, clearInvokeState } from "@/hooks/useInvoke";
+import { useInvoke, clearInvokeState, sendElicitationResponse, type StreamSegment } from "@/hooks/useInvoke";
 import { useAuth } from "@/contexts/AuthContext";
 import { useTheme, isLightTheme, THEME_LABELS, type Theme } from "@/contexts/ThemeContext";
 import { listConnectors, setUserApiKey, deleteUserApiKey } from "@/api/mcp";
@@ -219,11 +221,25 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
 
   useEffect(() => {
     if (!connectorStorageKey) { setEnabledConnectors(new Set()); return; }
-    try {
-      const stored = JSON.parse(localStorage.getItem(connectorStorageKey) || "[]") as number[];
-      setEnabledConnectors(new Set(stored));
-    } catch { setEnabledConnectors(new Set()); }
-  }, [connectorStorageKey]);
+    const stored = localStorage.getItem(connectorStorageKey);
+    if (stored) {
+      try {
+        setEnabledConnectors(new Set(JSON.parse(stored) as number[]));
+      } catch { setEnabledConnectors(new Set()); }
+    } else {
+      // No user preference saved yet — pre-enable connectors configured on the agent
+      const agent = agents.find((a) => a.id === selectedAgentId);
+      const agentMcpNames = agent?.mcp_names ?? [];
+      if (agentMcpNames.length > 0 && connectors.length > 0) {
+        const preEnabled = connectors
+          .filter((c) => agentMcpNames.includes(c.name))
+          .map((c) => c.id);
+        setEnabledConnectors(new Set(preEnabled));
+      } else {
+        setEnabledConnectors(new Set());
+      }
+    }
+  }, [connectorStorageKey, agents, selectedAgentId, connectors]);
 
   const toggleConnector = (c: ConnectorInfo) => {
     const isEnabled = enabledConnectors.has(c.id);
@@ -1005,6 +1021,11 @@ export function ChatPage({ userGroups, onLogout, viewAsUser, onExitViewAs }: Cha
                       <StreamingBubble
                         segments={segments}
                         isStreaming={isCurrentlyStreaming}
+                        onElicitationRespond={
+                          selectedAgentId != null
+                            ? (id, action, content) => sendElicitationResponse(selectedAgentId, id, action, content)
+                            : undefined
+                        }
                       />
                     )}
 
@@ -1377,9 +1398,11 @@ function ChatToolUseBlock({ tools, isActive }: { tools: { name: string; index: n
 function StreamingBubble({
   segments,
   isStreaming,
+  onElicitationRespond,
 }: {
-  segments: { type: string; content?: string; name?: string; index?: number; total?: number; timestamp?: number }[];
+  segments: StreamSegment[];
   isStreaming: boolean;
+  onElicitationRespond?: (id: string, action: "accept" | "decline", content?: Record<string, unknown>) => void;
 }) {
   return (
     <div className="flex justify-start">
@@ -1399,7 +1422,16 @@ function StreamingBubble({
           segments.forEach((seg, i) => {
             if (seg.type === "tool_use") {
               if (toolGroup.length === 0) toolGroupStart = i;
-              toolGroup.push({ name: seg.name!, index: seg.index!, total: seg.total!, timestamp: seg.timestamp! });
+              toolGroup.push({ name: seg.name, index: seg.index, total: seg.total, timestamp: seg.timestamp });
+            } else if (seg.type === "approval_request") {
+              flushTools();
+              blocks.push(<ApprovalRequestBubble key={`approval-${i}`} data={seg.data} />);
+            } else if (seg.type === "approval_resolved") {
+              flushTools();
+              blocks.push(<ApprovalResolvedBubble key={`resolved-${i}`} data={seg.data} />);
+            } else if (seg.type === "elicitation_request") {
+              flushTools();
+              blocks.push(<ElicitationRequestBubble key={`elicit-${i}`} data={seg.data} onRespond={onElicitationRespond} />);
             } else {
               flushTools();
               blocks.push(

--- a/frontend/src/pages/McpServersPage.tsx
+++ b/frontend/src/pages/McpServersPage.tsx
@@ -147,6 +147,7 @@ export function McpServersPage({ viewMode, onViewModeChange, readOnly, initialSe
                   oauth2_client_id: editingServer.oauth2_client_id ?? undefined,
                   oauth2_scopes: editingServer.oauth2_scopes ?? undefined,
                   api_key_header_name: editingServer.api_key_header_name ?? undefined,
+                  supports_elicitation: editingServer.supports_elicitation,
                 }}
               />
             </CardContent>
@@ -323,6 +324,7 @@ export function McpServersPage({ viewMode, onViewModeChange, readOnly, initialSe
                   <div className="truncate" title={server.endpoint_url}><span className="text-muted-foreground/70">Endpoint:</span> {server.endpoint_url}</div>
                   <div><span className="text-muted-foreground/70">Transport:</span> {server.transport_type === "streamable_http" ? "Streamable HTTP" : "SSE"}</div>
                   <div><span className="text-muted-foreground/70">Authentication:</span> {server.auth_type === "oauth2" ? "OAuth2" : server.auth_type === "api_key" ? "API Key" : "None"}</div>
+                  <div><span className="text-muted-foreground/70">Elicitation:</span> {server.supports_elicitation ? "Supported" : "Not supported"}</div>
                   {server.created_at && (
                     <div><span className="text-muted-foreground/70">Created:</span> {formatTimestamp(server.created_at, timezone)}</div>
                   )}

--- a/frontend/src/pages/SecurityAdminPage.tsx
+++ b/frontend/src/pages/SecurityAdminPage.tsx
@@ -3,8 +3,9 @@ import { RoleManagementPanel } from "@/components/RoleManagementPanel";
 import { AuthorizerManagementPanel } from "@/components/AuthorizerManagementPanel";
 import { PermissionRequestsPanel } from "@/components/PermissionRequestsPanel";
 import { IdentityProviderPanel } from "@/components/IdentityProviderPanel";
+import { ApprovalPolicyPanel } from "@/components/ApprovalPolicyPanel";
 
-type SecurityTab = "identity" | "roles" | "authorizers" | "permissions";
+type SecurityTab = "identity" | "roles" | "authorizers" | "permissions" | "approvals";
 
 export function SecurityAdminPage({ readOnly }: { readOnly?: boolean }) {
   const [activeTab, setActiveTab] = useState<SecurityTab>("identity");
@@ -13,6 +14,7 @@ export function SecurityAdminPage({ readOnly }: { readOnly?: boolean }) {
     { key: "identity", label: "Identity Providers" },
     { key: "roles", label: "IAM Roles" },
     { key: "authorizers", label: "Authorizers" },
+    { key: "approvals", label: "Approval Policies" },
     { key: "permissions", label: "Permission Requests" },
   ];
 
@@ -50,6 +52,7 @@ export function SecurityAdminPage({ readOnly }: { readOnly?: boolean }) {
       {activeTab === "roles" && <RoleManagementPanel readOnly={readOnly} />}
       {activeTab === "authorizers" && <AuthorizerManagementPanel readOnly={readOnly} />}
       {activeTab === "permissions" && <PermissionRequestsPanel readOnly={readOnly} />}
+      {activeTab === "approvals" && <ApprovalPolicyPanel readOnly={readOnly} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add HITL approval policies with four methods: agentic loop hooks, tool context interrupts, MCP elicitation, and harness inline functions
- Implement approval/elicitation SSE events with inline UI (approve/reject buttons, dynamic forms, countdown timers)
- Add harness inline function HITL with multi-round support and configurable confirmation policy at deploy time
- Persist HITL segments across message re-fetches, enforce per-user session filtering for external IdP users, and fix streaming visibility edge cases

## Test Plan
- Verified hook-based HITL approval flow end-to-end (custom agent with approval policy)
- Verified MCP elicitation flow end-to-end (MCP server with ctx.elicit())
- Verified harness inline function HITL with multiple consecutive approval rounds
- Confirmed buttons disable after interaction and response values persist after stream completion
- Confirmed conversation history correctly scoped per-user for Entra ID/Okta logins
- TypeScript compiles cleanly (`npx tsc --noEmit`)
- Backend unit tests pass (`backend/tests/test_approvals.py`)

Closes #88

Co-Authored-By: Claude <noreply@anthropic.com>