### PR TITLE
feat: add Code Interpreter support for custom agents

### DIFF
--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -635,7 +635,14 @@ Agents support runtime model selection, allowing users to choose from a set of a
 - **`WORKLOAD_IDENTITY_NAME` env var:** Automatically set to `loom-{agent_name}` at deploy time for credential provider discovery.
 - **Agent list registry filtering:** When registry is enabled, `t-user` users see only `APPROVED` agents (previously saw both approved and unregistered). When registry is disabled, the original behavior (show all non-draft) is preserved.
 
-### Phase 29 — Advanced Operations
+### Phase 29 — Code Interpreter for Custom Agents
+- **Config:** `CodeInterpreterConfig` dataclass added to `agents/strands_agent/src/config.py` under `IntegrationsConfig` — fields: `enabled` (bool), `region` (string), `identifier` (string, optional custom interpreter ID).
+- **Agent wiring:** `build_agent()` in `agents/strands_agent/src/agent.py` instantiates `AgentCoreCodeInterpreter` from `strands-agents-tools` when `config.integrations.code_interpreter.enabled` is `True`. The `.code_interpreter` tool is appended to the agent's tool list.
+- **SDK dependency:** Uses `strands-agents-tools` (already in `requirements.txt`) which provides `AgentCoreCodeInterpreter` — a Strands `@tool`-decorated class backed by `bedrock_agentcore.tools.code_interpreter_client.CodeInterpreter`.
+- **Sandbox isolation:** Code executes in an AWS-managed sandbox with no access to the host filesystem or network.
+- **Configuration parsing:** `_parse_integrations()` reads `code_interpreter` from the JSON config and populates `CodeInterpreterConfig`.
+
+### Phase 30 — Advanced Operations
 - Real-time metrics auto-refresh.
 - Multi-agent comparison views.
 - Alert configuration.

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -641,6 +641,16 @@ Agents support runtime model selection, allowing users to choose from a set of a
 - **SDK dependency:** Uses `strands-agents-tools` (already in `requirements.txt`) which provides `AgentCoreCodeInterpreter` — a Strands `@tool`-decorated class backed by `bedrock_agentcore.tools.code_interpreter_client.CodeInterpreter`.
 - **Sandbox isolation:** Code executes in an AWS-managed sandbox with no access to the host filesystem or network.
 - **Configuration parsing:** `_parse_integrations()` reads `code_interpreter` from the JSON config and populates `CodeInterpreterConfig`.
+- **Custom CI resource:** When a Code Interpreter execution role is configured, the backend creates a custom `bedrock-agentcore-control` Code Interpreter resource in parallel with the runtime artifact build. The resource ID is stored in `agents.code_interpreter_id` and its identifier is injected into `AGENT_CONFIG_JSON` before deployment.
+- **IAM roles — two-role pattern:** Two distinct IAM roles are used. The agent execution role (deployed via `shared/iac/role.yaml`) requires `bedrock-agentcore` actions covering `code-interpreter/*` (system) and `code-interpreter-custom/*` (customer-owned) resource ARNs. A separate CI execution role (deployed via `shared/iac/code_interpreter_role.yaml`, named `loom-ci-role-{sanitized-name}`) is the sandbox identity used by the custom interpreter.
+- **Deployment form:** Registration form exposes Code Interpreter as a peer integration section alongside Memory, MCP, and A2A. Fields: enable toggle, network mode (SANDBOX/PUBLIC), region dropdown, and CI execution role selector (filtered to `role_type="code_interpreter"` managed roles).
+- **JSON manifest:** CI config exported/imported under nested `code_interpreter` key: `{"enabled": true, "region": "us-east-1", "network_mode": "SANDBOX", "role": "loom-ci-role-demo"}`.
+- **CI observability:** `enable_code_interpreter_observability()` wires USAGE_LOGS and APPLICATION_LOGS vended log delivery for the custom CI resource, mirroring the runtime observability pattern. Account ID is extracted from the CI ARN to ensure the log group ARN is always valid.
+- **X-Ray tracing:** Runtime deployments now include `OTEL_TRACES_EXPORTER=awsxray` and `OTEL_PROPAGATORS=xray` environment variables, activating the ADOT auto-instrumentation pipeline already present in the agent package.
+- **Lifecycle:** Deleting an agent also deletes its associated CI resource. If active sessions are present, sessions are terminated first via `StopCodeInterpreterSession` before retrying the delete.
+- **Role management:** `ManagedRole` model extended with `role_type` column (`"agent"` or `"code_interpreter"`). The Role Management panel groups roles by type with collapsible sections.
+- **Status polling:** CI status is surfaced via `code_interpreter_status` on `AgentResponse`. CI polling is skipped when the agent is in `DELETING` state. `ResourceNotFoundException` during CI poll is logged at DEBUG (expected post-deletion).
+- **Deployment phase label:** `creating_ci_resource` displays as "Building artifact & creating Code Interpreter" to reflect the parallel nature of the two operations.
 
 ### Phase 30 — Advanced Operations
 - Real-time metrics auto-refresh.

--- a/agents/strands_agent/README.md
+++ b/agents/strands_agent/README.md
@@ -207,13 +207,21 @@ When enabled, the agent gains access to a sandboxed Code Interpreter tool powere
 **Configuration fields:**
 - `enabled` (bool) — Toggle the integration on/off.
 - `region` (string, optional) — AWS region for the Code Interpreter service. Defaults to the agent's region if empty.
-- `identifier` (string, optional) — Custom code interpreter identifier. Defaults to the system interpreter (`aws.codeinterpreter.v1`) if empty.
+- `identifier` (string, optional) — Custom code interpreter identifier. When set, the agent uses the specified customer-owned Code Interpreter resource instead of the default system interpreter (`aws.codeinterpreter.v1`). The backend populates this automatically when a custom CI resource is created during deployment.
 
 **How it works:**
 1. The `AgentCoreCodeInterpreter` tool from `strands-agents-tools` is registered in the agent's tool list.
 2. The agent can invoke the tool to execute code, read/write files, and run shell commands within the sandbox.
 3. Sessions are managed automatically — no manual lifecycle management required.
 4. Code execution failures (syntax errors, exceptions) are returned as structured errors without crashing the agent.
+
+**Custom Code Interpreter resource:** When a CI execution role is configured in the deployment form, the backend creates a custom `bedrock-agentcore-control` Code Interpreter resource and stores its ID in `agents.code_interpreter_id`. The resource identifier is then injected into `AGENT_CONFIG_JSON` as `integrations.code_interpreter.identifier` before the runtime is deployed.
+
+**IAM permissions:** The agent execution role must include `bedrock-agentcore` actions for two ARN patterns:
+- `code-interpreter/*` — system-managed interpreters
+- `code-interpreter-custom/*` — customer-owned interpreter resources
+
+A separate CI execution role (deployed via `shared/iac/code_interpreter_role.yaml`) serves as the sandbox identity for the custom interpreter. This two-role pattern keeps agent execution permissions separate from sandbox execution permissions.
 
 **Security:** The sandbox has no access to the host filesystem or network. All code runs in an isolated environment managed by AWS.
 

--- a/agents/strands_agent/README.md
+++ b/agents/strands_agent/README.md
@@ -28,6 +28,7 @@ strands_agent/
 │   ├── __init__.py
 │   ├── test_config.py
 │   ├── test_agent.py
+│   ├── test_code_interpreter.py
 │   ├── test_handler.py
 │   ├── test_telemetry.py
 │   ├── test_mcp_client.py
@@ -83,6 +84,11 @@ The agent reads configuration from one of two sources (checked in order):
     ],
     "memory": {
       "enabled": true
+    },
+    "code_interpreter": {
+      "enabled": true,
+      "region": "us-west-2",
+      "identifier": ""
     }
   }
 }
@@ -193,6 +199,23 @@ When enabled, the agent uses the `MemoryHook` (a Strands `HookProvider`) to load
 **Cost telemetry:** The hook always emits a `LOOM_MEMORY_TELEMETRY: retrievals=N, events_sent=M` structured log line at INFO level after each invocation. The backend parses this to compute memory costs (`stm_cost = events_sent / 1000 * $0.25`, `ltm_cost = retrievals / 1000 * $0.50`).
 
 **Error handling:** `AccessDeniedException` and other errors are caught and logged at WARNING level without interrupting the agent invocation. If memory operations fail, the telemetry line still emits with zero counters.
+
+### Code Interpreter
+
+When enabled, the agent gains access to a sandboxed Code Interpreter tool powered by AWS Bedrock AgentCore. The agent can generate and execute Python, JavaScript, or TypeScript code in an isolated environment — useful for calculations, data analysis, and validating AI-generated logic before surfacing results.
+
+**Configuration fields:**
+- `enabled` (bool) — Toggle the integration on/off.
+- `region` (string, optional) — AWS region for the Code Interpreter service. Defaults to the agent's region if empty.
+- `identifier` (string, optional) — Custom code interpreter identifier. Defaults to the system interpreter (`aws.codeinterpreter.v1`) if empty.
+
+**How it works:**
+1. The `AgentCoreCodeInterpreter` tool from `strands-agents-tools` is registered in the agent's tool list.
+2. The agent can invoke the tool to execute code, read/write files, and run shell commands within the sandbox.
+3. Sessions are managed automatically — no manual lifecycle management required.
+4. Code execution failures (syntax errors, exceptions) are returned as structured errors without crashing the agent.
+
+**Security:** The sandbox has no access to the host filesystem or network. All code runs in an isolated environment managed by AWS.
 
 ### Observability (OTEL)
 

--- a/agents/strands_agent/src/agent.py
+++ b/agents/strands_agent/src/agent.py
@@ -6,6 +6,8 @@ from typing import Optional
 from strands import Agent
 from strands.models.bedrock import BedrockModel
 
+from strands_tools.code_interpreter import AgentCoreCodeInterpreter
+
 from src.config import AgentConfig, MCPServerConfig
 from src.integrations.approval import ApprovalHook
 from src.integrations.mcp_client import build_mcp_clients, create_mcp_clients, has_oauth2_servers, _install_logging_callback, TokenInfoHook
@@ -59,6 +61,17 @@ def build_agent(config: AgentConfig, defer_mcp: bool = False) -> tuple[Agent, Ap
             if a2a_clients:
                 tools.extend(a2a_clients)
                 logger.info("Loaded %d A2A client(s)", len(a2a_clients))
+
+    # Code Interpreter tool
+    if config.integrations.code_interpreter.enabled:
+        ci_kwargs: dict = {}
+        if config.integrations.code_interpreter.region:
+            ci_kwargs["region"] = config.integrations.code_interpreter.region
+        if config.integrations.code_interpreter.identifier:
+            ci_kwargs["identifier"] = config.integrations.code_interpreter.identifier
+        ci = AgentCoreCodeInterpreter(**ci_kwargs)
+        tools.append(ci.code_interpreter)
+        logger.info("Loaded Code Interpreter tool (region=%s)", ci_kwargs.get("region", "default"))
 
     # Approval hook (HITL Method 1) — policies injected at invocation time
     approval_hook = ApprovalHook(agent_tags=config.tags if hasattr(config, "tags") else None)

--- a/agents/strands_agent/src/config.py
+++ b/agents/strands_agent/src/config.py
@@ -61,12 +61,22 @@ class MemoryConfig:
 
 
 @dataclass
+class CodeInterpreterConfig:
+    """Configuration for the Code Interpreter integration."""
+
+    enabled: bool = False
+    region: str = ""
+    identifier: str = ""
+
+
+@dataclass
 class IntegrationsConfig:
     """Configuration for all integrations."""
 
     mcp_servers: list[MCPServerConfig] = field(default_factory=list)
     a2a_agents: list[A2AAgentConfig] = field(default_factory=list)
     memory: MemoryConfig = field(default_factory=MemoryConfig)
+    code_interpreter: CodeInterpreterConfig = field(default_factory=CodeInterpreterConfig)
 
 
 @dataclass
@@ -128,6 +138,7 @@ def _parse_integrations(data: Optional[dict]) -> IntegrationsConfig:
     """Parse integrations configuration from a dictionary."""
     if data is None:
         return IntegrationsConfig()
+    ci_data = data.get("code_interpreter", {})
     return IntegrationsConfig(
         mcp_servers=_parse_mcp_servers(data.get("mcp_servers", [])),
         a2a_agents=_parse_a2a_agents(data.get("a2a_agents", [])),
@@ -141,6 +152,11 @@ def _parse_integrations(data: Optional[dict]) -> IntegrationsConfig:
                 )
                 for r in data.get("memory", {}).get("resources", [])
             ],
+        ),
+        code_interpreter=CodeInterpreterConfig(
+            enabled=ci_data.get("enabled", False),
+            region=ci_data.get("region", ""),
+            identifier=ci_data.get("identifier", ""),
         ),
     )
 

--- a/agents/strands_agent/src/handler.py
+++ b/agents/strands_agent/src/handler.py
@@ -423,7 +423,7 @@ async def invoke(payload: dict[str, Any]) -> AsyncGenerator[Any, None]:
                             yield text
                             continue
                         event_keys = list(event.keys())
-                        logger.info("Stream event keys: %s", event_keys)
+                        logger.debug("Stream event keys: %s", event_keys)
                         chunk = event.get("event")
                         if isinstance(chunk, dict):
                             if "contentBlockStart" in chunk:

--- a/agents/strands_agent/tests/test_code_interpreter.py
+++ b/agents/strands_agent/tests/test_code_interpreter.py
@@ -1,0 +1,167 @@
+"""Tests for Code Interpreter integration."""
+
+import unittest
+from unittest.mock import patch, MagicMock
+
+from src.config import (
+    AgentConfig,
+    CodeInterpreterConfig,
+    IntegrationsConfig,
+    MemoryConfig,
+)
+from src.agent import build_agent
+
+
+class TestCodeInterpreterIntegration(unittest.TestCase):
+    """Tests for Code Interpreter tool registration in build_agent."""
+
+    def _make_config(self, ci_enabled: bool = False, ci_region: str = "", ci_identifier: str = "") -> AgentConfig:
+        return AgentConfig(
+            system_prompt="Test prompt",
+            model_id="us.anthropic.claude-sonnet-4-20250514",
+            integrations=IntegrationsConfig(
+                memory=MemoryConfig(enabled=False),
+                code_interpreter=CodeInterpreterConfig(
+                    enabled=ci_enabled,
+                    region=ci_region,
+                    identifier=ci_identifier,
+                ),
+            ),
+        )
+
+    @patch("src.agent.Agent")
+    @patch("src.agent.BedrockModel")
+    @patch("src.agent.AgentCoreCodeInterpreter")
+    def test_code_interpreter_enabled(
+        self,
+        mock_ci_cls: MagicMock,
+        mock_model_cls: MagicMock,
+        mock_agent_cls: MagicMock,
+    ) -> None:
+        mock_ci_instance = MagicMock()
+        mock_tool = MagicMock()
+        mock_ci_instance.code_interpreter = mock_tool
+        mock_ci_cls.return_value = mock_ci_instance
+
+        config = self._make_config(ci_enabled=True, ci_region="us-west-2")
+        build_agent(config)
+
+        mock_ci_cls.assert_called_once_with(region="us-west-2")
+        call_kwargs = mock_agent_cls.call_args[1]
+        self.assertIn(mock_tool, call_kwargs["tools"])
+
+    @patch("src.agent.Agent")
+    @patch("src.agent.BedrockModel")
+    @patch("src.agent.AgentCoreCodeInterpreter")
+    def test_code_interpreter_with_identifier(
+        self,
+        mock_ci_cls: MagicMock,
+        mock_model_cls: MagicMock,
+        mock_agent_cls: MagicMock,
+    ) -> None:
+        mock_ci_instance = MagicMock()
+        mock_ci_instance.code_interpreter = MagicMock()
+        mock_ci_cls.return_value = mock_ci_instance
+
+        config = self._make_config(ci_enabled=True, ci_region="us-east-1", ci_identifier="my-custom-ci")
+        build_agent(config)
+
+        mock_ci_cls.assert_called_once_with(region="us-east-1", identifier="my-custom-ci")
+
+    @patch("src.agent.Agent")
+    @patch("src.agent.BedrockModel")
+    @patch("src.agent.AgentCoreCodeInterpreter")
+    def test_code_interpreter_disabled(
+        self,
+        mock_ci_cls: MagicMock,
+        mock_model_cls: MagicMock,
+        mock_agent_cls: MagicMock,
+    ) -> None:
+        config = self._make_config(ci_enabled=False)
+        build_agent(config)
+
+        mock_ci_cls.assert_not_called()
+        call_kwargs = mock_agent_cls.call_args[1]
+        self.assertEqual(call_kwargs["tools"], [])
+
+    @patch("src.agent.Agent")
+    @patch("src.agent.BedrockModel")
+    @patch("src.agent.AgentCoreCodeInterpreter")
+    def test_code_interpreter_no_region_uses_default(
+        self,
+        mock_ci_cls: MagicMock,
+        mock_model_cls: MagicMock,
+        mock_agent_cls: MagicMock,
+    ) -> None:
+        mock_ci_instance = MagicMock()
+        mock_ci_instance.code_interpreter = MagicMock()
+        mock_ci_cls.return_value = mock_ci_instance
+
+        config = self._make_config(ci_enabled=True)
+        build_agent(config)
+
+        mock_ci_cls.assert_called_once_with()
+
+
+class TestCodeInterpreterConfig(unittest.TestCase):
+    """Tests for CodeInterpreterConfig parsing."""
+
+    def test_default_config(self) -> None:
+        config = CodeInterpreterConfig()
+        self.assertFalse(config.enabled)
+        self.assertEqual(config.region, "")
+        self.assertEqual(config.identifier, "")
+
+    def test_config_with_values(self) -> None:
+        config = CodeInterpreterConfig(enabled=True, region="us-west-2", identifier="custom-ci")
+        self.assertTrue(config.enabled)
+        self.assertEqual(config.region, "us-west-2")
+        self.assertEqual(config.identifier, "custom-ci")
+
+
+class TestCodeInterpreterConfigParsing(unittest.TestCase):
+    """Tests for parsing code_interpreter from JSON config."""
+
+    def test_parse_with_code_interpreter(self) -> None:
+        from src.config import _parse_config
+        import os
+        from unittest.mock import patch as mock_patch
+
+        data = {
+            "system_prompt": "Test",
+            "model_id": "test-model",
+            "integrations": {
+                "code_interpreter": {
+                    "enabled": True,
+                    "region": "us-west-2",
+                    "identifier": "my-ci",
+                }
+            },
+        }
+        with mock_patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGENT_SYSTEM_PROMPT", None)
+            config = _parse_config(data)
+
+        self.assertTrue(config.integrations.code_interpreter.enabled)
+        self.assertEqual(config.integrations.code_interpreter.region, "us-west-2")
+        self.assertEqual(config.integrations.code_interpreter.identifier, "my-ci")
+
+    def test_parse_without_code_interpreter(self) -> None:
+        from src.config import _parse_config
+        import os
+        from unittest.mock import patch as mock_patch
+
+        data = {
+            "system_prompt": "Test",
+            "model_id": "test-model",
+            "integrations": {},
+        }
+        with mock_patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGENT_SYSTEM_PROMPT", None)
+            config = _parse_config(data)
+
+        self.assertFalse(config.integrations.code_interpreter.enabled)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/SPECIFICATIONS.md
+++ b/backend/SPECIFICATIONS.md
@@ -215,7 +215,7 @@ uv pip install ".[postgres]"
 | `available_qualifiers` | TEXT | JSON array of endpoint names (e.g., `["DEFAULT"]`) |
 | `raw_metadata` | TEXT | Full JSON from AgentCore describe API |
 | `source` | TEXT | `register`, `deploy`, or `harness` |
-| `deployment_status` | TEXT | `initializing`, `creating_credentials`, `creating_role`, `building_artifact`, `deploying`, `deployed`, `failed`, `removing`, `READY` |
+| `deployment_status` | TEXT | `initializing`, `creating_credentials`, `creating_role`, `building_artifact`, `creating_ci_resource`, `deploying`, `deployed`, `failed`, `removing`, `READY` |
 | `execution_role_arn` | TEXT | IAM execution role ARN |
 | `config_hash` | TEXT | Configuration hash |
 | `endpoint_name` | TEXT | Runtime endpoint name |
@@ -227,6 +227,7 @@ uv pip install ".[postgres]"
 | `tags` | TEXT | JSON dict of resolved tags applied to this agent's AWS resources |
 | `allowed_model_ids` | TEXT | JSON array of model IDs the agent is allowed to use at invoke time (defaults to `[model_id]`) |
 | `harness_id` | VARCHAR | Harness ID for managed agent deployments (nullable, set when `source="harness"`) |
+| `code_interpreter_id` | TEXT | Custom Code Interpreter resource ID (nullable, set when a custom CI resource is created on deploy) |
 | `registered_at` | DATETIME | Timestamp of local registration |
 | `deployed_at` | DATETIME | Deployment timestamp |
 | `last_refreshed_at` | DATETIME | Last time metadata was fetched from AWS |
@@ -259,6 +260,7 @@ uv pip install ".[postgres]"
 | `description` | TEXT | Role description |
 | `policy_document` | TEXT | JSON policy document |
 | `tags` | TEXT | JSON dict of tags fetched from AWS IAM on import |
+| `role_type` | TEXT DEFAULT 'agent' | Role type: `"agent"` or `"code_interpreter"` |
 | `created_at` | DATETIME | Creation timestamp |
 | `updated_at` | DATETIME | Last update timestamp |
 
@@ -1276,6 +1278,7 @@ Wraps `boto3.client('bedrock-agentcore-control')` (control plane) and `boto3.cli
 CloudWatch vended log delivery configuration for agent runtimes and memory resources:
 
 - `enable_runtime_observability(runtime_arn, runtime_id, account_id, region) -> dict` — configures USAGE_LOGS and APPLICATION_LOGS delivery for an agent runtime using the CloudWatch `put_delivery_source`, `put_delivery_destination`, and `create_delivery` APIs. Called during agent deployment to enable cost tracking via vended logs.
+- `enable_code_interpreter_observability(ci_arn, ci_id, account_id, region) -> dict` — configures USAGE_LOGS and APPLICATION_LOGS delivery for a custom Code Interpreter resource. Account ID is parsed from `ci_arn` directly to ensure the log group ARN is valid. Delivery source/destination names use the last 8 characters of the CI ID to stay within CloudWatch's 64-character limit.
 
 ---
 
@@ -1289,8 +1292,8 @@ Deployment runs asynchronously via FastAPI `BackgroundTasks` with progressive `d
 3. Background task progresses through deployment phases:
    - **`creating_credentials`**: For each MCP server or A2A agent with OAuth2 auth, calls `create_oauth2_credential_provider` (vendor=`CustomOauth2`, using `discoveryUrl` from config) with exponential backoff retry. If the provider already exists (e.g., redeployment), automatically falls back to `update_oauth2_credential_provider` to apply the latest configuration. Stores credential provider names in `AGENT_CONFIG_JSON` under `integrations.mcp_servers[].auth.credential_provider_name` or `integrations.a2a_agents[].auth.credential_provider_name`. If credential provider creation fails after all retries, sets `deployment_status="credential_creation_failed"` and returns without deploying.
    - **`creating_role`**: Creates or validates the IAM execution role (if needed).
-   - **`building_artifact`**: Builds the deployment artifact by copying source from `agents/strands_agent/src/`, running `pip install` against `requirements.txt` targeting `linux/arm64` (`manylinux2014_aarch64`), fixing console script shebangs (e.g. `opentelemetry-instrument`) to use `#!/usr/bin/env python3` for Linux compatibility, zipping the package and uploading it to S3.
-   - **`deploying`**: Calls `create_agent_runtime` with the artifact location, environment variables (including `OTEL_SERVICE_NAME` set to the agent name and `AGENT_OBSERVABILITY_ENABLED=true` to activate the `aws-opentelemetry-distro` export pipeline), network/protocol/lifecycle/authorizer configuration.
+   - **`building_artifact`**: Builds the deployment artifact by copying source from `agents/strands_agent/src/`, running `pip install` against `requirements.txt` targeting `linux/arm64` (`manylinux2014_aarch64`), fixing console script shebangs (e.g. `opentelemetry-instrument`) to use `#!/usr/bin/env python3` for Linux compatibility, zipping the package and uploading it to S3. When `code_interpreter_enabled` is true and a CI execution role is configured, a custom Code Interpreter resource is created in parallel via `ThreadPoolExecutor`. The resulting resource ID is stored in `agents.code_interpreter_id` and injected into `AGENT_CONFIG_JSON` as `integrations.code_interpreter.identifier`.
+   - **`deploying`**: Calls `create_agent_runtime` with the artifact location, environment variables (including `OTEL_SERVICE_NAME` set to the agent name, `AGENT_OBSERVABILITY_ENABLED=true` to activate the `aws-opentelemetry-distro` export pipeline, `OTEL_TRACES_EXPORTER=awsxray`, and `OTEL_PROPAGATORS=xray` to activate X-Ray tracing), network/protocol/lifecycle/authorizer configuration.
    - **`deployed`**: Stores authorizer config on the agent record. Stores the Cognito `client_id` as a config entry. Stores the `client_secret` in AWS Secrets Manager and saves the resulting ARN as a config entry. Updates `deployment_status="deployed"` and `status="READY"`.
 4. On error during any phase: sets `deployment_status="failed"` (or `"credential_creation_failed"` specifically for credential failures).
 5. Frontend polls the status endpoint to track progress. Smart polling returns DB state immediately during local build phases (`creating_credentials`, `creating_role`, `building_artifact`) without AWS API calls. Only when `deployment_status="deployed"` does the status endpoint query AWS for runtime state.

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -142,6 +142,8 @@ def _migrate_add_columns(eng) -> None:
         ("mcp_servers", "obo_grant_type", "VARCHAR"),
         ("a2a_agents", "obo_grant_type", "VARCHAR"),
         ("mcp_servers", "oauth2_audience", "VARCHAR"),
+        ("managed_roles", "role_type", "VARCHAR DEFAULT 'agent'"),
+        ("agents", "code_interpreter_id", "VARCHAR"),
     ]
 
     is_postgres = eng.dialect.name == "postgresql"

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -51,6 +51,7 @@ class Agent(Base):
     registry_status = Column(String, nullable=True)
     allowed_model_ids = Column(Text, nullable=True)  # JSON array of allowed model IDs
     harness_id = Column(String, nullable=True)  # Harness ID for managed agent deployments
+    code_interpreter_id = Column(String, nullable=True)
 
     # Relationships
     sessions = relationship("InvocationSession", back_populates="agent", cascade="all, delete-orphan")
@@ -154,4 +155,5 @@ class Agent(Base):
             "registry_status": self.registry_status,
             "allowed_model_ids": self.get_allowed_model_ids(),
             "harness_id": self.harness_id,
+            "code_interpreter_id": self.code_interpreter_id,
         }

--- a/backend/app/models/managed_role.py
+++ b/backend/app/models/managed_role.py
@@ -9,6 +9,7 @@ class ManagedRole(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     role_name = Column(String, nullable=False)
     role_arn = Column(String, nullable=False, unique=True)
+    role_type = Column(String, nullable=False, default="agent")  # "agent" or "code_interpreter"
     description = Column(Text, default="")
     policy_document = Column(Text, default="{}")  # JSON string
     tags = Column(Text, nullable=True)  # JSON dict
@@ -28,6 +29,7 @@ class ManagedRole(Base):
             "id": self.id,
             "role_name": self.role_name,
             "role_arn": self.role_arn,
+            "role_type": self.role_type or "agent",
             "description": self.description,
             "policy_document": json.loads(self.policy_document) if self.policy_document else {},
             "tags": self.get_tags(),

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -1,4 +1,5 @@
 """Agent registration, deployment, and management endpoints."""
+import concurrent.futures
 import json
 import logging
 import os
@@ -150,6 +151,8 @@ class AgentCreateRequest(BaseModel):
     a2a_agents: list[int] = Field(default_factory=list, description="A2A agent IDs to integrate")
     code_interpreter_enabled: bool = Field(default=False, description="Enable Code Interpreter tool")
     code_interpreter_region: str = Field(default="", description="AWS region for Code Interpreter (empty = agent region)")
+    code_interpreter_network_mode: str = Field(default="SANDBOX", description="Code Interpreter network mode: PUBLIC, SANDBOX, or VPC")
+    code_interpreter_role_id: int | None = Field(None, description="Managed role ID for Code Interpreter execution role")
     tags: dict[str, str] | None = Field(None, description="Build-time tag values")
     # Harness-specific fields
     harness_tools: list[dict[str, Any]] | None = Field(None, description="Harness tool configurations")
@@ -193,6 +196,8 @@ class AgentResponse(BaseModel):
     memory_names: list[str] = []
     mcp_names: list[str] = []
     a2a_names: list[str] = []
+    code_interpreter_id: str | None = None
+    code_interpreter_status: str | None = None
 
 
 class ConfigEntryResponse(BaseModel):
@@ -371,7 +376,8 @@ def _agent_response(agent: Agent, db: Session) -> AgentResponse:
         active_session_count=compute_active_session_count(agent.id, db),
         memory_names=memory_names,
         mcp_names=mcp_names,
-        a2a_names=a2a_names
+        a2a_names=a2a_names,
+        code_interpreter_status=None,
     )
     if inv_count > 0 and grand_total > 0:
         result.cost_summary = {
@@ -483,6 +489,7 @@ def get_defaults(user: UserInfo = Depends(require_scopes("agent:read"))) -> dict
     return {
         "idle_timeout_seconds": int(os.getenv("LOOM_SESSION_IDLE_TIMEOUT_SECONDS", "300")),
         "max_lifetime_seconds": int(os.getenv("LOOM_SESSION_MAX_LIFETIME_SECONDS", "3600")),
+        "region": DEFAULT_REGION,
     }
 
 
@@ -1058,35 +1065,18 @@ def _deploy_agent_background(
                 "resources": memory_configs,
             },
         }
+        ci_config: dict[str, Any] | None = None
         if request.code_interpreter_enabled:
-            integrations_config["code_interpreter"] = {
+            ci_config = {
                 "enabled": True,
                 "region": request.code_interpreter_region or "",
+                "network_mode": request.code_interpreter_network_mode or "SANDBOX",
             }
-        config_json = json.dumps({
-            "system_prompt": system_prompt,
-            "model_id": request.model_id,
-            "max_tokens": model_max_tokens,
-            "integrations": integrations_config,
-        })
-        env_vars = {
-            "AGENT_CONFIG_JSON": config_json,
-            "OTEL_SERVICE_NAME": request.name,
-            "WORKLOAD_IDENTITY_NAME": f"loom-{request.name}",
-            "AGENT_OBSERVABILITY_ENABLED": "true",
-            "AWS_REGION": region,
-        }
-
-        # Store config entries
-        for key, value in env_vars.items():
-            db.add(ConfigEntry(
-                agent_id=agent.id,
-                key=key,
-                value=value,
-                is_secret=False,
-                source="env_var",
-            ))
-        db.commit()
+            if request.code_interpreter_role_id:
+                ci_role = db.query(ManagedRole).filter(ManagedRole.id == request.code_interpreter_role_id).first()
+                if ci_role:
+                    ci_config["execution_role_arn"] = ci_role.role_arn
+            integrations_config["code_interpreter"] = ci_config
 
         # --- Step 2: Create or use provided IAM execution role ---
         agent.deployment_status = "creating_role"
@@ -1103,6 +1093,7 @@ def _deploy_agent_background(
                     account_id=account_id,
                     tag_policies=tag_policy_dicts,
                     extra_tags=resolved_tags,
+                    code_interpreter=request.code_interpreter_enabled,
                 )
                 created_role = True
                 agent.execution_role_arn = execution_role_arn
@@ -1117,9 +1108,37 @@ def _deploy_agent_background(
             agent.execution_role_arn = execution_role_arn
             db.commit()
 
-        # --- Step 3: Build agent artifact ---
+        # --- Step 3: Build agent artifact (and optionally create CI resource in parallel) ---
         agent.deployment_status = "building_artifact"
         db.commit()
+
+        _needs_ci_resource = (
+            request.code_interpreter_enabled
+            and ci_config is not None
+            and bool(ci_config.get("execution_role_arn"))
+        )
+
+        def _create_ci_resource() -> str:
+            import boto3
+            ci_region = (request.code_interpreter_region or "").strip() or region
+            raw_name = f"loom-ci-{request.name}".replace("_", "-")
+            sanitized = re.sub(r"[^a-zA-Z0-9-]", "-", raw_name)[:48]
+            network_mode = request.code_interpreter_network_mode or "PUBLIC"
+            boto_client = boto3.client("bedrock-agentcore-control", region_name=ci_region)
+            resp = boto_client.create_code_interpreter(
+                name=sanitized,
+                executionRoleArn=ci_config["execution_role_arn"],
+                networkConfiguration={"networkMode": network_mode},
+            )
+            return resp["codeInterpreterId"]
+
+        ci_future: concurrent.futures.Future | None = None
+        ci_executor: concurrent.futures.ThreadPoolExecutor | None = None
+        if _needs_ci_resource:
+            agent.deployment_status = "creating_ci_resource"
+            db.commit()
+            ci_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+            ci_future = ci_executor.submit(_create_ci_resource)
 
         try:
             artifact_bucket, artifact_key = build_agent_artifact(region)
@@ -1127,10 +1146,55 @@ def _deploy_agent_background(
             agent.deployment_status = "failed"
             agent.status = "FAILED"
             db.commit()
+            if ci_future is not None:
+                ci_future.cancel()
+            if ci_executor is not None:
+                ci_executor.shutdown(wait=False)
             if created_role and execution_role_arn:
                 _cleanup_role(execution_role_arn)
             logger.error("Failed to build artifact for agent %s: %s", agent.id, e)
             return
+
+        if ci_future is not None:
+            try:
+                ci_id = ci_future.result(timeout=60)
+                agent.code_interpreter_id = ci_id
+                if ci_config is not None:
+                    ci_config["identifier"] = ci_id
+                db.commit()
+                logger.info("Created CI resource %s for agent %s", ci_id, agent.id)
+            except Exception as ci_err:
+                logger.warning("CI resource creation failed for agent %s, continuing: %s", agent.id, ci_err)
+            finally:
+                if ci_executor is not None:
+                    ci_executor.shutdown(wait=False)
+
+        agent.deployment_status = "building_artifact"
+        db.commit()
+
+        config_json = json.dumps({
+            "system_prompt": system_prompt,
+            "model_id": request.model_id,
+            "max_tokens": model_max_tokens,
+            "integrations": integrations_config,
+        })
+        env_vars = {
+            "AGENT_CONFIG_JSON": config_json,
+            "OTEL_SERVICE_NAME": request.name,
+            "WORKLOAD_IDENTITY_NAME": f"loom-{request.name}",
+            "AGENT_OBSERVABILITY_ENABLED": "true",
+            "AWS_REGION": region,
+        }
+
+        for key, value in env_vars.items():
+            db.add(ConfigEntry(
+                agent_id=agent.id,
+                key=key,
+                value=value,
+                is_secret=False,
+                source="env_var",
+            ))
+        db.commit()
 
         # Build optional configs
         lifecycle_config = None
@@ -1909,7 +1973,7 @@ def get_agent_status(agent_id: int, user: UserInfo = Depends(require_scopes("age
     agent = get_agent_or_404(agent_id, db)
 
     # Local build phases — runtime doesn't exist in AWS yet, just return DB state
-    _local_phases = {"initializing", "creating_credentials", "creating_role", "building_artifact", "deploying"}
+    _local_phases = {"initializing", "creating_credentials", "creating_role", "building_artifact", "creating_ci_resource", "deploying"}
     if agent.deployment_status in _local_phases:
         return _agent_response(agent, db)
 
@@ -2023,10 +2087,24 @@ def get_agent_status(agent_id: int, user: UserInfo = Depends(require_scopes("age
             except Exception as reg_err:
                 logger.warning("Failed to auto-register agent %s in registry: %s", agent.id, reg_err)
 
+    ci_status: str | None = None
+    if agent.code_interpreter_id:
+        try:
+            import boto3
+            ci_region = agent.region
+            boto_client = boto3.client("bedrock-agentcore-control", region_name=ci_region)
+            ci_resp = boto_client.get_code_interpreter(codeInterpreterId=agent.code_interpreter_id)
+            ci_status = ci_resp.get("status")
+        except Exception as ci_poll_err:
+            logger.warning("Failed to poll CI status for agent %s: %s", agent.id, ci_poll_err)
+
     db.commit()
     db.refresh(agent)
 
-    return _agent_response(agent, db)
+    response = _agent_response(agent, db)
+    if ci_status is not None:
+        response.code_interpreter_status = ci_status
+    return response
 
 
 @router.delete("/{agent_id}", response_model=AgentResponse)
@@ -2676,9 +2754,19 @@ def export_agent(agent_id: int, user: UserInfo = Depends(require_scopes("admin:w
             data["memories"] = verified
     ci_cfg = integrations.get("code_interpreter", {})
     if ci_cfg.get("enabled"):
-        data["code_interpreter"] = True
-        if ci_cfg.get("region"):
-            data["code_interpreter_region"] = ci_cfg["region"]
+        ci_export: dict[str, Any] = {
+            "enabled": True,
+            "region": ci_cfg.get("region") or "us-east-1",
+            "network_mode": ci_cfg.get("network_mode") or "SANDBOX",
+        }
+        if ci_cfg.get("execution_role_arn"):
+            role_arn = ci_cfg["execution_role_arn"]
+            managed_role = db.query(ManagedRole).filter(ManagedRole.role_arn == role_arn).first()
+            if managed_role:
+                ci_export["role"] = managed_role.role_name
+            else:
+                ci_export["role"] = role_arn
+        data["code_interpreter"] = ci_export
 
     return data
 

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -1118,11 +1118,12 @@ def _deploy_agent_background(
             and bool(ci_config.get("execution_role_arn"))
         )
 
-        def _create_ci_resource() -> str:
+        def _create_ci_resource() -> tuple[str, str]:
             import boto3
             ci_region = (request.code_interpreter_region or "").strip() or region
-            raw_name = f"loom-ci-{request.name}".replace("_", "-")
-            sanitized = re.sub(r"[^a-zA-Z0-9-]", "-", raw_name)[:48]
+            base_name = re.sub(r"_?code_interpreter$", "", request.name).strip("_")
+            raw_name = f"loom_ci_{base_name}"
+            sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", raw_name)[:48]
             network_mode = request.code_interpreter_network_mode or "PUBLIC"
             boto_client = boto3.client("bedrock-agentcore-control", region_name=ci_region)
             resp = boto_client.create_code_interpreter(
@@ -1130,7 +1131,7 @@ def _deploy_agent_background(
                 executionRoleArn=ci_config["execution_role_arn"],
                 networkConfiguration={"networkMode": network_mode},
             )
-            return resp["codeInterpreterId"]
+            return resp["codeInterpreterId"], resp["codeInterpreterArn"]
 
         ci_future: concurrent.futures.Future | None = None
         ci_executor: concurrent.futures.ThreadPoolExecutor | None = None
@@ -1157,12 +1158,27 @@ def _deploy_agent_background(
 
         if ci_future is not None:
             try:
-                ci_id = ci_future.result(timeout=60)
+                ci_id, ci_arn = ci_future.result(timeout=60)
                 agent.code_interpreter_id = ci_id
                 if ci_config is not None:
                     ci_config["identifier"] = ci_id
                 db.commit()
                 logger.info("Created CI resource %s for agent %s", ci_id, agent.id)
+                ci_region = (request.code_interpreter_region or "").strip() or region
+                try:
+                    from app.services.observability import enable_code_interpreter_observability
+                    # Parse account_id from the CI ARN directly — the env var may be empty
+                    ci_arn_parts = ci_arn.split(":")
+                    ci_account_id = ci_arn_parts[4] if len(ci_arn_parts) >= 6 else account_id
+                    ci_obs = enable_code_interpreter_observability(
+                        ci_arn=ci_arn,
+                        ci_id=ci_id,
+                        account_id=ci_account_id,
+                        region=ci_region,
+                    )
+                    logger.info("Enabled CI observability for agent %s: %s", agent.id, ci_obs)
+                except Exception as ci_obs_err:
+                    logger.warning("Failed to enable CI observability for agent %s: %s", agent.id, ci_obs_err)
             except Exception as ci_err:
                 logger.warning("CI resource creation failed for agent %s, continuing: %s", agent.id, ci_err)
             finally:
@@ -1181,6 +1197,8 @@ def _deploy_agent_background(
         env_vars = {
             "AGENT_CONFIG_JSON": config_json,
             "OTEL_SERVICE_NAME": request.name,
+            "OTEL_TRACES_EXPORTER": "awsxray",
+            "OTEL_PROPAGATORS": "xray",
             "WORKLOAD_IDENTITY_NAME": f"loom-{request.name}",
             "AGENT_OBSERVABILITY_ENABLED": "true",
             "AWS_REGION": region,
@@ -1926,6 +1944,58 @@ def _cleanup_role(role_arn: str) -> None:
         logger.warning("Failed to clean up orphaned IAM role %s: %s", role_arn, e)
 
 
+def _delete_code_interpreter(ci_id: str, region: str) -> None:
+    """Best-effort deletion of a custom Code Interpreter resource.
+
+    If active sessions are present, terminates them and retries once.
+    """
+    import boto3
+    client = boto3.client("bedrock-agentcore-control", region_name=region)
+    data_client = boto3.client("bedrock-agentcore", region_name=region)
+
+    def _attempt_delete() -> bool:
+        try:
+            client.delete_code_interpreter(codeInterpreterId=ci_id)
+            logger.info("Deleted CI resource %s", ci_id)
+            return True
+        except client.exceptions.ConflictException as e:
+            raise e
+        except Exception as e:
+            logger.warning("Failed to delete CI resource %s: %s", ci_id, e)
+            return False
+
+    try:
+        _attempt_delete()
+    except Exception as e:
+        err_msg = str(e)
+        if "active sessions" in err_msg.lower() or "ConflictException" in type(e).__name__:
+            logger.info("CI resource %s has active sessions; terminating before retry", ci_id)
+            try:
+                paginator_resp = data_client.list_code_interpreter_sessions(codeInterpreterIdentifier=ci_id)
+                sessions = paginator_resp.get("items", [])
+                for s in sessions:
+                    sid = s.get("sessionId")
+                    if sid:
+                        try:
+                            data_client.stop_code_interpreter_session(
+                                codeInterpreterIdentifier=ci_id,
+                                sessionId=sid,
+                            )
+                            logger.info("Stopped CI session %s", sid)
+                        except Exception as stop_err:
+                            logger.warning("Failed to stop CI session %s: %s", sid, stop_err)
+            except Exception as list_err:
+                logger.warning("Failed to list CI sessions for %s: %s", ci_id, list_err)
+            # Retry delete after terminating sessions
+            try:
+                client.delete_code_interpreter(codeInterpreterId=ci_id)
+                logger.info("Deleted CI resource %s after session cleanup", ci_id)
+            except Exception as retry_err:
+                logger.warning("Failed to delete CI resource %s after session cleanup: %s", ci_id, retry_err)
+        else:
+            logger.warning("Failed to delete CI resource %s: %s", ci_id, e)
+
+
 @router.get("", response_model=list[AgentResponse])
 def list_agents(
     user: UserInfo = Depends(require_scopes("agent:read")),
@@ -2088,7 +2158,7 @@ def get_agent_status(agent_id: int, user: UserInfo = Depends(require_scopes("age
                 logger.warning("Failed to auto-register agent %s in registry: %s", agent.id, reg_err)
 
     ci_status: str | None = None
-    if agent.code_interpreter_id:
+    if agent.code_interpreter_id and agent.status != "DELETING":
         try:
             import boto3
             ci_region = agent.region
@@ -2096,7 +2166,10 @@ def get_agent_status(agent_id: int, user: UserInfo = Depends(require_scopes("age
             ci_resp = boto_client.get_code_interpreter(codeInterpreterId=agent.code_interpreter_id)
             ci_status = ci_resp.get("status")
         except Exception as ci_poll_err:
-            logger.warning("Failed to poll CI status for agent %s: %s", agent.id, ci_poll_err)
+            if _is_resource_not_found(ci_poll_err):
+                logger.debug("CI resource %s not found during poll (already deleted)", agent.code_interpreter_id)
+            else:
+                logger.warning("Failed to poll CI status for agent %s: %s", agent.id, ci_poll_err)
 
     db.commit()
     db.refresh(agent)
@@ -2190,6 +2263,14 @@ def delete_agent(
     _endpoint_name = agent.endpoint_name
     _region = agent.region
     _secret_arn = config_map.get("COGNITO_CLIENT_SECRET_ARN")
+    _ci_id = agent.code_interpreter_id
+    _ci_region = None
+    if _ci_id:
+        try:
+            agent_cfg = json.loads(config_map.get("AGENT_CONFIG_JSON") or "{}")
+            _ci_region = (agent_cfg.get("integrations", {}).get("code_interpreter") or {}).get("region") or _region
+        except (json.JSONDecodeError, TypeError):
+            _ci_region = _region
 
     # Initiate async deletion in AWS
     _harness_id = agent.harness_id
@@ -2217,6 +2298,10 @@ def delete_agent(
             delete_runtime(_runtime_id, _region)
         except Exception as e:
             logger.warning("Failed to delete runtime %s: %s", _runtime_id, e)
+
+    # Delete custom Code Interpreter resource if one was created
+    if _ci_id and _ci_region:
+        _delete_code_interpreter(_ci_id, _ci_region)
 
     # Clean up credential providers
     for cp_name in cp_names:

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -148,6 +148,8 @@ class AgentCreateRequest(BaseModel):
     memory_ids: list[int] = Field(default_factory=list, description="Memory resource IDs to integrate")
     mcp_servers: list[int] = Field(default_factory=list, description="MCP server IDs to integrate")
     a2a_agents: list[int] = Field(default_factory=list, description="A2A agent IDs to integrate")
+    code_interpreter_enabled: bool = Field(default=False, description="Enable Code Interpreter tool")
+    code_interpreter_region: str = Field(default="", description="AWS region for Code Interpreter (empty = agent region)")
     tags: dict[str, str] | None = Field(None, description="Build-time tag values")
     # Harness-specific fields
     harness_tools: list[dict[str, Any]] | None = Field(None, description="Harness tool configurations")
@@ -1048,18 +1050,24 @@ def _deploy_agent_background(
             for m in memory_snapshots
         ]
 
+        integrations_config: dict[str, Any] = {
+            "mcp_servers": mcp_server_configs,
+            "a2a_agents": a2a_agent_configs,
+            "memory": {
+                "enabled": request.memory_enabled or len(memory_configs) > 0,
+                "resources": memory_configs,
+            },
+        }
+        if request.code_interpreter_enabled:
+            integrations_config["code_interpreter"] = {
+                "enabled": True,
+                "region": request.code_interpreter_region or "",
+            }
         config_json = json.dumps({
             "system_prompt": system_prompt,
             "model_id": request.model_id,
             "max_tokens": model_max_tokens,
-            "integrations": {
-                "mcp_servers": mcp_server_configs,
-                "a2a_agents": a2a_agent_configs,
-                "memory": {
-                    "enabled": request.memory_enabled or len(memory_configs) > 0,
-                    "resources": memory_configs,
-                },
-            },
+            "integrations": integrations_config,
         })
         env_vars = {
             "AGENT_CONFIG_JSON": config_json,
@@ -2666,6 +2674,11 @@ def export_agent(agent_id: int, user: UserInfo = Depends(require_scopes("admin:w
         verified = [n for n in names if db.query(Memory).filter(Memory.name == n).first()]
         if verified:
             data["memories"] = verified
+    ci_cfg = integrations.get("code_interpreter", {})
+    if ci_cfg.get("enabled"):
+        data["code_interpreter"] = True
+        if ci_cfg.get("region"):
+            data["code_interpreter_region"] = ci_cfg["region"]
 
     return data
 

--- a/backend/app/routers/security.py
+++ b/backend/app/routers/security.py
@@ -56,6 +56,7 @@ class CreateRoleRequest(BaseModel):
     mode: str = Field(..., description="'import' or 'wizard'")
     role_arn: str | None = Field(None, description="Existing role ARN (import mode)")
     role_name: str | None = Field(None, description="New role name (wizard mode)")
+    role_type: str = Field(default="agent", description="Role type: 'agent' or 'code_interpreter'")
     description: str = Field(default="", description="Role description")
     policy_document: dict = Field(default_factory=dict, description="IAM policy document (wizard mode)")
     tags: dict[str, str] | None = Field(None, description="Tags to apply (merged with AWS IAM tags on import)")
@@ -158,6 +159,7 @@ def create_role(request: CreateRoleRequest, user: UserInfo = Depends(require_sco
         role = ManagedRole(
             role_name=role_name,
             role_arn=request.role_arn,
+            role_type=request.role_type,
             description=request.description,
             policy_document=json.dumps(policy_doc),
         )
@@ -184,6 +186,7 @@ def create_role(request: CreateRoleRequest, user: UserInfo = Depends(require_sco
         role = ManagedRole(
             role_name=request.role_name,
             role_arn=role_arn,
+            role_type=request.role_type,
             description=request.description,
             policy_document=json.dumps(request.policy_document),
         )

--- a/backend/app/services/iam.py
+++ b/backend/app/services/iam.py
@@ -122,6 +122,7 @@ def create_execution_role(
     account_id: str,
     tag_policies: list[dict[str, Any]] | None = None,
     extra_tags: dict[str, str] | None = None,
+    code_interpreter: bool = False,
 ) -> str:
     """
     Create an IAM execution role for an agent runtime.
@@ -131,6 +132,7 @@ def create_execution_role(
         runtime_id: AgentCore Runtime ID (used in role naming)
         region: AWS region name
         account_id: AWS account ID
+        code_interpreter: If True, include Code Interpreter permissions
 
     Returns:
         ARN of the created IAM role
@@ -141,7 +143,7 @@ def create_execution_role(
 
     role_name = f"loom-agent-{runtime_id}"
     trust_policy = build_trust_policy()
-    base_policy = build_base_policy(region, account_id, agent_name)
+    base_policy = build_base_policy(region, account_id, agent_name, code_interpreter=code_interpreter)
 
     response = client.create_role(
         RoleName=role_name,
@@ -181,7 +183,12 @@ def build_trust_policy() -> dict:
     }
 
 
-def build_base_policy(region: str, account_id: str, agent_name: str) -> dict:
+def build_base_policy(
+    region: str,
+    account_id: str,
+    agent_name: str,
+    code_interpreter: bool = False,
+) -> dict:
     """
     Build the base IAM policy for workload access token permissions.
 
@@ -189,52 +196,74 @@ def build_base_policy(region: str, account_id: str, agent_name: str) -> dict:
         region: AWS region name
         account_id: AWS account ID
         agent_name: Name of the agent (used for resource scoping)
+        code_interpreter: If True, include Code Interpreter sandbox permissions
 
     Returns:
         IAM policy document with bedrock-agentcore workload identity permissions
     """
+    statements = [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "bedrock-agentcore:GetWorkloadAccessToken",
+                "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
+                "bedrock-agentcore:GetWorkloadAccessTokenForUserId",
+            ],
+            "Resource": [
+                f"arn:aws:bedrock-agentcore:{region}:{account_id}:workload-identity-directory/default",
+                f"arn:aws:bedrock-agentcore:{region}:{account_id}:workload-identity-directory/default/workload-identity/{agent_name}-*",
+                f"arn:aws:bedrock-agentcore:{region}:{account_id}:workload-identity-directory/default/workload-identity/harness_{agent_name}-*",
+            ],
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "bedrock-agentcore:GetResourceOauth2Token",
+            ],
+            "Resource": [
+                f"arn:aws:bedrock-agentcore:{region}:{account_id}:token-vault/default/oauth2credentialprovider/*",
+            ],
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams",
+            ],
+            "Resource": [
+                f"arn:aws:logs:{region}:{account_id}:log-group:/aws/bedrock-agentcore/runtimes/{agent_name}*",
+                f"arn:aws:logs:{region}:{account_id}:log-group:/aws/bedrock-agentcore/runtimes/{agent_name}*:*",
+                f"arn:aws:logs:{region}:{account_id}:log-group:/aws/bedrock-agentcore/runtimes/harness_{agent_name}*",
+                f"arn:aws:logs:{region}:{account_id}:log-group:/aws/bedrock-agentcore/runtimes/harness_{agent_name}*:*",
+            ],
+        },
+    ]
+    if code_interpreter:
+        statements.append({
+            "Effect": "Allow",
+            "Action": [
+                "bedrock-agentcore:CreateCodeInterpreter",
+                "bedrock-agentcore:DeleteCodeInterpreter",
+                "bedrock-agentcore:GetCodeInterpreter",
+                "bedrock-agentcore:ListCodeInterpreters",
+                "bedrock-agentcore:StartCodeInterpreterSession",
+                "bedrock-agentcore:StopCodeInterpreterSession",
+                "bedrock-agentcore:InvokeCodeInterpreter",
+                "bedrock-agentcore:GetCodeInterpreterSession",
+                "bedrock-agentcore:ListCodeInterpreterSessions",
+            ],
+            "Resource": [
+                f"arn:aws:bedrock-agentcore:{region}:aws:code-interpreter/*",
+                f"arn:aws:bedrock-agentcore:{region}:{account_id}:code-interpreter/*",
+                f"arn:aws:bedrock-agentcore:{region}:{account_id}:code-interpreter-custom/*",
+            ],
+        })
     return {
         "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "bedrock-agentcore:GetWorkloadAccessToken",
-                    "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
-                    "bedrock-agentcore:GetWorkloadAccessTokenForUserId",
-                ],
-                "Resource": [
-                    f"arn:aws:bedrock-agentcore:{region}:{account_id}:workload-identity-directory/default",
-                    f"arn:aws:bedrock-agentcore:{region}:{account_id}:workload-identity-directory/default/workload-identity/{agent_name}-*",
-                    f"arn:aws:bedrock-agentcore:{region}:{account_id}:workload-identity-directory/default/workload-identity/harness_{agent_name}-*",
-                ],
-            },
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "bedrock-agentcore:GetResourceOauth2Token",
-                ],
-                "Resource": [
-                    f"arn:aws:bedrock-agentcore:{region}:{account_id}:token-vault/default/oauth2credentialprovider/*",
-                ],
-            },
-            {
-                "Effect": "Allow",
-                "Action": [
-                    "logs:CreateLogGroup",
-                    "logs:CreateLogStream",
-                    "logs:PutLogEvents",
-                    "logs:DescribeLogGroups",
-                    "logs:DescribeLogStreams",
-                ],
-                "Resource": [
-                    f"arn:aws:logs:{region}:{account_id}:log-group:/aws/bedrock-agentcore/runtimes/{agent_name}*",
-                    f"arn:aws:logs:{region}:{account_id}:log-group:/aws/bedrock-agentcore/runtimes/{agent_name}*:*",
-                    f"arn:aws:logs:{region}:{account_id}:log-group:/aws/bedrock-agentcore/runtimes/harness_{agent_name}*",
-                    f"arn:aws:logs:{region}:{account_id}:log-group:/aws/bedrock-agentcore/runtimes/harness_{agent_name}*:*",
-                ],
-            },
-        ],
+        "Statement": statements,
     }
 
 
@@ -377,6 +406,7 @@ def update_role_policy(
     region: str,
     account_id: str,
     agent_name: str,
+    code_interpreter: bool = False,
 ) -> None:
     """
     Update the inline policy on an execution role.
@@ -387,12 +417,13 @@ def update_role_policy(
         region: AWS region name
         account_id: AWS account ID
         agent_name: Name of the agent (used for resource scoping)
+        code_interpreter: If True, include Code Interpreter permissions
     """
     import boto3
 
     client = boto3.client("iam")
 
-    base_policy = build_base_policy(region, account_id, agent_name)
+    base_policy = build_base_policy(region, account_id, agent_name, code_interpreter=code_interpreter)
     integration_statements = build_integration_policy_statements(integrations)
 
     if integration_statements:

--- a/backend/app/services/observability.py
+++ b/backend/app/services/observability.py
@@ -104,6 +104,83 @@ def enable_runtime_observability(
     return result
 
 
+def enable_code_interpreter_observability(
+    ci_arn: str,
+    ci_id: str,
+    account_id: str,
+    region: str = "us-east-1",
+) -> dict[str, Any]:
+    """Enable USAGE_LOGS and APPLICATION_LOGS delivery for a Code Interpreter resource.
+
+    Args:
+        ci_arn: Full ARN of the code interpreter resource.
+        ci_id: Code interpreter resource ID (short form).
+        account_id: AWS account ID.
+        region: AWS region name.
+
+    Returns:
+        Dictionary with ``log_group``, ``usage_delivery_id``, and
+        ``app_delivery_id`` keys.
+    """
+    import boto3
+
+    logs = boto3.client("logs", region_name=region)
+
+    log_group = f"/aws/vendedlogs/bedrock-agentcore/code-interpreter/{ci_id}"
+
+    try:
+        logs.create_log_group(logGroupName=log_group)
+        logger.info("Created CI observability log group: %s", log_group)
+    except logs.exceptions.ResourceAlreadyExistsException:
+        logger.debug("CI log group already exists: %s", log_group)
+
+    result: dict[str, Any] = {"log_group": log_group}
+
+    # Use last 8 chars of ci_id (the random suffix) to keep names short
+    ci_short = ci_id[-8:] if len(ci_id) > 8 else ci_id
+    dest_name = f"loom-ci-{ci_short}-dest"
+    log_group_arn = f"arn:aws:logs:{region}:{account_id}:log-group:{log_group}"
+    try:
+        dest_resp = logs.put_delivery_destination(
+            name=dest_name,
+            deliveryDestinationType="CWL",
+            deliveryDestinationConfiguration={
+                "destinationResourceArn": log_group_arn,
+            },
+        )
+        dest_arn = dest_resp["deliveryDestination"]["arn"]
+        logger.info("Created CI delivery destination: %s", dest_name)
+    except Exception as e:
+        logger.warning("Failed to create CI delivery destination %s: %s", dest_name, e)
+        return result
+
+    for log_type, suffix in [("USAGE_LOGS", "usage"), ("APPLICATION_LOGS", "app")]:
+        source_name = f"loom-ci-{ci_short}-{suffix}-source"
+        try:
+            logs.put_delivery_source(
+                name=source_name,
+                logType=log_type,
+                resourceArn=ci_arn,
+            )
+            logger.info("Created CI delivery source: %s (%s)", source_name, log_type)
+        except Exception as e:
+            logger.warning("Failed to create CI delivery source %s: %s", source_name, e)
+            continue
+
+        delivery_key = f"{suffix}_delivery_id"
+        try:
+            delivery_resp = logs.create_delivery(
+                deliverySourceName=source_name,
+                deliveryDestinationArn=dest_arn,
+            )
+            result[delivery_key] = delivery_resp.get("delivery", {}).get("id")
+            logger.info("Created CI delivery for %s: %s", log_type, result.get(delivery_key))
+        except Exception as e:
+            logger.warning("Failed to create CI delivery for %s: %s", log_type, e)
+
+    return result
+
+
 def cleanup_runtime_observability(
     runtime_id: str,
     region: str = "us-east-1",

--- a/frontend/SPECIFICATIONS.md
+++ b/frontend/SPECIFICATIONS.md
@@ -187,7 +187,7 @@ Each card displays:
 - Protocol badge (e.g., `HTTP`) — inline with name
 - Status badge (color-coded: READY=default, CREATING=secondary, FAILED=destructive) — inline with name
 - Deployment type badge (`MANAGED` or `CUSTOM`) and cost badge displayed below the info box as outline badges (not in the header row)
-- Progressive deployment status phases: `initializing`, `creating_credentials` (Creating credential provider), `creating_role` (Creating IAM role), `building_artifact` (Building artifact), `deploying` (Deploying runtime / Creating harness), then "Completing deployment" / "Creating harness", "Finalizing endpoint"
+- Progressive deployment status phases: `initializing`, `creating_credentials` (Creating credential provider), `creating_role` (Creating IAM role), `building_artifact` (Building artifact), `creating_ci_resource` (Building artifact & creating Code Interpreter), `deploying` (Deploying runtime / Creating harness), then "Completing deployment" / "Creating harness", "Finalizing endpoint"
 - Spinner animation when agent is in a creating/deploying state
 - Spinner animation and elapsed timer when agent is in DELETING state, using `deleteStartTime` prop for accurate timer display
 - Endpoint status badge hidden during DELETING state
@@ -245,7 +245,7 @@ Full deployment form with sections:
 - **Harness Parameters** (managed only): max iterations and timeout seconds — positioned between Authorizer and Lifecycle.
 - **Lifecycle**: idle timeout and max lifetime fields with dynamic placeholders fetched from `/api/agents/defaults` (e.g., "300" and "3600")
 - **Resource Tags**: `ResourceTagFields` component with tag profile dropdown (persisted in `sessionStorage`). Deploy-time tags are auto-applied; build-time tags are resolved from the selected tag profile.
-- **Integrations**: Memory (enabled, with multi-select dropdown for memory resources, custom only), MCP Servers (enabled with multi-select dropdown), A2A Agents (enabled with multi-select dropdown, custom only)
+- **Integrations**: Memory (enabled, with multi-select dropdown for memory resources, custom only), MCP Servers (enabled with multi-select dropdown), A2A Agents (enabled with multi-select dropdown, custom only), Code Interpreter (custom only — peer integration section with enable toggle, network mode select (SANDBOX/PUBLIC), region labeled dropdown, and CI execution role selector filtered to `role_type="code_interpreter"` managed roles). JSON import/export uses nested `code_interpreter` key: `{"enabled": true, "region": "us-east-1", "network_mode": "SANDBOX", "role": "loom-ci-role-demo"}`.
 
 ---
 
@@ -316,7 +316,7 @@ Full deployment form with sections:
 
 **Content:**
 - `SecurityAdminPage` with sections for:
-  - **Managed Roles**: list, create (import existing / wizard), view policy document, delete. Uses `SortableCardGrid` with drag-to-reorder (storage key `security-roles`), full-width single-column layout (role cards contain long ARNs and expandable policy documents), default alphabetical sort by role name, and A-Z/Z-A sort toggle.
+  - **Managed Roles**: list, create (import existing / wizard), view policy document, delete. Uses `SortableCardGrid` with drag-to-reorder (storage key `security-roles`), full-width single-column layout (role cards contain long ARNs and expandable policy documents), default alphabetical sort by role name, and A-Z/Z-A sort toggle. Roles are grouped by `role_type` into collapsible sections ("Agent Roles" for `"agent"`, "Code Interpreter Roles" for `"code_interpreter"`). The import form includes a role type selector to set this field on import. `AgentResponse` includes `code_interpreter_id?: string | null` and `code_interpreter_status?: string | null` to surface CI resource status. `ManagedRole` interface includes `role_type: "agent" | "code_interpreter"`.
   - **Authorizer Configs**: list, create (Amazon Cognito, Microsoft Entra ID, Okta, or Other type with auto-populated discovery URL for Cognito), update, delete. Uses `SortableCardGrid` with drag-to-reorder (storage key `security-authorizers`), default alphabetical sort by config name, and A-Z/Z-A sort toggle.
   - **Authorizer Credentials**: per-config credential management (add label + client_id + client_secret, list, delete). Credential form uses 1/4 / 1/4 / 1/2 field widths. Authorizer type displayed as "Amazon Cognito", "Microsoft Entra ID", or "Okta" for known types.
   - **Permission Requests**: create requests for additional IAM permissions, review (approve/deny) with role application. Uses `SortableCardGrid` with drag-to-reorder (storage key `security-permissions`), default alphabetical sort by role name, and A-Z/Z-A sort toggle.

--- a/frontend/src/api/agents.ts
+++ b/frontend/src/api/agents.ts
@@ -125,6 +125,7 @@ export function fetchModels(): Promise<ModelOption[]> {
 export interface LoomDefaults {
   idle_timeout_seconds: number;
   max_lifetime_seconds: number;
+  region: string;
 }
 
 export function fetchDefaults(): Promise<LoomDefaults> {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -42,6 +42,8 @@ export interface AgentResponse {
   harness_id: string | null;
   registry_record_id: string | null;
   registry_status: string | null;
+  code_interpreter_id?: string | null;
+  code_interpreter_status?: string | null;
 }
 
 export interface AgentHarnessDeployRequest {
@@ -106,6 +108,8 @@ export interface AgentDeployRequest {
   a2a_agents: number[];
   code_interpreter_enabled: boolean;
   code_interpreter_region: string;
+  code_interpreter_network_mode: string;
+  code_interpreter_role_id: number | null;
   tags?: Record<string, string>;
 }
 
@@ -337,6 +341,7 @@ export interface ManagedRole {
   id: number;
   role_name: string;
   role_arn: string;
+  role_type: "agent" | "code_interpreter";
   description: string;
   policy_document: PolicyDocument;
   tags: Record<string, string>;
@@ -360,6 +365,7 @@ export interface ManagedRoleCreateRequest {
   mode: "import" | "wizard";
   role_arn?: string;
   role_name?: string;
+  role_type?: "agent" | "code_interpreter";
   description?: string;
   policy_document?: PolicyDocument;
   tags?: Record<string, string>;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -104,6 +104,8 @@ export interface AgentDeployRequest {
   memory_ids: number[];
   mcp_servers: number[];
   a2a_agents: number[];
+  code_interpreter_enabled: boolean;
+  code_interpreter_region: string;
   tags?: Record<string, string>;
 }
 

--- a/frontend/src/components/AgentCard.tsx
+++ b/frontend/src/components/AgentCard.tsx
@@ -46,7 +46,7 @@ function phaseLabel(agent: AgentResponse): string | null {
     case "creating_credentials": return "Creating credential provider";
     case "creating_role": return "Creating IAM role";
     case "building_artifact": return "Building artifact";
-    case "creating_ci_resource": return "Creating Code Interpreter";
+    case "creating_ci_resource": return "Building artifact & creating Code Interpreter";
     case "deploying": return agent.source === "harness" ? "Creating harness" : "Deploying runtime";
     default: break;
   }

--- a/frontend/src/components/AgentCard.tsx
+++ b/frontend/src/components/AgentCard.tsx
@@ -26,6 +26,7 @@ const DEPLOY_IN_PROGRESS = new Set([
   "creating_credentials",
   "creating_role",
   "building_artifact",
+  "creating_ci_resource",
   "deploying",
 ]);
 
@@ -45,6 +46,7 @@ function phaseLabel(agent: AgentResponse): string | null {
     case "creating_credentials": return "Creating credential provider";
     case "creating_role": return "Creating IAM role";
     case "building_artifact": return "Building artifact";
+    case "creating_ci_resource": return "Creating Code Interpreter";
     case "deploying": return agent.source === "harness" ? "Creating harness" : "Deploying runtime";
     default: break;
   }

--- a/frontend/src/components/AgentRegistrationForm.tsx
+++ b/frontend/src/components/AgentRegistrationForm.tsx
@@ -137,6 +137,8 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
   const [selectedMcpServerIds, setSelectedMcpServerIds] = useState<number[]>([]);
   const [selectedA2aAgentIds, setSelectedA2aAgentIds] = useState<number[]>([]);
   const [selectedMemoryIds, setSelectedMemoryIds] = useState<number[]>([]);
+  const [codeInterpreterEnabled, setCodeInterpreterEnabled] = useState(false);
+  const [codeInterpreterRegion, setCodeInterpreterRegion] = useState("");
   const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
   const [a2aAgents, setA2aAgents] = useState<A2aAgent[]>([]);
   const [memories, setMemories] = useState<MemoryResponse[]>([]);
@@ -240,6 +242,8 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
           .filter((id): id is number => id !== undefined);
         setSelectedMemoryIds(ids);
       }
+      if (parsed.code_interpreter != null) setCodeInterpreterEnabled(!!parsed.code_interpreter);
+      if (parsed.code_interpreter_region != null) setCodeInterpreterRegion(parsed.code_interpreter_region as string);
       if (parsed.max_iterations != null) setHarnessMaxIterations(String(parsed.max_iterations));
       if (parsed.max_tokens != null) setHarnessMaxTokens(String(parsed.max_tokens));
       if (parsed.human_confirmation != null) setEnableHumanConfirmation(!!parsed.human_confirmation);
@@ -394,6 +398,8 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
         memory_ids: selectedMemoryIds,
         mcp_servers: selectedMcpServerIds,
         a2a_agents: selectedA2aAgentIds,
+        code_interpreter_enabled: codeInterpreterEnabled,
+        code_interpreter_region: codeInterpreterRegion,
         tags: Object.fromEntries(
           Object.entries(tagValues).filter(([, v]) => v.trim() !== "")
         ),
@@ -415,6 +421,8 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
       setSelectedMcpServerIds([]);
       setSelectedA2aAgentIds([]);
       setSelectedMemoryIds([]);
+      setCodeInterpreterEnabled(false);
+      setCodeInterpreterRegion("");
     }
   };
 
@@ -523,6 +531,8 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                         .filter((id: number | undefined): id is number => id !== undefined);
                       setSelectedMemoryIds(ids);
                     }
+                    if (parsed.code_interpreter != null) setCodeInterpreterEnabled(!!parsed.code_interpreter);
+                    if (parsed.code_interpreter_region != null) setCodeInterpreterRegion(parsed.code_interpreter_region);
                     if (parsed.max_iterations != null) setHarnessMaxIterations(String(parsed.max_iterations));
                     if (parsed.max_tokens != null) setHarnessMaxTokens(String(parsed.max_tokens));
                     if (parsed.human_confirmation != null) setEnableHumanConfirmation(!!parsed.human_confirmation);
@@ -585,9 +595,13 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                       return mem?.name ?? id;
                     });
                   }
+                  if (codeInterpreterEnabled) {
+                    result.code_interpreter = true;
+                    if (codeInterpreterRegion) result.code_interpreter_region = codeInterpreterRegion;
+                  }
                   return JSON.stringify(result, null, 2);
                 }}
-                placeholder='{"deployment_type": "custom|managed", "name": "...", "description": "...", "system_prompt": "...", "model": "... (default)", "allowed_models": ["..."], "network_mode": "PUBLIC", "role": "...", "tags": "...", "authorizer": "...", "max_iterations": 75, "max_tokens": 4096, "human_confirmation": true, "confirmation_policy": "...", "mcp_servers": ["..."], "a2a_agents": ["..."], "memories": ["..."]}'
+                placeholder='{"deployment_type": "custom|managed", "name": "...", "system_prompt": "...", "model": "...", "role": "...", "mcp_servers": ["..."], "a2a_agents": ["..."], "memories": ["..."], "code_interpreter": true, "code_interpreter_region": "us-west-2"}'
               />
 
               {/* Deployment Type Selector */}
@@ -1083,6 +1097,30 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                       </div>
                     )}
                   </div>}
+                  {/* Code Interpreter (Custom Agent only) */}
+                  {deploymentType === "custom" && <div className="space-y-1.5">
+                    <label className="flex items-center gap-2 text-xs cursor-pointer">
+                      <input
+                        type="checkbox"
+                        className="h-3.5 w-3.5"
+                        checked={codeInterpreterEnabled}
+                        onChange={(e) => setCodeInterpreterEnabled(e.target.checked)}
+                      />
+                      <span>Code Interpreter</span>
+                      <span className="text-[10px] text-muted-foreground bg-accent px-1 rounded">Sandbox</span>
+                    </label>
+                    {codeInterpreterEnabled && (
+                      <div className="pl-5 space-y-1">
+                        <label className="text-[10px] text-muted-foreground">Region (optional, defaults to agent region)</label>
+                        <Input
+                          placeholder="e.g. us-west-2"
+                          value={codeInterpreterRegion}
+                          onChange={(e) => setCodeInterpreterRegion(e.target.value)}
+                          className="text-xs h-7"
+                        />
+                      </div>
+                    )}
+                  </div>}
                 </div>
               </section>
 
@@ -1119,6 +1157,8 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                     setSelectedMcpServerIds([]);
                     setSelectedA2aAgentIds([]);
                     setSelectedMemoryIds([]);
+                    setCodeInterpreterEnabled(false);
+                    setCodeInterpreterRegion("");
                   }}
                   disabled={isLoading}
                 >

--- a/frontend/src/components/AgentRegistrationForm.tsx
+++ b/frontend/src/components/AgentRegistrationForm.tsx
@@ -138,7 +138,9 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
   const [selectedA2aAgentIds, setSelectedA2aAgentIds] = useState<number[]>([]);
   const [selectedMemoryIds, setSelectedMemoryIds] = useState<number[]>([]);
   const [codeInterpreterEnabled, setCodeInterpreterEnabled] = useState(false);
-  const [codeInterpreterRegion, setCodeInterpreterRegion] = useState("");
+  const [codeInterpreterRegion, setCodeInterpreterRegion] = useState("us-east-1");
+  const [codeInterpreterNetworkMode, setCodeInterpreterNetworkMode] = useState("SANDBOX");
+  const [codeInterpreterRoleId, setCodeInterpreterRoleId] = useState<string>("");
   const [mcpServers, setMcpServers] = useState<McpServer[]>([]);
   const [a2aAgents, setA2aAgents] = useState<A2aAgent[]>([]);
   const [memories, setMemories] = useState<MemoryResponse[]>([]);
@@ -158,7 +160,7 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
   const [models, setModels] = useState<ModelOption[]>([]);
   const [managedRoles, setManagedRoles] = useState<ManagedRole[]>([]);
   const [authConfigs, setAuthConfigs] = useState<AuthorizerConfigResponse[]>([]);
-  const [defaults, setDefaults] = useState<agentsApi.LoomDefaults>({ idle_timeout_seconds: 300, max_lifetime_seconds: 3600 });
+  const [defaults, setDefaults] = useState<agentsApi.LoomDefaults>({ idle_timeout_seconds: 300, max_lifetime_seconds: 3600, region: "us-east-1" });
 
   const [dataLoaded, setDataLoaded] = useState(false);
   useEffect(() => {
@@ -242,8 +244,20 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
           .filter((id): id is number => id !== undefined);
         setSelectedMemoryIds(ids);
       }
-      if (parsed.code_interpreter != null) setCodeInterpreterEnabled(!!parsed.code_interpreter);
-      if (parsed.code_interpreter_region != null) setCodeInterpreterRegion(parsed.code_interpreter_region as string);
+      if (parsed.code_interpreter != null) {
+        const ci = typeof parsed.code_interpreter === "object" ? parsed.code_interpreter as Record<string, unknown> : null;
+        if (ci) {
+          setCodeInterpreterEnabled(!!ci.enabled);
+          if (ci.region) setCodeInterpreterRegion(ci.region as string);
+          if (ci.network_mode) setCodeInterpreterNetworkMode(ci.network_mode as string);
+          if (ci.role) {
+            const ciRole = managedRoles.find((r) => r.role_name === ci.role || r.role_arn === ci.role);
+            if (ciRole) setCodeInterpreterRoleId(ciRole.id.toString());
+          }
+        } else {
+          setCodeInterpreterEnabled(!!parsed.code_interpreter);
+        }
+      }
       if (parsed.max_iterations != null) setHarnessMaxIterations(String(parsed.max_iterations));
       if (parsed.max_tokens != null) setHarnessMaxTokens(String(parsed.max_tokens));
       if (parsed.human_confirmation != null) setEnableHumanConfirmation(!!parsed.human_confirmation);
@@ -400,6 +414,8 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
         a2a_agents: selectedA2aAgentIds,
         code_interpreter_enabled: codeInterpreterEnabled,
         code_interpreter_region: codeInterpreterRegion,
+        code_interpreter_network_mode: codeInterpreterNetworkMode,
+        code_interpreter_role_id: codeInterpreterRoleId ? parseInt(codeInterpreterRoleId) : null,
         tags: Object.fromEntries(
           Object.entries(tagValues).filter(([, v]) => v.trim() !== "")
         ),
@@ -422,7 +438,9 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
       setSelectedA2aAgentIds([]);
       setSelectedMemoryIds([]);
       setCodeInterpreterEnabled(false);
-      setCodeInterpreterRegion("");
+      setCodeInterpreterRegion("us-east-1");
+      setCodeInterpreterNetworkMode("SANDBOX");
+      setCodeInterpreterRoleId("");
     }
   };
 
@@ -437,9 +455,10 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
   const filteredMemories = groupRestriction
     ? memories.filter((m) => m.tags?.["loom:group"] === groupRestriction)
     : memories;
-  const filteredRoles = groupRestriction
+  const filteredRoles = (groupRestriction
     ? managedRoles.filter((r) => r.tags?.["loom:group"] === groupRestriction)
-    : managedRoles;
+    : managedRoles
+  ).filter((r) => r.role_type !== "code_interpreter");
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
@@ -531,8 +550,20 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                         .filter((id: number | undefined): id is number => id !== undefined);
                       setSelectedMemoryIds(ids);
                     }
-                    if (parsed.code_interpreter != null) setCodeInterpreterEnabled(!!parsed.code_interpreter);
-                    if (parsed.code_interpreter_region != null) setCodeInterpreterRegion(parsed.code_interpreter_region);
+                    if (parsed.code_interpreter != null) {
+                      const ci = typeof parsed.code_interpreter === "object" ? parsed.code_interpreter as Record<string, unknown> : null;
+                      if (ci) {
+                        setCodeInterpreterEnabled(!!ci.enabled);
+                        if (ci.region) setCodeInterpreterRegion(ci.region as string);
+                        if (ci.network_mode) setCodeInterpreterNetworkMode(ci.network_mode as string);
+                        if (ci.role) {
+                          const ciRole = managedRoles.find((r) => r.role_name === ci.role || r.role_arn === ci.role);
+                          if (ciRole) setCodeInterpreterRoleId(ciRole.id.toString());
+                        }
+                      } else {
+                        setCodeInterpreterEnabled(!!parsed.code_interpreter);
+                      }
+                    }
                     if (parsed.max_iterations != null) setHarnessMaxIterations(String(parsed.max_iterations));
                     if (parsed.max_tokens != null) setHarnessMaxTokens(String(parsed.max_tokens));
                     if (parsed.human_confirmation != null) setEnableHumanConfirmation(!!parsed.human_confirmation);
@@ -596,12 +627,20 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                     });
                   }
                   if (codeInterpreterEnabled) {
-                    result.code_interpreter = true;
-                    if (codeInterpreterRegion) result.code_interpreter_region = codeInterpreterRegion;
+                    const ciObj: Record<string, unknown> = {
+                      enabled: true,
+                      region: codeInterpreterRegion || "us-east-1",
+                      network_mode: codeInterpreterNetworkMode,
+                    };
+                    if (codeInterpreterRoleId) {
+                      const ciRole = managedRoles.find((r) => r.id.toString() === codeInterpreterRoleId);
+                      if (ciRole) ciObj.role = ciRole.role_name;
+                    }
+                    result.code_interpreter = ciObj;
                   }
                   return JSON.stringify(result, null, 2);
                 }}
-                placeholder='{"deployment_type": "custom|managed", "name": "...", "system_prompt": "...", "model": "...", "role": "...", "mcp_servers": ["..."], "a2a_agents": ["..."], "memories": ["..."], "code_interpreter": true, "code_interpreter_region": "us-west-2"}'
+                placeholder='{"deployment_type": "custom|managed", "name": "...", "system_prompt": "...", "model": "...", "role": "...", "mcp_servers": ["..."], "a2a_agents": ["..."], "memories": ["..."], "code_interpreter": {"enabled": true, "region": "us-east-1", "network_mode": "SANDBOX", "role": "..."}}'
               />
 
               {/* Deployment Type Selector */}
@@ -984,12 +1023,46 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
               <ResourceTagFields onChange={setTagValues} profileId={selectedTagProfileId} groupRestriction={groupRestriction} ownerRestriction={ownerRestriction} />
 
               {/* Integrations */}
+              {/* Memory Resources (Custom Agent only) */}
+              {deploymentType === "custom" && (
               <section className="space-y-3">
-                <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">{deploymentType === "managed" ? "MCP Servers (Remote MCP Tools)" : "Integrations"}</h4>
+                <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Memory Resources</h4>
+                <div className="space-y-1.5">
+                  {filteredMemories.length === 0 ? (
+                    <p className="text-xs text-muted-foreground italic">No memory resources available{groupRestriction ? " for your group" : ""}. Create one on the Memory page first.</p>
+                  ) : (
+                    <div className="space-y-1">
+                      {filteredMemories.map((mem) => (
+                        <label key={mem.id} className="flex items-center gap-2 text-xs cursor-pointer">
+                          <input
+                            type="checkbox"
+                            className="h-3.5 w-3.5"
+                            checked={selectedMemoryIds.includes(mem.id)}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                setSelectedMemoryIds((prev) => [...prev, mem.id]);
+                              } else {
+                                setSelectedMemoryIds((prev) => prev.filter((id) => id !== mem.id));
+                              }
+                            }}
+                          />
+                          <span>{mem.name}</span>
+                          {mem.status !== "ACTIVE" && (
+                            <span className="text-[10px] text-muted-foreground bg-accent px-1 rounded">{mem.status}</span>
+                          )}
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </section>
+              )}
+
+              {/* MCP Servers */}
+              <section className="space-y-3">
+                <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">MCP Servers{deploymentType === "managed" ? " (Remote MCP Tools)" : ""}</h4>
                 <div className="space-y-3">
-                  {/* MCP Servers */}
                   <div className="space-y-1.5">
-                    <label className="text-xs text-muted-foreground">MCP Servers</label>
                     {filteredMcpServers.length === 0 ? (
                       <p className="text-xs text-muted-foreground italic">No MCP servers available. Register servers on the MCP Servers page first.</p>
                     ) : (
@@ -1027,102 +1100,103 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                       </div>
                     )}
                   </div>
-                  {/* A2A Agents (Custom Agent only) */}
-                  {deploymentType === "custom" && <div className="space-y-1.5">
-                    <label className="text-xs text-muted-foreground">A2A Agents</label>
-                    {filteredA2aAgents.length === 0 ? (
-                      <p className="text-xs text-muted-foreground italic">No A2A agents available. Register agents on the A2A Agents page first.</p>
-                    ) : (
-                      <div className="space-y-1">
-                        {filteredA2aAgents.map((agent) => (
-                          <label key={agent.id} className="flex items-center gap-2 text-xs cursor-pointer min-w-0">
-                            <input
-                              type="checkbox"
-                              className="h-3.5 w-3.5 shrink-0"
-                              checked={selectedA2aAgentIds.includes(agent.id)}
-                              onChange={(e) => {
-                                if (e.target.checked) {
-                                  setSelectedA2aAgentIds((prev) => [...prev, agent.id]);
-                                } else {
-                                  setSelectedA2aAgentIds((prev) => prev.filter((id) => id !== agent.id));
-                                }
-                              }}
-                            />
-                            <span className="shrink-0">{agent.name}</span>
-                            {agent.auth_type === "oauth2" && (
-                              <span className="text-[10px] text-muted-foreground bg-accent px-1 rounded shrink-0">OAuth2</span>
-                            )}
-                            {agent.auth_type === "oauth2" && agent.delegation_mode === "obo" && (
-                              <span className="text-[10px] text-blue-700 dark:text-blue-300 bg-blue-100 dark:bg-blue-950 px-1 rounded shrink-0">OBO</span>
-                            )}
-                            {agent.auth_type === "oauth2" && agent.delegation_mode !== "obo" && (
-                              <span className="text-[10px] text-muted-foreground bg-accent px-1 rounded shrink-0">M2M</span>
-                            )}
-                            <span className="relative group text-muted-foreground/60 shrink-0">
-                              {(() => { try { return new URL(agent.base_url).host; } catch { return agent.base_url; } })()}
-                              <span className="absolute left-0 top-full mt-1 z-50 hidden group-hover:block text-[10px] text-foreground bg-popover border border-border px-2 py-1 rounded shadow-md whitespace-nowrap">{agent.base_url}</span>
-                            </span>
-                          </label>
-                        ))}
-                      </div>
-                    )}
-                  </div>}
-                  {/* Memory Resources (Custom Agent only) */}
-                  {deploymentType === "custom" && <div className="space-y-1.5">
-                    <label className="text-xs text-muted-foreground">Memory Resources</label>
-                    {filteredMemories.length === 0 ? (
-                      <p className="text-xs text-muted-foreground italic">No memory resources available{groupRestriction ? " for your group" : ""}. Create one on the Memory page first.</p>
-                    ) : (
-                      <div className="space-y-1">
-                        {filteredMemories.map((mem) => (
-                          <label key={mem.id} className="flex items-center gap-2 text-xs cursor-pointer">
-                            <input
-                              type="checkbox"
-                              className="h-3.5 w-3.5"
-                              checked={selectedMemoryIds.includes(mem.id)}
-                              onChange={(e) => {
-                                if (e.target.checked) {
-                                  setSelectedMemoryIds((prev) => [...prev, mem.id]);
-                                } else {
-                                  setSelectedMemoryIds((prev) => prev.filter((id) => id !== mem.id));
-                                }
-                              }}
-                            />
-                            <span>{mem.name}</span>
-                            {mem.status !== "ACTIVE" && (
-                              <span className="text-[10px] text-muted-foreground bg-accent px-1 rounded">{mem.status}</span>
-                            )}
-                          </label>
-                        ))}
-                      </div>
-                    )}
-                  </div>}
-                  {/* Code Interpreter (Custom Agent only) */}
-                  {deploymentType === "custom" && <div className="space-y-1.5">
-                    <label className="flex items-center gap-2 text-xs cursor-pointer">
-                      <input
-                        type="checkbox"
-                        className="h-3.5 w-3.5"
-                        checked={codeInterpreterEnabled}
-                        onChange={(e) => setCodeInterpreterEnabled(e.target.checked)}
-                      />
-                      <span>Code Interpreter</span>
-                      <span className="text-[10px] text-muted-foreground bg-accent px-1 rounded">Sandbox</span>
-                    </label>
-                    {codeInterpreterEnabled && (
-                      <div className="pl-5 space-y-1">
-                        <label className="text-[10px] text-muted-foreground">Region (optional, defaults to agent region)</label>
-                        <Input
-                          placeholder="e.g. us-west-2"
-                          value={codeInterpreterRegion}
-                          onChange={(e) => setCodeInterpreterRegion(e.target.value)}
-                          className="text-xs h-7"
-                        />
-                      </div>
-                    )}
-                  </div>}
                 </div>
               </section>
+
+              {/* A2A Agents (Custom Agent only) */}
+              {deploymentType === "custom" && (
+              <section className="space-y-3">
+                <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">A2A Agents</h4>
+                <div className="space-y-1.5">
+                  {filteredA2aAgents.length === 0 ? (
+                    <p className="text-xs text-muted-foreground italic">No A2A agents available. Register agents on the A2A Agents page first.</p>
+                  ) : (
+                    <div className="space-y-1">
+                      {filteredA2aAgents.map((agent) => (
+                        <label key={agent.id} className="flex items-center gap-2 text-xs cursor-pointer min-w-0">
+                          <input
+                            type="checkbox"
+                            className="h-3.5 w-3.5 shrink-0"
+                            checked={selectedA2aAgentIds.includes(agent.id)}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                setSelectedA2aAgentIds((prev) => [...prev, agent.id]);
+                              } else {
+                                setSelectedA2aAgentIds((prev) => prev.filter((id) => id !== agent.id));
+                              }
+                            }}
+                          />
+                          <span className="shrink-0">{agent.name}</span>
+                          {agent.auth_type === "oauth2" && (
+                            <span className="text-[10px] text-muted-foreground bg-accent px-1 rounded shrink-0">OAuth2</span>
+                          )}
+                          {agent.auth_type === "oauth2" && agent.delegation_mode === "obo" && (
+                            <span className="text-[10px] text-blue-700 dark:text-blue-300 bg-blue-100 dark:bg-blue-950 px-1 rounded shrink-0">OBO</span>
+                          )}
+                          {agent.auth_type === "oauth2" && agent.delegation_mode !== "obo" && (
+                            <span className="text-[10px] text-muted-foreground bg-accent px-1 rounded shrink-0">M2M</span>
+                          )}
+                          <span className="relative group text-muted-foreground/60 shrink-0">
+                            {(() => { try { return new URL(agent.base_url).host; } catch { return agent.base_url; } })()}
+                            <span className="absolute left-0 top-full mt-1 z-50 hidden group-hover:block text-[10px] text-foreground bg-popover border border-border px-2 py-1 rounded shadow-md whitespace-nowrap">{agent.base_url}</span>
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </section>
+              )}
+
+              {/* Code Interpreter (Custom Agent only) */}
+              {deploymentType === "custom" && (
+              <section className="space-y-3">
+                <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Code Interpreter</h4>
+                <label className="flex items-center gap-2 text-xs cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="h-3.5 w-3.5"
+                    checked={codeInterpreterEnabled}
+                    onChange={(e) => setCodeInterpreterEnabled(e.target.checked)}
+                  />
+                  <span>Enable</span>
+                </label>
+                {codeInterpreterEnabled && (
+                  <div className="flex items-center gap-2">
+                    <Select value={codeInterpreterNetworkMode} onValueChange={setCodeInterpreterNetworkMode}>
+                      <SelectTrigger className="text-sm w-36 shrink-0">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="SANDBOX">Sandbox</SelectItem>
+                        <SelectItem value="PUBLIC">Public</SelectItem>
+                        <SelectItem value="VPC" disabled>VPC (coming soon)</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <Select value={codeInterpreterRegion} onValueChange={setCodeInterpreterRegion}>
+                      <SelectTrigger className="text-sm w-52 shrink-0">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="us-east-1">us-east-1 — N. Virginia</SelectItem>
+                        <SelectItem value="us-west-2">us-west-2 — Oregon</SelectItem>
+                        <SelectItem value="eu-west-1">eu-west-1 — Ireland</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <SearchableSelect
+                      className="flex-1 min-w-0"
+                      options={managedRoles.filter((r) => r.role_type === "code_interpreter").map((r) => ({
+                        value: r.id.toString(),
+                        label: r.role_name,
+                      }))}
+                      value={codeInterpreterRoleId}
+                      onValueChange={setCodeInterpreterRoleId}
+                      placeholder="Execution role (optional)"
+                    />
+                  </div>
+                )}
+              </section>
+              )}
 
               <div className="space-y-1.5">
               <p className="text-[10px] text-muted-foreground italic">
@@ -1158,7 +1232,9 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                     setSelectedA2aAgentIds([]);
                     setSelectedMemoryIds([]);
                     setCodeInterpreterEnabled(false);
-                    setCodeInterpreterRegion("");
+                    setCodeInterpreterRegion("us-east-1");
+                    setCodeInterpreterNetworkMode("SANDBOX");
+                    setCodeInterpreterRoleId("");
                   }}
                   disabled={isLoading}
                 >

--- a/frontend/src/components/DeploymentPanel.tsx
+++ b/frontend/src/components/DeploymentPanel.tsx
@@ -20,6 +20,7 @@ const DEPLOY_IN_PROGRESS = new Set([
   "creating_credentials",
   "creating_role",
   "building_artifact",
+  "creating_ci_resource",
   "deploying",
   "ENDPOINT_CREATING",
 ]);
@@ -187,6 +188,15 @@ export function DeploymentPanel({ agent, onPatchAgent }: DeploymentPanelProps) {
         </div>
         {agent.source !== "harness" && <div>Protocol: {agent.protocol ?? "—"}</div>}
         <div>Network: {agent.network_mode ?? "—"}</div>
+        {agent.code_interpreter_id && (
+          <div className="flex items-center gap-1.5">
+            <span>Code Interpreter:</span>
+            <Badge variant={statusVariant(agent.code_interpreter_status ?? null)} className="text-[10px] px-1.5 py-0">
+              {agent.code_interpreter_status ?? "UNKNOWN"}
+            </Badge>
+            <span className="text-[10px] text-muted-foreground/60 font-mono truncate">{agent.code_interpreter_id}</span>
+          </div>
+        )}
         <div className="truncate">Execution Role: {agent.execution_role_arn ?? "—"}</div>
         {agent.deployed_at && (
           <div>Deployed: {formatTimestamp(agent.deployed_at, timezone)}</div>

--- a/frontend/src/components/RoleManagementPanel.tsx
+++ b/frontend/src/components/RoleManagementPanel.tsx
@@ -6,6 +6,13 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PolicyViewer } from "@/components/PolicyViewer";
 import { SearchableSelect } from "@/components/ui/searchable-select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { SortableCardGrid, SortButton, loadSortDirection, toggleSortDirection, saveSortDirection, type SortDirection } from "@/components/SortableCardGrid";
 import { useManagedRoles } from "@/hooks/useSecurity";
 import { ChevronDown, ChevronRight, Trash2, Plus } from "lucide-react";
@@ -20,12 +27,22 @@ export function RoleManagementPanel({ readOnly }: { readOnly?: boolean }) {
   const { roles, loading, error, createRole, deleteRole } = useManagedRoles();
   const [showAddForm, setShowAddForm] = useState(false);
   const [importArn, setImportArn] = useState("");
+  const [importRoleType, setImportRoleType] = useState<"agent" | "code_interpreter">("agent");
   const [tagProfiles, setTagProfiles] = useState<TagProfile[]>([]);
   const [selectedProfileId, setSelectedProfileId] = useState<string>("");
   const [expandedRoleId, setExpandedRoleId] = useState<number | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
   const [sortDir, setSortDir] = useState<SortDirection>(() => loadSortDirection("security-roles"));
+  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
+
+  const toggleSection = (key: string) => {
+    setCollapsedSections(prev => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+  };
 
   useEffect(() => {
     void settingsApi.listTagProfiles().then(setTagProfiles).catch(() => {});
@@ -38,8 +55,9 @@ export function RoleManagementPanel({ readOnly }: { readOnly?: boolean }) {
       const profile = tagProfiles.find((p) => p.id.toString() === selectedProfileId);
       const tags = profile?.tags ?? {};
       if (user && browserSessionId) trackAction(user.username ?? user.sub, browserSessionId, 'security', 'add_role', importArn.trim());
-      await createRole({ mode: "import", role_arn: importArn.trim(), tags });
+      await createRole({ mode: "import", role_arn: importArn.trim(), role_type: importRoleType, tags });
       setImportArn("");
+      setImportRoleType("agent");
       setSelectedProfileId("");
       setShowAddForm(false);
       toast.success("Role added");
@@ -101,16 +119,26 @@ export function RoleManagementPanel({ readOnly }: { readOnly?: boolean }) {
                 placeholder="arn:aws:iam::123456789012:role/my-role"
                 value={importArn}
                 onChange={(e) => setImportArn(e.target.value)}
-                className="flex-1"
+                className="basis-3/5 min-w-0"
               />
-              <div className="w-48 shrink-0">
-                <SearchableSelect
-                  options={tagProfiles.map((p) => ({ value: p.id.toString(), label: p.name }))}
-                  value={selectedProfileId}
-                  onValueChange={setSelectedProfileId}
-                  placeholder="Tag profile (required)"
-                />
+              <div className="basis-1/5 min-w-0 flex">
+                <Select value={importRoleType} onValueChange={(v) => setImportRoleType(v as "agent" | "code_interpreter")}>
+                  <SelectTrigger className="h-9 text-sm w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="agent">Agent Role</SelectItem>
+                    <SelectItem value="code_interpreter">Code Interpreter Role</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
+              <SearchableSelect
+                className="basis-1/5 min-w-0"
+                options={tagProfiles.map((p) => ({ value: p.id.toString(), label: p.name }))}
+                value={selectedProfileId}
+                onValueChange={setSelectedProfileId}
+                placeholder="Tag profile (required)"
+              />
               <Button size="sm" onClick={handleCreate} disabled={submitting || !importArn.trim() || !selectedProfileId}>
                 {submitting ? "Importing..." : "Import"}
               </Button>
@@ -122,81 +150,108 @@ export function RoleManagementPanel({ readOnly }: { readOnly?: boolean }) {
       {roles.length === 0 ? (
         <p className="text-sm text-muted-foreground py-8">No managed roles yet. Add one above.</p>
       ) : (
-        <SortableCardGrid
-          items={roles}
-          getId={(r) => r.id.toString()}
-          getName={(r) => r.role_name}
-          storageKey="security-roles"
-          sortDirection={sortDir}
-          onSortDirectionChange={(d) => { if (d) { setSortDir(d); saveSortDirection("security-roles", d); } }}
-          className="grid gap-2"
-          renderItem={(role) => (
-            <Card className="relative py-3 gap-1 transition-colors hover:bg-accent/50">
-              <CardHeader className="gap-1 pb-2">
-                <div className="flex items-center justify-between gap-2">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <button
-                      type="button"
-                      onClick={() => setExpandedRoleId(expandedRoleId === role.id ? null : role.id)}
-                      className="text-muted-foreground hover:text-foreground"
-                    >
-                      {expandedRoleId === role.id ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
-                    </button>
-                    <div className="min-w-0">
-                      <div className="text-sm font-medium truncate">{role.role_name}</div>
-                      <div className="text-xs text-muted-foreground truncate">{role.role_arn}</div>
-                    </div>
-                  </div>
-                  {!readOnly && (
-                    <div className="flex items-center gap-1 shrink-0">
-                      <button
-                        type="button"
-                        onClick={() => setConfirmDeleteId(role.id)}
-                        className="text-muted-foreground/50 hover:text-destructive transition-colors"
-                        title="Delete"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
-                    </div>
+        <div className="space-y-4">
+          {(["agent", "code_interpreter"] as const).map((type) => {
+            const group = roles.filter((r) => (r.role_type ?? "agent") === type);
+            if (group.length === 0) return null;
+            const sectionKey = `roles-${type}`;
+            const collapsed = collapsedSections.has(sectionKey);
+            const label = type === "agent" ? "Agent Roles" : "Code Interpreter Roles";
+            return (
+              <section key={type} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <button
+                    type="button"
+                    className="flex items-center gap-1 text-sm font-medium hover:text-foreground/80"
+                    onClick={() => toggleSection(sectionKey)}
+                  >
+                    {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+                    {label}
+                    <span className="ml-1 inline-flex items-center justify-center rounded-full bg-white text-foreground border text-[10px] font-normal px-1.5 min-w-[1.25rem] h-4">
+                      {group.length}
+                    </span>
+                  </button>
+                  {!collapsed && (
+                    <SortButton direction={sortDir} onClick={() => setSortDir(toggleSortDirection("security-roles", sortDir))} />
                   )}
                 </div>
-              </CardHeader>
-              <CardContent className="space-y-2">
-                {role.tags && Object.keys(role.tags).length > 0 && (
-                  <div className="flex flex-wrap gap-1 ml-6">
-                    {Object.entries(role.tags).map(([key, value]) => (
-                      <Badge key={key} variant="outline" className="text-[10px] px-1.5 py-0 font-normal">
-                        {key.replace(/^loom:/, "")}: {value}
-                      </Badge>
-                    ))}
-                  </div>
+                {!collapsed && (
+                  <SortableCardGrid
+                    items={group}
+                    getId={(r) => r.id.toString()}
+                    getName={(r) => r.role_name}
+                    storageKey={`security-roles-${type}`}
+                    sortDirection={sortDir}
+                    onSortDirectionChange={(d) => { if (d) { setSortDir(d); saveSortDirection("security-roles", d); } }}
+                    className="grid gap-2"
+                    renderItem={(role) => (
+                      <Card className="relative py-3 gap-1 transition-colors hover:bg-accent/50">
+                        <CardHeader className="gap-1 pb-2">
+                          <div className="flex items-center justify-between gap-2">
+                            <div className="flex items-center gap-2 min-w-0">
+                              <button
+                                type="button"
+                                onClick={() => setExpandedRoleId(expandedRoleId === role.id ? null : role.id)}
+                                className="text-muted-foreground hover:text-foreground"
+                              >
+                                {expandedRoleId === role.id ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+                              </button>
+                              <div className="min-w-0">
+                                <div className="text-sm font-medium truncate">{role.role_name}</div>
+                                <div className="text-xs text-muted-foreground truncate">{role.role_arn}</div>
+                              </div>
+                            </div>
+                            {!readOnly && (
+                              <div className="flex items-center gap-1 shrink-0">
+                                <button
+                                  type="button"
+                                  onClick={() => setConfirmDeleteId(role.id)}
+                                  className="text-muted-foreground/50 hover:text-destructive transition-colors"
+                                  title="Delete"
+                                >
+                                  <Trash2 className="h-3.5 w-3.5" />
+                                </button>
+                              </div>
+                            )}
+                          </div>
+                        </CardHeader>
+                        <CardContent className="space-y-2">
+                          {role.tags && Object.keys(role.tags).length > 0 && (
+                            <div className="flex flex-wrap gap-1 ml-6">
+                              {Object.entries(role.tags).map(([key, value]) => (
+                                <Badge key={key} variant="outline" className="text-[10px] px-1.5 py-0 font-normal">
+                                  {key.replace(/^loom:/, "")}: {value}
+                                </Badge>
+                              ))}
+                            </div>
+                          )}
+                          {role.description && (
+                            <div className="text-xs text-muted-foreground truncate">{role.description}</div>
+                          )}
+                          {confirmDeleteId === role.id && (
+                            <div className="flex items-center justify-end gap-2 pt-1">
+                              <Button size="sm" variant="ghost" className="h-6 text-xs" onClick={() => setConfirmDeleteId(null)}>
+                                Cancel
+                              </Button>
+                              <Button size="sm" variant="destructive" className="h-6 text-xs" onClick={() => handleDelete(role.id)} disabled={submitting}>
+                                Confirm
+                              </Button>
+                            </div>
+                          )}
+                          {expandedRoleId === role.id && (
+                            <div className="pl-6">
+                              <PolicyViewer policy={role.policy_document} />
+                            </div>
+                          )}
+                        </CardContent>
+                      </Card>
+                    )}
+                  />
                 )}
-                {role.description && (
-                  <div className="text-xs text-muted-foreground truncate">
-                    {role.description}
-                  </div>
-                )}
-
-                {confirmDeleteId === role.id && (
-                  <div className="flex items-center justify-end gap-2 pt-1">
-                    <Button size="sm" variant="ghost" className="h-6 text-xs" onClick={() => setConfirmDeleteId(null)}>
-                      Cancel
-                    </Button>
-                    <Button size="sm" variant="destructive" className="h-6 text-xs" onClick={() => handleDelete(role.id)} disabled={submitting}>
-                      Confirm
-                    </Button>
-                  </div>
-                )}
-
-                {expandedRoleId === role.id && (
-                  <div className="pl-6">
-                    <PolicyViewer policy={role.policy_document} />
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          )}
-        />
+              </section>
+            );
+          })}
+        </div>
       )}
     </div>
   );

--- a/shared/iac/code_interpreter_role.yaml
+++ b/shared/iac/code_interpreter_role.yaml
@@ -1,0 +1,72 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: IAM execution role for Bedrock AgentCore Code Interpreter sandboxes
+
+Parameters:
+  pRoleSuffix:
+    Type: String
+    Description: Sanitized agent name (underscores replaced with hyphens) for role naming
+  pCodeInterpreterRegions:
+    Type: String
+    Description: Region pattern for Code Interpreter resources (e.g. us-east-1 or *)
+    Default: "*"
+  pTagApplication:
+    Type: String
+    Description: Value for the loom:application tag
+  pTagGroup:
+    Type: String
+    Description: Value for the loom:group tag
+  pTagOwner:
+    Type: String
+    Description: Value for the loom:owner tag
+
+Resources:
+  CodeInterpreterRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "loom-ci-role-${pRoleSuffix}"
+      Tags:
+        - Key: "loom:application"
+          Value: !Ref pTagApplication
+        - Key: "loom:group"
+          Value: !Ref pTagGroup
+        - Key: "loom:owner"
+          Value: !Ref pTagOwner
+        - Key: "loom:role_type"
+          Value: "code_interpreter"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: bedrock-agentcore.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+      Path: "/"
+      Policies:
+        - PolicyName: code-interpreter-sandbox
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource: !Sub "arn:aws:s3:::bedrock-agentcore-${AWS::AccountId}-${pCodeInterpreterRegions}-code-interpreter/*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub "arn:aws:logs:${pCodeInterpreterRegions}:${AWS::AccountId}:log-group:/aws/bedrock-agentcore/code-interpreter*"
+
+Outputs:
+  oCodeInterpreterRole:
+    Description: Code Interpreter IAM role name
+    Value: !Ref CodeInterpreterRole
+  oCodeInterpreterRoleArn:
+    Description: Code Interpreter IAM role ARN
+    Value: !GetAtt CodeInterpreterRole.Arn

--- a/shared/iac/role.yaml
+++ b/shared/iac/role.yaml
@@ -25,6 +25,13 @@ Parameters:
     Type: String
     Description: ARN of an AgentCore Memory resource to grant access to (leave empty to skip memory policy)
     Default: ""
+  pEnableCodeInterpreter:
+    Type: String
+    Description: Set to "true" to include Code Interpreter sandbox permissions
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
   pTagApplication:
     Type: String
     Description: Value for the loom:application tag
@@ -37,6 +44,7 @@ Parameters:
 
 Conditions:
   IncludeMemoryPolicy: !Not [!Equals [!Ref pMemoryArn, ""]]
+  IncludeCodeInterpreterPolicy: !Equals [!Ref pEnableCodeInterpreter, "true"]
 
 Resources:
   AgentRole:
@@ -132,6 +140,28 @@ Resources:
                     - bedrock-agentcore:ListSessions
                     - bedrock-agentcore:RetrieveMemoryRecords
                   Resource: !Ref pMemoryArn
+          - !Ref AWS::NoValue
+        - !If
+          - IncludeCodeInterpreterPolicy
+          - PolicyName: code-interpreter
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - bedrock-agentcore:CreateCodeInterpreter
+                    - bedrock-agentcore:DeleteCodeInterpreter
+                    - bedrock-agentcore:GetCodeInterpreter
+                    - bedrock-agentcore:ListCodeInterpreters
+                    - bedrock-agentcore:StartCodeInterpreterSession
+                    - bedrock-agentcore:StopCodeInterpreterSession
+                    - bedrock-agentcore:InvokeCodeInterpreter
+                    - bedrock-agentcore:GetCodeInterpreterSession
+                    - bedrock-agentcore:ListCodeInterpreterSessions
+                  Resource:
+                    - !Sub "arn:aws:bedrock-agentcore:${pAgentCoreRegions}:aws:code-interpreter/*"
+                    - !Sub "arn:aws:bedrock-agentcore:${pAgentCoreRegions}:${AWS::AccountId}:code-interpreter/*"
+                    - !Sub "arn:aws:bedrock-agentcore:${pAgentCoreRegions}:${AWS::AccountId}:code-interpreter-custom/*"
           - !Ref AWS::NoValue
 
 Outputs:

--- a/shared/makefile
+++ b/shared/makefile
@@ -26,6 +26,7 @@ role.deploy:
 			pAgentCoreRegions=$(P_AGENTCORE_REGIONS) \
 			pLogsRegion=$(P_LOGS_REGION) \
 			pMemoryArn=${P_MEMORY_ARN} \
+			pEnableCodeInterpreter=$(P_ENABLE_CODE_INTERPRETER) \
 			pTagApplication=$(P_TAG_APPLICATION) \
 			pTagGroup=$(P_TAG_GROUP) \
 			pTagOwner=$(P_TAG_OWNER) \
@@ -37,6 +38,41 @@ role.delete:
 		--profile $(PROFILE) \
 		--region $(REGION) \
 		--stack-name $(P_ROLE_STACK) \
+		--no-prompts
+
+# code interpreter role
+ci-role: ci-role.package ci-role.deploy
+ci-role.package:
+	sam package \
+		--profile $(PROFILE) \
+		--region $(REGION) \
+		--template-file $(P_CI_ROLE_TEMPLATE) \
+		--output-template-file $(P_CI_ROLE_OUTPUT) \
+		--s3-bucket $(BUCKET) \
+		--s3-prefix $(P_CI_ROLE_STACK)
+
+ci-role.deploy:
+	sam deploy \
+		--profile $(PROFILE) \
+		--region $(REGION) \
+		--template-file $(P_CI_ROLE_OUTPUT) \
+		--stack-name $(P_CI_ROLE_STACK) \
+		--s3-bucket $(BUCKET) \
+		--s3-prefix $(P_CI_ROLE_STACK) \
+		--parameter-overrides \
+			pRoleSuffix=$(P_AGENT_NAME_SANITIZED) \
+			pCodeInterpreterRegions=$(P_CI_REGIONS) \
+			pTagApplication=$(P_TAG_APPLICATION) \
+			pTagGroup=$(P_TAG_GROUP) \
+			pTagOwner=$(P_TAG_OWNER) \
+		--capabilities CAPABILITY_NAMED_IAM \
+		--no-confirm-changeset
+
+ci-role.delete:
+	sam delete \
+		--profile $(PROFILE) \
+		--region $(REGION) \
+		--stack-name $(P_CI_ROLE_STACK) \
 		--no-prompts
 
 # cognito


### PR DESCRIPTION
## Summary
- Add Code Interpreter as a configurable integration for custom agents, backed by AWS Bedrock AgentCore's managed sandbox
- Provision a custom Code Interpreter resource in parallel with the runtime artifact build, using a dedicated CI execution role; surface status via `code_interpreter_status` polling
- Enable X-Ray tracing on all runtime deployments via OTEL env vars; wire CloudWatch vended log delivery for custom CI resources
- Harden CI lifecycle: terminate active sessions before deleting the CI resource on agent deletion; fix IAM policies to cover both system (`aws:code-interpreter/*`) and customer-owned (`account:code-interpreter-custom/*`) ARN patterns

## Test Plan
- Deploy an agent with Code Interpreter enabled and a CI execution role selected; verify `creating_ci_resource` phase label and that the CI resource appears in the AWS console
- Prompt the agent to perform a calculation; confirm Code Interpreter is invoked rather than pure LLM reasoning
- Delete the agent with an active CI session; verify sessions are terminated and the CI resource is removed
- Verify CloudWatch log deliveries are created for the CI resource under `/aws/vendedlogs/bedrock-agentcore/code-interpreter/`
- Verify X-Ray traces appear for runtime invocations

Closes #93

Co-Authored-By: Claude <noreply@anthropic.com>