### PR TITLE
feat: VPC-enabled agents with PrivateLink ingress support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Loom seamlessly weaves together agents, memory stores, MCP servers, and agent-to
 ### Agent Lifecycle
 - Deploy new agents or import existing AgentCore Runtime agents
 - Deploy managed agents via AgentCore Harness (no code required) with configurable model parameters, built-in tools (code interpreter, browser), and MCP server integration
+- **VPC-enabled agents:** deploy both custom and managed agents with VPC egress — configure subnets and security groups via named VPC config profiles for private access to VPC-internal resources
+- **PrivateLink ingress:** IaC template (`shared/iac/privatelink.yaml`) provisions an NLB and VPC Endpoint Service for invoking agents from within a VPC
 - SSE streaming invocation with real-time response display
 - Progressive deployment status tracking and async deletion
 - Cold-start latency measurement via CloudWatch log parsing

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -653,6 +653,21 @@ Agents support runtime model selection, allowing users to choose from a set of a
 - **Status polling:** CI status is surfaced via `code_interpreter_status` on `AgentResponse`. CI polling is skipped when the agent is in `DELETING` state. `ResourceNotFoundException` during CI poll is logged at DEBUG (expected post-deletion).
 - **Deployment phase label:** `creating_ci_resource` displays as "Building artifact & creating Code Interpreter" to reflect the parallel nature of the two operations.
 
+### Phase 31 — VPC-Enabled Agents *(Complete)*
+- **VPC configuration model:** `VpcConfig` ORM model with `name`, `vpc_id`, `subnet_ids` (JSON array), and `security_group_ids` (JSON array). Full CRUD API under `/api/vpc-configs`. Stored in the `vpc_configs` table; referenced by agents via `vpc_config_id` (INTEGER FK).
+- **VPC egress for deploy-type agents:** `AgentDeployRequest` accepts `network_mode` (`PUBLIC` or `VPC`) and `vpc_config_id`. When `network_mode=VPC`, the runtime is created with `networkConfiguration.networkMode=VPC` and the resolved subnet/SG IDs. `vpc_config_id` is persisted on the `Agent` record and included in `AgentResponse` for export/edit round-trips.
+- **VPC egress for harness agents:** `AgentHarnessDeployRequest` accepts `network_mode` and `vpc_config_id`. `create_harness` / `update_harness` accept optional `vpc_subnet_ids` and `vpc_security_group_ids` parameters passed through to the AgentCore Harness API when `network_mode=VPC`. `vpc_config_id` is persisted on the `Agent` record at harness creation time.
+- **PrivateLink ingress IaC:** `shared/iac/privatelink.yaml` SAM template creates the NLB, VPC Endpoint Service, and required security groups for PrivateLink-based agent invocation. Makefile targets: `privatelink`, `privatelink.delete`, `privatelink.describe`.
+- **Frontend VPC selector:** Network mode radio (PUBLIC/VPC) in the deploy form expands to show a VPC Config dropdown when VPC is selected. On agent edit, the previously-selected VPC config is pre-populated using a `useRef`-deferred effect that resolves the config name after the `vpcConfigs` list loads.
+- **Harness refinements (same branch):**
+  - All MCP tools (including OAuth2-authenticated) are included in the harness tool list; OAuth2 tokens are injected at invocation time via `remoteMcp.headers`.
+  - `actor_id` sanitized with regex `[^a-zA-Z0-9:_/\-] → _` to handle Okta email-format subs that contain `@` and `.`.
+  - Code Interpreter `ConflictException` handled by reusing existing CI resource by name (`list_code_interpreters` scan); orphaned CI resource deleted when harness is deleted.
+  - Memory `retrievalConfig` built from active strategies (`strategy.status == "ACTIVE"`) using `strategyId` as key; `get_memory` response unwrapped from nested `"memory"` key.
+  - `bedrock-agentcore:ListEvents` added to the memory policy in `shared/iac/role.yaml`.
+  - Harness `ConflictException` on create resolved by pre-deleting the existing harness with the same name before calling `create_harness`.
+  - Registry auto-registration for harness agents: harness status polling now includes the same auto-registration block as custom deploy-type agents — when deployment reaches READY and no `registry_record_id` exists, a DRAFT registry record is created.
+
 ### Phase 30 — Advanced Operations
 - Real-time metrics auto-refresh.
 - Multi-agent comparison views.

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -144,6 +144,10 @@ def _migrate_add_columns(eng) -> None:
         ("mcp_servers", "oauth2_audience", "VARCHAR"),
         ("managed_roles", "role_type", "VARCHAR DEFAULT 'agent'"),
         ("agents", "code_interpreter_id", "VARCHAR"),
+        ("agents", "vpc_subnet_ids", "TEXT"),
+        ("agents", "vpc_security_group_ids", "TEXT"),
+        ("agents", "vpc_config_id", "INTEGER"),
+        ("agents", "status_reason", "TEXT"),
     ]
 
     is_postgres = eng.dialect.name == "postgresql"

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -114,8 +114,16 @@ class UserInfo:
 
     @property
     def actor_id(self) -> str:
-        """Return a provider:sub formatted actor ID safe for AWS APIs."""
-        return f"{self.idp_type}:{self.sub}" if self.sub else "loom-agent"
+        """Return a provider:sub formatted actor ID safe for AWS APIs.
+
+        AWS requires: [a-zA-Z0-9][a-zA-Z0-9-_/]*(?::[a-zA-Z0-9-_/]+)*
+        Characters outside that set (e.g. '@', '.') are replaced with '_'.
+        """
+        import re as _re
+        if not self.sub:
+            return "loom-agent"
+        raw = f"{self.idp_type}:{self.sub}"
+        return _re.sub(r"[^a-zA-Z0-9:_/\-]", "_", raw)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -17,6 +17,7 @@ from app.models.site_setting import SiteSetting
 from app.models.audit import AuditLogin, AuditAction, AuditPageView
 from app.models.approval_policy import ApprovalPolicy
 from app.models.approval_log import ApprovalLog
+from app.models.vpc_config import VpcConfig
 
 __all__ = [
     "Agent", "InvocationSession", "Invocation", "ConfigEntry",
@@ -25,5 +26,5 @@ __all__ = [
     "AuthorizerCredential", "Memory", "TagPolicy", "TagProfile",
     "McpServer", "McpTool", "McpServerAccess", "SiteSetting",
     "AuditLogin", "AuditAction", "AuditPageView",
-    "ApprovalPolicy", "ApprovalLog",
+    "ApprovalPolicy", "ApprovalLog", "VpcConfig",
 ]

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -52,6 +52,8 @@ class Agent(Base):
     allowed_model_ids = Column(Text, nullable=True)  # JSON array of allowed model IDs
     harness_id = Column(String, nullable=True)  # Harness ID for managed agent deployments
     code_interpreter_id = Column(String, nullable=True)
+    vpc_subnet_ids = Column(Text, nullable=True)      # JSON array of subnet IDs for VPC network mode
+    vpc_security_group_ids = Column(Text, nullable=True)  # JSON array of security group IDs for VPC network mode
 
     # Relationships
     sessions = relationship("InvocationSession", back_populates="agent", cascade="all, delete-orphan")
@@ -124,6 +126,32 @@ class Agent(Base):
         """Serialize authorizer_config to JSON text."""
         self.authorizer_config = json.dumps(config) if config else None
 
+    def get_vpc_subnet_ids(self) -> list[str]:
+        """Parse vpc_subnet_ids from JSON text."""
+        if not self.vpc_subnet_ids:
+            return []
+        try:
+            return json.loads(self.vpc_subnet_ids)
+        except json.JSONDecodeError:
+            return []
+
+    def set_vpc_subnet_ids(self, subnet_ids: list[str] | None) -> None:
+        """Serialize vpc_subnet_ids to JSON text."""
+        self.vpc_subnet_ids = json.dumps(subnet_ids) if subnet_ids else None
+
+    def get_vpc_security_group_ids(self) -> list[str]:
+        """Parse vpc_security_group_ids from JSON text."""
+        if not self.vpc_security_group_ids:
+            return []
+        try:
+            return json.loads(self.vpc_security_group_ids)
+        except json.JSONDecodeError:
+            return []
+
+    def set_vpc_security_group_ids(self, sg_ids: list[str] | None) -> None:
+        """Serialize vpc_security_group_ids to JSON text."""
+        self.vpc_security_group_ids = json.dumps(sg_ids) if sg_ids else None
+
     def to_dict(self) -> dict:
         """Convert agent to dictionary for API responses."""
         return {
@@ -156,4 +184,6 @@ class Agent(Base):
             "allowed_model_ids": self.get_allowed_model_ids(),
             "harness_id": self.harness_id,
             "code_interpreter_id": self.code_interpreter_id,
+            "vpc_subnet_ids": self.get_vpc_subnet_ids(),
+            "vpc_security_group_ids": self.get_vpc_security_group_ids(),
         }

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -1,7 +1,7 @@
 """Agent ORM model for storing registered AgentCore Runtime metadata."""
 import json
 from datetime import datetime
-from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean
+from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, ForeignKey
 from sqlalchemy.orm import relationship
 from app.db import Base
 
@@ -52,8 +52,10 @@ class Agent(Base):
     allowed_model_ids = Column(Text, nullable=True)  # JSON array of allowed model IDs
     harness_id = Column(String, nullable=True)  # Harness ID for managed agent deployments
     code_interpreter_id = Column(String, nullable=True)
-    vpc_subnet_ids = Column(Text, nullable=True)      # JSON array of subnet IDs for VPC network mode
-    vpc_security_group_ids = Column(Text, nullable=True)  # JSON array of security group IDs for VPC network mode
+    vpc_subnet_ids = Column(Text, nullable=True)      # kept for migration; resolved via vpc_config_id at deploy time
+    vpc_security_group_ids = Column(Text, nullable=True)  # kept for migration; resolved via vpc_config_id at deploy time
+    vpc_config_id = Column(Integer, ForeignKey("vpc_configs.id"), nullable=True)
+    status_reason = Column(String, nullable=True)  # failureReason from AgentCore API on CREATE_FAILED/UPDATE_FAILED
 
     # Relationships
     sessions = relationship("InvocationSession", back_populates="agent", cascade="all, delete-orphan")
@@ -184,6 +186,6 @@ class Agent(Base):
             "allowed_model_ids": self.get_allowed_model_ids(),
             "harness_id": self.harness_id,
             "code_interpreter_id": self.code_interpreter_id,
-            "vpc_subnet_ids": self.get_vpc_subnet_ids(),
-            "vpc_security_group_ids": self.get_vpc_security_group_ids(),
+            "vpc_config_id": self.vpc_config_id,
+            "status_reason": self.status_reason,
         }

--- a/backend/app/models/vpc_config.py
+++ b/backend/app/models/vpc_config.py
@@ -1,0 +1,49 @@
+"""VpcConfig ORM model for named VPC networking configurations."""
+import json
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, Text, DateTime
+from app.db import Base
+
+
+class VpcConfig(Base):
+    """A named VPC configuration (subnet IDs + security group IDs) selectable at agent deploy time."""
+    __tablename__ = "vpc_configs"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String, unique=True, nullable=False)
+    description = Column(Text, nullable=True)
+    vpc_id = Column(String, nullable=False)
+    subnet_ids = Column(Text, nullable=False)   # JSON array
+    sg_ids = Column(Text, nullable=False)        # JSON array
+    created_at = Column(DateTime, nullable=True, default=datetime.utcnow)
+    updated_at = Column(DateTime, nullable=True, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    def get_subnet_ids(self) -> list[str]:
+        try:
+            return json.loads(self.subnet_ids) if self.subnet_ids else []
+        except json.JSONDecodeError:
+            return []
+
+    def set_subnet_ids(self, ids: list[str]) -> None:
+        self.subnet_ids = json.dumps(ids)
+
+    def get_sg_ids(self) -> list[str]:
+        try:
+            return json.loads(self.sg_ids) if self.sg_ids else []
+        except json.JSONDecodeError:
+            return []
+
+    def set_sg_ids(self, ids: list[str]) -> None:
+        self.sg_ids = json.dumps(ids)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "vpc_id": self.vpc_id,
+            "subnet_ids": self.get_subnet_ids(),
+            "sg_ids": self.get_sg_ids(),
+            "created_at": self.created_at.isoformat() + "Z" if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() + "Z" if self.updated_at else None,
+        }

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -2633,6 +2633,29 @@ def get_agent_status(agent_id: int, user: UserInfo = Depends(require_scopes("age
                 db.refresh(agent)
                 return _agent_response(agent, db)
 
+        # Auto-register in Agent Registry once harness is fully READY
+        if agent.deployment_status == "READY" and not agent.registry_record_id:
+            try:
+                from app.services.registry import get_registry_client
+                reg_client = get_registry_client()
+                if reg_client.registry_id:
+                    descriptors = reg_client.build_agent_descriptors(agent)
+                    reg_result = reg_client.create_record(
+                        name=agent.name or agent.harness_id,
+                        descriptor_type="A2A",
+                        descriptors=descriptors,
+                        record_version="1",
+                        description=agent.description,
+                    )
+                    reg_record_id = reg_result.get("recordId", "")
+                    if reg_record_id:
+                        rec = reg_client.wait_for_record(reg_record_id)
+                        agent.registry_record_id = reg_record_id
+                        agent.registry_status = rec.get("status", "DRAFT")
+                        logger.info("Auto-registered harness agent %s in registry: %s", agent.id, reg_record_id)
+            except Exception as reg_err:
+                logger.warning("Failed to auto-register harness agent %s in registry: %s", agent.id, reg_err)
+
         db.commit()
         db.refresh(agent)
         return _agent_response(agent, db)

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -101,12 +101,13 @@ class AgentDeployRequest(BaseModel):
     role_arn: str | None = Field(None, description="Existing IAM role ARN or null to create new")
     protocol: str = Field(default="HTTP", description="HTTP, MCP, or A2A")
     network_mode: str = Field(default="PUBLIC", description="PUBLIC or VPC")
+    vpc_subnet_ids: list[str] = Field(default_factory=list, description="Subnet IDs for VPC network mode")
+    vpc_security_group_ids: list[str] = Field(default_factory=list, description="Security group IDs for VPC network mode")
     idle_timeout: int | None = Field(None, description="Idle runtime session timeout (seconds)")
     max_lifetime: int | None = Field(None, description="Max lifetime (seconds)")
     authorizer_type: str | None = Field(None, description="Authorizer type: 'cognito', 'entra_id', 'okta', or 'other'")
     authorizer_pool_id: str | None = Field(None, description="Cognito pool ID for authorizer (when type is 'cognito')")
     authorizer_discovery_url: str | None = Field(None, description="OIDC discovery URL (when type is 'other')")
-    authorizer_allowed_audience: list[str] = Field(default_factory=list, description="Allowed JWT audience values")
     authorizer_allowed_audience: list[str] = Field(default_factory=list, description="Allowed JWT audience values")
     authorizer_allowed_clients: list[str] = Field(default_factory=list, description="Allowed client IDs")
     authorizer_allowed_scopes: list[str] = Field(default_factory=list, description="Allowed OAuth scopes")
@@ -135,6 +136,8 @@ class AgentCreateRequest(BaseModel):
     role_arn: str | None = Field(None, description="Existing IAM role ARN or null to create new")
     protocol: str = Field(default="HTTP", description="HTTP, MCP, or A2A")
     network_mode: str = Field(default="PUBLIC", description="PUBLIC or VPC")
+    vpc_subnet_ids: list[str] = Field(default_factory=list, description="Subnet IDs for VPC network mode")
+    vpc_security_group_ids: list[str] = Field(default_factory=list, description="Security group IDs for VPC network mode")
     idle_timeout: int | None = Field(None, description="Idle runtime session timeout (seconds)")
     max_lifetime: int | None = Field(None, description="Max lifetime (seconds)")
     authorizer_type: str | None = Field(None, description="Authorizer type: 'cognito', 'entra_id', 'okta', or 'other'")
@@ -181,6 +184,8 @@ class AgentResponse(BaseModel):
     endpoint_status: str | None = None
     protocol: str | None = None
     network_mode: str | None = None
+    vpc_subnet_ids: list[str] = []
+    vpc_security_group_ids: list[str] = []
     tags: dict[str, str] = {}
     authorizer_config: dict | None = None
     model_id: str | None = None
@@ -823,6 +828,9 @@ def _deploy_agent(request: AgentCreateRequest, db: Session, background_tasks: Ba
         registered_at=datetime.utcnow(),
     )
     agent.set_allowed_model_ids(effective_allowed)
+    if request.network_mode == "VPC":
+        agent.set_vpc_subnet_ids(request.vpc_subnet_ids or None)
+        agent.set_vpc_security_group_ids(request.vpc_security_group_ids or None)
     db.add(agent)
     db.commit()
     db.refresh(agent)
@@ -1265,6 +1273,8 @@ def _deploy_agent_background(
                 role_arn=execution_role_arn,
                 env_vars=env_vars,
                 network_mode=request.network_mode,
+                vpc_subnet_ids=request.vpc_subnet_ids or None,
+                vpc_security_group_ids=request.vpc_security_group_ids or None,
                 protocol=request.protocol,
                 lifecycle_config=lifecycle_config,
                 authorizer_config=authorizer_config,
@@ -1623,12 +1633,20 @@ def _update_deploy_agent_background(
                 artifact_bucket=artifact_bucket,
                 artifact_prefix=artifact_key,
                 network_mode=request.network_mode,
+                vpc_subnet_ids=request.vpc_subnet_ids or None,
+                vpc_security_group_ids=request.vpc_security_group_ids or None,
                 lifecycle_config=lifecycle_config,
                 region=region,
             )
 
             agent.description = request.description or agent.description
             agent.network_mode = request.network_mode
+            if request.network_mode == "VPC":
+                agent.set_vpc_subnet_ids(request.vpc_subnet_ids or None)
+                agent.set_vpc_security_group_ids(request.vpc_security_group_ids or None)
+            else:
+                agent.set_vpc_subnet_ids(None)
+                agent.set_vpc_security_group_ids(None)
             agent.deployment_status = "deployed"
             agent.status = response.get("status", "UPDATING")
             agent.deployed_at = datetime.utcnow()
@@ -2793,6 +2811,9 @@ def refresh_agent(agent_id: int, user: UserInfo = Depends(require_scopes("agent:
     agent.protocol = protocol_config.get("serverProtocol", agent.protocol or "HTTP")
     network_config = metadata.get("networkConfiguration", {})
     agent.network_mode = network_config.get("networkMode", agent.network_mode or "PUBLIC")
+    if agent.network_mode == "VPC":
+        agent.set_vpc_subnet_ids(network_config.get("vpcSubnetIds") or agent.get_vpc_subnet_ids() or None)
+        agent.set_vpc_security_group_ids(network_config.get("vpcSecurityGroupIds") or agent.get_vpc_security_group_ids() or None)
     if not agent.account_id:
         try:
             _, arn_account_id, _ = parse_arn(agent.arn)
@@ -3081,6 +3102,12 @@ def redeploy_harness_agent(
     agent.description = request.description or agent.description
     agent.execution_role_arn = request.role_arn or agent.execution_role_arn
     agent.network_mode = request.network_mode or agent.network_mode
+    if agent.network_mode == "VPC":
+        agent.set_vpc_subnet_ids(request.vpc_subnet_ids or agent.get_vpc_subnet_ids() or None)
+        agent.set_vpc_security_group_ids(request.vpc_security_group_ids or agent.get_vpc_security_group_ids() or None)
+    else:
+        agent.set_vpc_subnet_ids(None)
+        agent.set_vpc_security_group_ids(None)
     agent.status = "UPDATING"
     agent.deployment_status = "updating"
 
@@ -3228,6 +3255,15 @@ def export_agent(agent_id: int, user: UserInfo = Depends(require_scopes("admin:w
 
     if agent.network_mode and agent.network_mode != "PUBLIC":
         data["network_mode"] = agent.network_mode
+        if agent.network_mode == "VPC":
+            vpc_subnets = agent.get_vpc_subnet_ids()
+            vpc_sgs = agent.get_vpc_security_group_ids()
+            if vpc_subnets or vpc_sgs:
+                data["vpc"] = {}
+                if vpc_subnets:
+                    data["vpc"]["subnet_ids"] = vpc_subnets
+                if vpc_sgs:
+                    data["vpc"]["security_group_ids"] = vpc_sgs
 
     if agent.execution_role_arn:
         managed_role = db.query(ManagedRole).filter(ManagedRole.role_arn == agent.execution_role_arn).first()

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -28,6 +28,7 @@ from app.models.invocation import Invocation
 from app.models.tag_policy import TagPolicy
 from app.models.tag_profile import TagProfile
 from app.models.managed_role import ManagedRole
+from app.models.vpc_config import VpcConfig
 from app.routers.utils import get_agent_or_404
 
 from app.services.agentcore import describe_runtime, list_runtime_endpoints
@@ -101,8 +102,7 @@ class AgentDeployRequest(BaseModel):
     role_arn: str | None = Field(None, description="Existing IAM role ARN or null to create new")
     protocol: str = Field(default="HTTP", description="HTTP, MCP, or A2A")
     network_mode: str = Field(default="PUBLIC", description="PUBLIC or VPC")
-    vpc_subnet_ids: list[str] = Field(default_factory=list, description="Subnet IDs for VPC network mode")
-    vpc_security_group_ids: list[str] = Field(default_factory=list, description="Security group IDs for VPC network mode")
+    vpc_config_id: int | None = Field(None, description="VPC configuration ID (required when network_mode is VPC)")
     idle_timeout: int | None = Field(None, description="Idle runtime session timeout (seconds)")
     max_lifetime: int | None = Field(None, description="Max lifetime (seconds)")
     authorizer_type: str | None = Field(None, description="Authorizer type: 'cognito', 'entra_id', 'okta', or 'other'")
@@ -136,8 +136,7 @@ class AgentCreateRequest(BaseModel):
     role_arn: str | None = Field(None, description="Existing IAM role ARN or null to create new")
     protocol: str = Field(default="HTTP", description="HTTP, MCP, or A2A")
     network_mode: str = Field(default="PUBLIC", description="PUBLIC or VPC")
-    vpc_subnet_ids: list[str] = Field(default_factory=list, description="Subnet IDs for VPC network mode")
-    vpc_security_group_ids: list[str] = Field(default_factory=list, description="Security group IDs for VPC network mode")
+    vpc_config_id: int | None = Field(None, description="VPC configuration ID (required when network_mode is VPC)")
     idle_timeout: int | None = Field(None, description="Idle runtime session timeout (seconds)")
     max_lifetime: int | None = Field(None, description="Max lifetime (seconds)")
     authorizer_type: str | None = Field(None, description="Authorizer type: 'cognito', 'entra_id', 'okta', or 'other'")
@@ -184,8 +183,7 @@ class AgentResponse(BaseModel):
     endpoint_status: str | None = None
     protocol: str | None = None
     network_mode: str | None = None
-    vpc_subnet_ids: list[str] = []
-    vpc_security_group_ids: list[str] = []
+    vpc_config_id: int | None = None
     tags: dict[str, str] = {}
     authorizer_config: dict | None = None
     model_id: str | None = None
@@ -203,6 +201,7 @@ class AgentResponse(BaseModel):
     a2a_names: list[str] = []
     code_interpreter_id: str | None = None
     code_interpreter_status: str | None = None
+    status_reason: str | None = None
 
 
 class ConfigEntryResponse(BaseModel):
@@ -829,8 +828,7 @@ def _deploy_agent(request: AgentCreateRequest, db: Session, background_tasks: Ba
     )
     agent.set_allowed_model_ids(effective_allowed)
     if request.network_mode == "VPC":
-        agent.set_vpc_subnet_ids(request.vpc_subnet_ids or None)
-        agent.set_vpc_security_group_ids(request.vpc_security_group_ids or None)
+        agent.vpc_config_id = request.vpc_config_id
     db.add(agent)
     db.commit()
     db.refresh(agent)
@@ -1267,14 +1265,15 @@ def _deploy_agent_background(
         db.commit()
 
         try:
+            vpc_cfg = db.query(VpcConfig).filter(VpcConfig.id == request.vpc_config_id).first() if request.network_mode == "VPC" and request.vpc_config_id else None
             response = create_runtime(
                 name=request.name,
                 description=request.description,
                 role_arn=execution_role_arn,
                 env_vars=env_vars,
                 network_mode=request.network_mode,
-                vpc_subnet_ids=request.vpc_subnet_ids or None,
-                vpc_security_group_ids=request.vpc_security_group_ids or None,
+                vpc_subnet_ids=vpc_cfg.get_subnet_ids() if vpc_cfg else None,
+                vpc_security_group_ids=vpc_cfg.get_sg_ids() if vpc_cfg else None,
                 protocol=request.protocol,
                 lifecycle_config=lifecycle_config,
                 authorizer_config=authorizer_config,
@@ -1624,6 +1623,7 @@ def _update_deploy_agent_background(
         db.commit()
 
         try:
+            vpc_cfg = db.query(VpcConfig).filter(VpcConfig.id == request.vpc_config_id).first() if request.network_mode == "VPC" and request.vpc_config_id else None
             response = update_runtime(
                 runtime_id=agent.runtime_id,
                 description=request.description,
@@ -1633,20 +1633,15 @@ def _update_deploy_agent_background(
                 artifact_bucket=artifact_bucket,
                 artifact_prefix=artifact_key,
                 network_mode=request.network_mode,
-                vpc_subnet_ids=request.vpc_subnet_ids or None,
-                vpc_security_group_ids=request.vpc_security_group_ids or None,
+                vpc_subnet_ids=vpc_cfg.get_subnet_ids() if vpc_cfg else None,
+                vpc_security_group_ids=vpc_cfg.get_sg_ids() if vpc_cfg else None,
                 lifecycle_config=lifecycle_config,
                 region=region,
             )
 
             agent.description = request.description or agent.description
             agent.network_mode = request.network_mode
-            if request.network_mode == "VPC":
-                agent.set_vpc_subnet_ids(request.vpc_subnet_ids or None)
-                agent.set_vpc_security_group_ids(request.vpc_security_group_ids or None)
-            else:
-                agent.set_vpc_subnet_ids(None)
-                agent.set_vpc_security_group_ids(None)
+            agent.vpc_config_id = request.vpc_config_id if request.network_mode == "VPC" else None
             agent.deployment_status = "deployed"
             agent.status = response.get("status", "UPDATING")
             agent.deployed_at = datetime.utcnow()
@@ -1769,6 +1764,38 @@ def _deploy_harness(request: AgentCreateRequest, db: Session, background_tasks: 
 
     extra_harness_tools = request.harness_tools or []
 
+    # Snapshot memory data (first memory resource is passed to harness API)
+    memory_snapshots: list[dict[str, Any]] = []
+    if request.memory_ids:
+        memory_records = db.query(Memory).filter(Memory.id.in_(request.memory_ids)).all()
+        memory_snapshots = [
+            {"name": m.name, "memory_id": m.memory_id, "arn": m.arn}
+            for m in memory_records
+        ]
+
+    # Resolve VPC subnet/SG IDs for harness VPC networking
+    harness_vpc_subnet_ids: list[str] | None = None
+    harness_vpc_sg_ids: list[str] | None = None
+    if request.network_mode == "VPC" and request.vpc_config_id:
+        vpc_cfg = db.query(VpcConfig).filter(VpcConfig.id == request.vpc_config_id).first()
+        if vpc_cfg:
+            harness_vpc_subnet_ids = vpc_cfg.get_subnet_ids()
+            harness_vpc_sg_ids = vpc_cfg.get_sg_ids()
+
+    # Resolve Code Interpreter config for harness
+    harness_ci_config: dict[str, Any] | None = None
+    if request.code_interpreter_enabled:
+        ci_role_arn = ""
+        if request.code_interpreter_role_id:
+            ci_role = db.query(ManagedRole).filter(ManagedRole.id == request.code_interpreter_role_id).first()
+            if ci_role:
+                ci_role_arn = ci_role.role_arn
+        harness_ci_config = {
+            "region": (request.code_interpreter_region or "").strip(),
+            "network_mode": request.code_interpreter_network_mode or "SANDBOX",
+            "execution_role_arn": ci_role_arn,
+        }
+
     effective_allowed = request.allowed_model_ids if request.allowed_model_ids else [request.model_id]
     if request.model_id not in effective_allowed:
         effective_allowed = [request.model_id] + effective_allowed
@@ -1815,6 +1842,7 @@ def _deploy_harness(request: AgentCreateRequest, db: Session, background_tasks: 
         execution_role_arn=request.role_arn,
         protocol="HTTP",
         network_mode=request.network_mode,
+        vpc_config_id=request.vpc_config_id if request.network_mode == "VPC" else None,
         registered_at=datetime.utcnow(),
     )
     agent.set_allowed_model_ids(effective_allowed)
@@ -1848,16 +1876,20 @@ def _deploy_harness(request: AgentCreateRequest, db: Session, background_tasks: 
         model_id=request.model_id,
         system_prompt=system_prompt,
         mcp_snapshots=mcp_snapshots,
+        memory_snapshots=memory_snapshots,
         extra_harness_tools=extra_harness_tools,
         max_iterations=request.harness_max_iterations,
         max_tokens=request.harness_max_tokens,
         authorizer_config=authorizer_config,
         network_mode=request.network_mode,
+        vpc_subnet_ids=harness_vpc_subnet_ids,
+        vpc_security_group_ids=harness_vpc_sg_ids,
         idle_timeout=request.idle_timeout,
         max_lifetime=request.max_lifetime,
         resolved_tags=resolved_tags,
         region=region,
         account_id=account_id,
+        ci_config=harness_ci_config,
     )
 
     return response_data
@@ -1889,6 +1921,10 @@ def _deploy_harness_background(
     resolved_tags: dict[str, str],
     region: str,
     account_id: str,
+    memory_snapshots: list[dict[str, Any]] | None = None,
+    vpc_subnet_ids: list[str] | None = None,
+    vpc_security_group_ids: list[str] | None = None,
+    ci_config: dict[str, Any] | None = None,
 ) -> None:
     """Background task that creates credential providers and the harness in AWS."""
     db = SessionLocal()
@@ -1939,10 +1975,9 @@ def _deploy_harness_background(
                     db.commit()
                     return
 
-            # Only include non-auth MCP tools at deploy time; OAuth2 tools
-            # require a Bearer header and are injected at invocation time.
-            if server["auth_type"] != "oauth2":
-                harness_tools.append(_build_harness_tool_for_mcp(server))
+            # Register all MCP tools at deploy time; OAuth2 tokens are injected
+            # into remoteMcp.headers at invocation time.
+            harness_tools.append(_build_harness_tool_for_mcp(server))
 
             mcp_entry: dict[str, Any] = {
                 "name": server["name"],
@@ -1965,12 +2000,101 @@ def _deploy_harness_background(
 
         harness_tools.extend(extra_harness_tools)
 
+        # --- Step 2: Create Code Interpreter resource if requested ---
+        ci_arn: str | None = None
+        if ci_config and ci_config.get("execution_role_arn"):
+            agent.deployment_status = "creating_ci_resource"
+            db.commit()
+            try:
+                import boto3 as _boto3
+                ci_region = ci_config.get("region") or region
+                base_name = re.sub(r"_?code_interpreter$", "", name).strip("_")
+                raw_ci_name = f"loom_ci_{base_name}"
+                sanitized_ci_name = re.sub(r"[^a-zA-Z0-9_]", "_", raw_ci_name)[:48]
+                ci_net_mode = ci_config.get("network_mode") or "SANDBOX"
+                ci_boto = _boto3.client("bedrock-agentcore-control", region_name=ci_region)
+                # Reuse existing CI resource with this name if it already exists
+                ci_id: str | None = None
+                ci_arn_val: str | None = None
+                existing_cis = ci_boto.list_code_interpreters().get("codeInterpreterSummaries", [])
+                for existing_ci in existing_cis:
+                    if existing_ci.get("name") == sanitized_ci_name:
+                        ci_id = existing_ci["codeInterpreterId"]
+                        ci_arn_val = existing_ci["codeInterpreterArn"]
+                        logger.info("Reusing existing CI resource %s for harness agent %s", ci_id, agent_id)
+                        break
+                if not ci_id:
+                    ci_resp = ci_boto.create_code_interpreter(
+                        name=sanitized_ci_name,
+                        executionRoleArn=ci_config["execution_role_arn"],
+                        networkConfiguration={"networkMode": ci_net_mode},
+                    )
+                    ci_id = ci_resp["codeInterpreterId"]
+                    ci_arn_val = ci_resp["codeInterpreterArn"]
+                    logger.info("Created CI resource %s for harness agent %s", ci_id, agent_id)
+                ci_arn = ci_arn_val
+                agent.code_interpreter_id = ci_id
+                db.commit()
+                try:
+                    from app.services.observability import enable_code_interpreter_observability
+                    ci_arn_parts = ci_arn.split(":")
+                    ci_account_id = ci_arn_parts[4] if len(ci_arn_parts) >= 6 else account_id
+                    enable_code_interpreter_observability(
+                        ci_arn=ci_arn,
+                        ci_id=ci_id,
+                        account_id=ci_account_id,
+                        region=ci_region,
+                    )
+                except Exception as obs_err:
+                    logger.warning("Failed to enable CI observability for harness agent %s: %s", agent_id, obs_err)
+            except Exception as ci_err:
+                logger.error("Failed to create CI resource for harness agent %s: %s", agent_id, ci_err)
+                agent.status = "FAILED"
+                agent.deployment_status = "failed"
+                db.commit()
+                return
+
+        # Add code_interpreter tool to harness if CI resource was created
+        if ci_arn:
+            harness_tools.append({
+                "type": "agentcore_code_interpreter",
+                "name": "code_interpreter",
+                "config": {"agentCoreCodeInterpreter": {"codeInterpreterArn": ci_arn}},
+            })
+
         agent.deployment_status = "deploying"
         db.commit()
 
         # Build all MCP tools (for invocation-time injection with auth headers)
         all_mcp_tools = [_build_harness_tool_for_mcp(s) for s in mcp_snapshots]
         all_mcp_tools.extend(extra_harness_tools)
+
+        # Resolve memory: harness supports one memory resource.
+        # Fetch strategies from AWS to build retrievalConfig (required by CreateHarness).
+        memory_configs = []
+        primary_memory_arn = None
+        primary_memory_retrieval_config: dict[str, Any] | None = None
+        for m in (memory_snapshots or []):
+            try:
+                import boto3 as _boto3
+                mem_client = _boto3.client("bedrock-agentcore-control", region_name=region)
+                mem_resp = mem_client.get_memory(memoryId=m["memory_id"])
+                mem_obj = mem_resp.get("memory", {})
+                mem_status = mem_obj.get("status")
+                if mem_status not in (None, "DELETING", "FAILED"):
+                    retrieval_config: dict[str, Any] = {}
+                    for strategy in mem_obj.get("strategies", []):
+                        sid = strategy.get("strategyId")
+                        if sid and strategy.get("status") == "ACTIVE":
+                            retrieval_config[sid] = {"topK": 10, "strategyId": sid}
+                    memory_configs.append({"name": m["name"], "memory_id": m["memory_id"], "arn": m["arn"]})
+                    if not primary_memory_arn:
+                        primary_memory_arn = m["arn"]
+                        primary_memory_retrieval_config = retrieval_config or None
+                else:
+                    logger.warning("Memory %s has status %s, skipping", m["memory_id"], mem_status)
+            except Exception as mem_err:
+                logger.warning("Memory %s not found in AWS, skipping: %s", m["memory_id"], mem_err)
 
         # Build config JSON — deploy_tools go to create_harness, all tools
         # are stored for invocation-time injection with auth headers
@@ -1986,7 +2110,7 @@ def _deploy_harness_background(
             "integrations": {
                 "mcp_servers": mcp_server_configs,
                 "a2a_agents": [],
-                "memory": {"enabled": False, "resources": []},
+                "memory": {"enabled": len(memory_configs) > 0, "resources": memory_configs},
             },
         })
 
@@ -2001,6 +2125,19 @@ def _deploy_harness_background(
         db.commit()
 
 
+        # Delete any existing harness with the same name left over from a prior failed deploy.
+        try:
+            import boto3 as _boto3
+            _hc = _boto3.client("bedrock-agentcore-control", region_name=region)
+            existing_harnesses = _hc.list_harnesses().get("harnesses", [])
+            for _h in existing_harnesses:
+                if _h.get("harnessName") == name:
+                    logger.info("Deleting conflicting existing harness %s before create", _h["harnessId"])
+                    _hc.delete_harness(harnessId=_h["harnessId"])
+                    break
+        except Exception as _pre_err:
+            logger.warning("Pre-create harness conflict check failed: %s", _pre_err)
+
         response = create_harness_api(
             name=name,
             execution_role_arn=execution_role_arn,
@@ -2011,8 +2148,12 @@ def _deploy_harness_background(
             max_tokens=max_tokens,
             authorizer_config=authorizer_config,
             network_mode=network_mode,
+            vpc_subnet_ids=vpc_subnet_ids,
+            vpc_security_group_ids=vpc_security_group_ids,
             idle_timeout=idle_timeout,
             max_lifetime=max_lifetime,
+            memory_arn=primary_memory_arn,
+            memory_retrieval_config=primary_memory_retrieval_config,
             tags=resolved_tags if resolved_tags else None,
             region=region,
         )
@@ -2097,6 +2238,10 @@ def _update_harness_background(
     old_cp_names: set[str],
     region: str,
     account_id: str,
+    memory_snapshots: list[dict[str, Any]] | None = None,
+    vpc_subnet_ids: list[str] | None = None,
+    vpc_security_group_ids: list[str] | None = None,
+    ci_config: dict[str, Any] | None = None,
 ) -> None:
     """Background task that updates an existing harness via UpdateHarness API."""
     db = SessionLocal()
@@ -2139,8 +2284,7 @@ def _update_harness_background(
                         db.commit()
                         return
 
-            if server["auth_type"] != "oauth2":
-                harness_tools.append(_build_harness_tool_for_mcp(server))
+            harness_tools.append(_build_harness_tool_for_mcp(server))
 
             mcp_entry: dict[str, Any] = {
                 "name": server["name"],
@@ -2180,6 +2324,74 @@ def _update_harness_background(
         all_mcp_tools = [_build_harness_tool_for_mcp(s) for s in mcp_snapshots]
         all_mcp_tools.extend(extra_harness_tools)
 
+        memory_configs = []
+        primary_memory_arn = None
+        primary_memory_retrieval_config: dict[str, Any] | None = None
+        for m in (memory_snapshots or []):
+            try:
+                import boto3 as _boto3
+                mem_client = _boto3.client("bedrock-agentcore-control", region_name=region)
+                mem_resp = mem_client.get_memory(memoryId=m["memory_id"])
+                mem_obj = mem_resp.get("memory", {})
+                mem_status = mem_obj.get("status")
+                if mem_status not in (None, "DELETING", "FAILED"):
+                    retrieval_config: dict[str, Any] = {}
+                    for strategy in mem_obj.get("strategies", []):
+                        sid = strategy.get("strategyId")
+                        if sid and strategy.get("status") == "ACTIVE":
+                            retrieval_config[sid] = {"topK": 10, "strategyId": sid}
+                    memory_configs.append({"name": m["name"], "memory_id": m["memory_id"], "arn": m["arn"]})
+                    if not primary_memory_arn:
+                        primary_memory_arn = m["arn"]
+                        primary_memory_retrieval_config = retrieval_config or None
+                else:
+                    logger.warning("Memory %s has status %s, skipping", m["memory_id"], mem_status)
+            except Exception as mem_err:
+                logger.warning("Memory %s not found in AWS, skipping: %s", m["memory_id"], mem_err)
+
+        # Handle Code Interpreter: reuse existing resource or create new one
+        update_ci_arn: str | None = None
+        if ci_config and ci_config.get("execution_role_arn"):
+            existing_ci_id = ci_config.get("existing_id")
+            if existing_ci_id:
+                # Fetch ARN from existing resource
+                try:
+                    import boto3 as _boto3
+                    ci_region_upd = ci_config.get("region") or region
+                    ci_boto_upd = _boto3.client("bedrock-agentcore-control", region_name=ci_region_upd)
+                    ci_info = ci_boto_upd.get_code_interpreter(codeInterpreterId=existing_ci_id)
+                    update_ci_arn = ci_info.get("codeInterpreterArn")
+                except Exception as ci_get_err:
+                    logger.warning("Could not fetch existing CI ARN for harness update %s: %s", agent_id, ci_get_err)
+            if not update_ci_arn:
+                # Create a new CI resource
+                try:
+                    import boto3 as _boto3
+                    ci_region_upd = ci_config.get("region") or region
+                    base_name_upd = re.sub(r"_?code_interpreter$", "", name).strip("_")
+                    raw_ci_name_upd = f"loom_ci_{base_name_upd}"
+                    san_ci_name_upd = re.sub(r"[^a-zA-Z0-9_]", "_", raw_ci_name_upd)[:48]
+                    ci_net_upd = ci_config.get("network_mode") or "SANDBOX"
+                    ci_boto_upd = _boto3.client("bedrock-agentcore-control", region_name=ci_region_upd)
+                    ci_resp_upd = ci_boto_upd.create_code_interpreter(
+                        name=san_ci_name_upd,
+                        executionRoleArn=ci_config["execution_role_arn"],
+                        networkConfiguration={"networkMode": ci_net_upd},
+                    )
+                    update_ci_arn = ci_resp_upd["codeInterpreterArn"]
+                    agent.code_interpreter_id = ci_resp_upd["codeInterpreterId"]
+                    db.commit()
+                    logger.info("Created new CI resource %s for harness update %s", agent.code_interpreter_id, agent_id)
+                except Exception as ci_create_err:
+                    logger.warning("Failed to create CI resource for harness update %s: %s", agent_id, ci_create_err)
+
+        if update_ci_arn:
+            harness_tools.append({
+                "type": "agentcore_code_interpreter",
+                "name": "code_interpreter",
+                "config": {"agentCoreCodeInterpreter": {"codeInterpreterArn": update_ci_arn}},
+            })
+
         config_json = json.dumps({
             "system_prompt": system_prompt,
             "model_id": model_id,
@@ -2192,7 +2404,7 @@ def _update_harness_background(
             "integrations": {
                 "mcp_servers": mcp_server_configs,
                 "a2a_agents": [],
-                "memory": {"enabled": False, "resources": []},
+                "memory": {"enabled": len(memory_configs) > 0, "resources": memory_configs},
             },
         })
 
@@ -2215,8 +2427,12 @@ def _update_harness_background(
             max_tokens=max_tokens,
             authorizer_config=authorizer_config,
             network_mode=network_mode,
+            vpc_subnet_ids=vpc_subnet_ids,
+            vpc_security_group_ids=vpc_security_group_ids,
             idle_timeout=idle_timeout,
             max_lifetime=max_lifetime,
+            memory_arn=primary_memory_arn,
+            memory_retrieval_config=primary_memory_retrieval_config,
             region=region,
         )
 
@@ -2426,6 +2642,7 @@ def get_agent_status(agent_id: int, user: UserInfo = Depends(require_scopes("age
         try:
             rt = get_runtime(agent.runtime_id, agent.region)
             agent.status = rt.get("status", agent.status)
+            agent.status_reason = rt.get("failureReason")
             agent.arn = rt.get("agentRuntimeArn", agent.arn)
             agent.last_refreshed_at = datetime.utcnow()
         except Exception as e:
@@ -2628,6 +2845,22 @@ def delete_agent(
     # Delete custom Code Interpreter resource if one was created
     if _ci_id and _ci_region:
         _delete_code_interpreter(_ci_id, _ci_region)
+    elif agent.source == "harness" and agent.name:
+        # Fallback: no code_interpreter_id stored, but a CI may exist from a failed deploy.
+        # Reconstruct the expected name and look it up.
+        try:
+            import boto3 as _boto3
+            _fallback_region = _region
+            base_name = re.sub(r"_?code_interpreter$", "", agent.name).strip("_")
+            expected_ci_name = re.sub(r"[^a-zA-Z0-9_]", "_", f"loom_ci_{base_name}")[:48]
+            ci_client = _boto3.client("bedrock-agentcore-control", region_name=_fallback_region)
+            summaries = ci_client.list_code_interpreters().get("codeInterpreterSummaries", [])
+            for s in summaries:
+                if s.get("name") == expected_ci_name:
+                    _delete_code_interpreter(s["codeInterpreterId"], _fallback_region)
+                    break
+        except Exception as ci_scan_err:
+            logger.warning("Failed to scan/delete orphaned CI for harness %s: %s", agent.name, ci_scan_err)
 
     # Clean up credential providers
     for cp_name in cp_names:
@@ -2807,6 +3040,7 @@ def refresh_agent(agent_id: int, user: UserInfo = Depends(require_scopes("agent:
 
     agent.name = metadata.get("agentRuntimeName")
     agent.status = metadata.get("status")
+    agent.status_reason = metadata.get("failureReason")
     protocol_config = metadata.get("protocolConfiguration", {})
     agent.protocol = protocol_config.get("serverProtocol", agent.protocol or "HTTP")
     network_config = metadata.get("networkConfiguration", {})
@@ -3102,12 +3336,7 @@ def redeploy_harness_agent(
     agent.description = request.description or agent.description
     agent.execution_role_arn = request.role_arn or agent.execution_role_arn
     agent.network_mode = request.network_mode or agent.network_mode
-    if agent.network_mode == "VPC":
-        agent.set_vpc_subnet_ids(request.vpc_subnet_ids or agent.get_vpc_subnet_ids() or None)
-        agent.set_vpc_security_group_ids(request.vpc_security_group_ids or agent.get_vpc_security_group_ids() or None)
-    else:
-        agent.set_vpc_subnet_ids(None)
-        agent.set_vpc_security_group_ids(None)
+    agent.vpc_config_id = request.vpc_config_id if agent.network_mode == "VPC" else None
     agent.status = "UPDATING"
     agent.deployment_status = "updating"
 
@@ -3182,6 +3411,39 @@ def redeploy_harness_agent(
 
     extra_harness_tools = request.harness_tools or []
 
+    # Snapshot memory resources for update
+    update_memory_snapshots: list[dict[str, Any]] = []
+    if request.memory_ids:
+        mem_records = db.query(Memory).filter(Memory.id.in_(request.memory_ids)).all()
+        update_memory_snapshots = [
+            {"name": m.name, "memory_id": m.memory_id, "arn": m.arn}
+            for m in mem_records
+        ]
+
+    # Resolve VPC subnet/SG IDs for harness VPC networking
+    update_vpc_subnet_ids: list[str] | None = None
+    update_vpc_sg_ids: list[str] | None = None
+    if request.network_mode == "VPC" and request.vpc_config_id:
+        vpc_cfg = db.query(VpcConfig).filter(VpcConfig.id == request.vpc_config_id).first()
+        if vpc_cfg:
+            update_vpc_subnet_ids = vpc_cfg.get_subnet_ids()
+            update_vpc_sg_ids = vpc_cfg.get_sg_ids()
+
+    # Resolve Code Interpreter config for harness update
+    update_ci_config: dict[str, Any] | None = None
+    if request.code_interpreter_enabled:
+        ci_role_arn_update = ""
+        if request.code_interpreter_role_id:
+            ci_role_upd = db.query(ManagedRole).filter(ManagedRole.id == request.code_interpreter_role_id).first()
+            if ci_role_upd:
+                ci_role_arn_update = ci_role_upd.role_arn
+        update_ci_config = {
+            "region": (request.code_interpreter_region or "").strip(),
+            "network_mode": request.code_interpreter_network_mode or "SANDBOX",
+            "execution_role_arn": ci_role_arn_update,
+            "existing_id": agent.code_interpreter_id,
+        }
+
     background_tasks.add_task(
         _update_harness_background,
         agent_id=agent_id,
@@ -3191,17 +3453,21 @@ def redeploy_harness_agent(
         model_id=request.model_id,
         system_prompt=system_prompt,
         mcp_snapshots=mcp_snapshots,
+        memory_snapshots=update_memory_snapshots,
         extra_harness_tools=extra_harness_tools,
         max_iterations=request.harness_max_iterations,
         max_tokens=request.harness_max_tokens,
         authorizer_config=authorizer_config,
         network_mode=request.network_mode,
+        vpc_subnet_ids=update_vpc_subnet_ids,
+        vpc_security_group_ids=update_vpc_sg_ids,
         idle_timeout=request.idle_timeout,
         max_lifetime=request.max_lifetime,
         resolved_tags=resolved_tags,
         old_cp_names=old_cp_names,
         region=region,
         account_id=account_id,
+        ci_config=update_ci_config,
     )
 
     return _agent_response(agent, db)
@@ -3254,16 +3520,12 @@ def export_agent(agent_id: int, user: UserInfo = Depends(require_scopes("admin:w
         data["allowed_models"] = allowed
 
     if agent.network_mode and agent.network_mode != "PUBLIC":
-        data["network_mode"] = agent.network_mode
-        if agent.network_mode == "VPC":
-            vpc_subnets = agent.get_vpc_subnet_ids()
-            vpc_sgs = agent.get_vpc_security_group_ids()
-            if vpc_subnets or vpc_sgs:
-                data["vpc"] = {}
-                if vpc_subnets:
-                    data["vpc"]["subnet_ids"] = vpc_subnets
-                if vpc_sgs:
-                    data["vpc"]["security_group_ids"] = vpc_sgs
+        vpc_block: dict[str, Any] = {"mode": agent.network_mode}
+        if agent.network_mode == "VPC" and agent.vpc_config_id:
+            vpc_cfg = db.query(VpcConfig).filter(VpcConfig.id == agent.vpc_config_id).first()
+            if vpc_cfg:
+                vpc_block["config"] = vpc_cfg.name
+        data["vpc"] = vpc_block
 
     if agent.execution_role_arn:
         managed_role = db.query(ManagedRole).filter(ManagedRole.role_arn == agent.execution_role_arn).first()

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -13,6 +13,7 @@ from app.dependencies.auth import UserInfo, get_current_user, require_scopes
 from app.models.tag_policy import TagPolicy
 from app.models.tag_profile import TagProfile
 from app.models.site_setting import SiteSetting
+from app.models.vpc_config import VpcConfig
 
 logger = logging.getLogger(__name__)
 
@@ -494,3 +495,253 @@ def update_enabled_models(
         db.add(setting)
     db.commit()
     return EnabledModelsResponse(model_ids=request.model_ids, all_models=SUPPORTED_MODELS)
+
+
+# ---------------------------------------------------------------------------
+# VPC Configuration CRUD
+# ---------------------------------------------------------------------------
+class VpcConfigRequest(BaseModel):
+    """Request body for creating/updating a VPC configuration."""
+    name: str = Field(..., description="Friendly name for this VPC configuration")
+    description: str | None = Field(None, description="Optional description")
+    vpc_id: str = Field(..., description="VPC ID (vpc-xxxxxxxx)")
+    subnet_ids: list[str] = Field(..., description="Private subnet IDs")
+    sg_ids: list[str] = Field(..., description="Security group IDs")
+
+
+class VpcConfigResponse(BaseModel):
+    """Response model for a VPC configuration."""
+    id: int
+    name: str
+    description: str | None
+    vpc_id: str
+    subnet_ids: list[str]
+    sg_ids: list[str]
+    created_at: str | None
+    updated_at: str | None
+
+
+@router.get("/vpc-configs", response_model=list[VpcConfigResponse])
+def list_vpc_configs(
+    user: UserInfo = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> list[VpcConfigResponse]:
+    """List all VPC configurations. Requires authentication (used in agent deploy form)."""
+    configs = db.query(VpcConfig).order_by(VpcConfig.name).all()
+    return [VpcConfigResponse(**c.to_dict()) for c in configs]
+
+
+@router.post("/vpc-configs", response_model=VpcConfigResponse, status_code=status.HTTP_201_CREATED)
+def create_vpc_config(
+    request: VpcConfigRequest,
+    user: UserInfo = Depends(require_scopes("settings:write")),
+    db: Session = Depends(get_db),
+) -> VpcConfigResponse:
+    """Create a new VPC configuration."""
+    existing = db.query(VpcConfig).filter(VpcConfig.name == request.name).first()
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"VPC configuration with name '{request.name}' already exists",
+        )
+    config = VpcConfig(
+        name=request.name,
+        description=request.description,
+        vpc_id=request.vpc_id,
+    )
+    config.set_subnet_ids(request.subnet_ids)
+    config.set_sg_ids(request.sg_ids)
+    db.add(config)
+    db.commit()
+    db.refresh(config)
+    return VpcConfigResponse(**config.to_dict())
+
+
+@router.put("/vpc-configs/{config_id}", response_model=VpcConfigResponse)
+def update_vpc_config(
+    config_id: int,
+    request: VpcConfigRequest,
+    user: UserInfo = Depends(require_scopes("settings:write")),
+    db: Session = Depends(get_db),
+) -> VpcConfigResponse:
+    """Update an existing VPC configuration."""
+    config = db.query(VpcConfig).filter(VpcConfig.id == config_id).first()
+    if not config:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="VPC configuration not found")
+    if request.name != config.name:
+        conflict = db.query(VpcConfig).filter(VpcConfig.name == request.name).first()
+        if conflict:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"VPC configuration with name '{request.name}' already exists",
+            )
+    config.name = request.name
+    config.description = request.description
+    config.vpc_id = request.vpc_id
+    config.set_subnet_ids(request.subnet_ids)
+    config.set_sg_ids(request.sg_ids)
+    config.updated_at = datetime.utcnow()
+    db.commit()
+    db.refresh(config)
+    return VpcConfigResponse(**config.to_dict())
+
+
+class VpcSubnetDetail(BaseModel):
+    """Enriched subnet info from EC2 DescribeSubnets."""
+    subnet_id: str
+    availability_zone: str | None
+    availability_zone_id: str | None
+    cidr_block: str | None
+    available_ips: int | None
+    name: str | None
+
+
+class VpcSgRuleDetail(BaseModel):
+    """A single inbound or outbound security group rule."""
+    protocol: str
+    from_port: int | None
+    to_port: int | None
+    cidr: str | None
+    source_sg_id: str | None
+    source_sg_name: str | None
+    description: str | None
+
+
+class VpcSgDetail(BaseModel):
+    """Enriched security group info from EC2 DescribeSecurityGroups."""
+    sg_id: str
+    name: str | None
+    ingress: list[VpcSgRuleDetail]
+    egress: list[VpcSgRuleDetail]
+
+
+class VpcConfigDetailResponse(BaseModel):
+    """Enriched VPC configuration with live EC2 metadata."""
+    id: int
+    name: str
+    description: str | None
+    vpc_id: str
+    subnets: list[VpcSubnetDetail]
+    security_groups: list[VpcSgDetail]
+
+
+def _parse_sg_rules(ip_permissions: list[dict]) -> list[VpcSgRuleDetail]:
+    rules: list[VpcSgRuleDetail] = []
+    for perm in ip_permissions:
+        protocol = perm.get("IpProtocol", "-1")
+        if protocol == "-1":
+            protocol = "All"
+        from_port = perm.get("FromPort")
+        to_port = perm.get("ToPort")
+        description_base = None
+
+        for ip_range in perm.get("IpRanges", []):
+            rules.append(VpcSgRuleDetail(
+                protocol=protocol,
+                from_port=from_port,
+                to_port=to_port,
+                cidr=ip_range.get("CidrIp"),
+                source_sg_id=None,
+                source_sg_name=None,
+                description=ip_range.get("Description") or description_base,
+            ))
+        for sg_ref in perm.get("UserIdGroupPairs", []):
+            rules.append(VpcSgRuleDetail(
+                protocol=protocol,
+                from_port=from_port,
+                to_port=to_port,
+                cidr=None,
+                source_sg_id=sg_ref.get("GroupId"),
+                source_sg_name=sg_ref.get("GroupName"),
+                description=sg_ref.get("Description") or description_base,
+            ))
+        if not perm.get("IpRanges") and not perm.get("UserIdGroupPairs"):
+            rules.append(VpcSgRuleDetail(
+                protocol=protocol,
+                from_port=from_port,
+                to_port=to_port,
+                cidr=None,
+                source_sg_id=None,
+                source_sg_name=None,
+                description=description_base,
+            ))
+    return rules
+
+
+@router.get("/vpc-configs/{config_id}/detail", response_model=VpcConfigDetailResponse)
+def get_vpc_config_detail(
+    config_id: int,
+    user: UserInfo = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> VpcConfigDetailResponse:
+    """Return a VPC configuration enriched with live EC2 subnet and security group metadata."""
+    import boto3
+    import os
+
+    config = db.query(VpcConfig).filter(VpcConfig.id == config_id).first()
+    if not config:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="VPC configuration not found")
+
+    region = os.getenv("AWS_REGION", "us-east-1")
+    ec2 = boto3.client("ec2", region_name=region)
+
+    subnet_ids = config.get_subnet_ids()
+    sg_ids = config.get_sg_ids()
+
+    subnets: list[VpcSubnetDetail] = []
+    if subnet_ids:
+        try:
+            resp = ec2.describe_subnets(SubnetIds=subnet_ids)
+            subnet_map = {s["SubnetId"]: s for s in resp.get("Subnets", [])}
+        except Exception:
+            subnet_map = {}
+        for sid in subnet_ids:
+            s = subnet_map.get(sid, {})
+            name_tag = next((t["Value"] for t in s.get("Tags", []) if t["Key"] == "Name"), None)
+            subnets.append(VpcSubnetDetail(
+                subnet_id=sid,
+                availability_zone=s.get("AvailabilityZone"),
+                availability_zone_id=s.get("AvailabilityZoneId"),
+                cidr_block=s.get("CidrBlock"),
+                available_ips=s.get("AvailableIpAddressCount"),
+                name=name_tag,
+            ))
+
+    security_groups: list[VpcSgDetail] = []
+    if sg_ids:
+        try:
+            resp = ec2.describe_security_groups(GroupIds=sg_ids)
+            sg_map = {g["GroupId"]: g for g in resp.get("SecurityGroups", [])}
+        except Exception:
+            sg_map = {}
+        for sgid in sg_ids:
+            g = sg_map.get(sgid, {})
+            security_groups.append(VpcSgDetail(
+                sg_id=sgid,
+                name=g.get("GroupName"),
+                ingress=_parse_sg_rules(g.get("IpPermissions", [])),
+                egress=_parse_sg_rules(g.get("IpPermissionsEgress", [])),
+            ))
+
+    return VpcConfigDetailResponse(
+        id=config.id,
+        name=config.name,
+        description=config.description,
+        vpc_id=config.vpc_id,
+        subnets=subnets,
+        security_groups=security_groups,
+    )
+
+
+@router.delete("/vpc-configs/{config_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_vpc_config(
+    config_id: int,
+    user: UserInfo = Depends(require_scopes("settings:write")),
+    db: Session = Depends(get_db),
+) -> None:
+    """Delete a VPC configuration."""
+    config = db.query(VpcConfig).filter(VpcConfig.id == config_id).first()
+    if not config:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="VPC configuration not found")
+    db.delete(config)
+    db.commit()

--- a/backend/app/services/deployment.py
+++ b/backend/app/services/deployment.py
@@ -234,10 +234,11 @@ def create_runtime(
     }
 
     network_config: dict[str, Any] = {"networkMode": network_mode}
-    if network_mode == "VPC" and vpc_subnet_ids:
-        network_config["vpcSubnetIds"] = vpc_subnet_ids
-    if network_mode == "VPC" and vpc_security_group_ids:
-        network_config["vpcSecurityGroupIds"] = vpc_security_group_ids
+    if network_mode == "VPC" and (vpc_subnet_ids or vpc_security_group_ids):
+        network_config["networkModeConfig"] = {
+            "subnets": vpc_subnet_ids or [],
+            "securityGroups": vpc_security_group_ids or [],
+        }
     params["networkConfiguration"] = network_config
 
     if lifecycle_config is not None:
@@ -414,10 +415,11 @@ def update_runtime(
         }
     if network_mode is not None:
         network_config: dict[str, Any] = {"networkMode": network_mode}
-        if network_mode == "VPC" and vpc_subnet_ids:
-            network_config["vpcSubnetIds"] = vpc_subnet_ids
-        if network_mode == "VPC" and vpc_security_group_ids:
-            network_config["vpcSecurityGroupIds"] = vpc_security_group_ids
+        if network_mode == "VPC" and (vpc_subnet_ids or vpc_security_group_ids):
+            network_config["networkModeConfig"] = {
+                "subnets": vpc_subnet_ids or [],
+                "securityGroups": vpc_security_group_ids or [],
+            }
         params["networkConfiguration"] = network_config
     if lifecycle_config is not None:
         params["lifecycleConfiguration"] = lifecycle_config

--- a/backend/app/services/deployment.py
+++ b/backend/app/services/deployment.py
@@ -176,6 +176,8 @@ def create_runtime(
     role_arn: str,
     env_vars: dict[str, str],
     network_mode: str = "PUBLIC",
+    vpc_subnet_ids: list[str] | None = None,
+    vpc_security_group_ids: list[str] | None = None,
     protocol: str = "HTTP",
     lifecycle_config: dict | None = None,
     authorizer_config: dict | None = None,
@@ -193,6 +195,8 @@ def create_runtime(
         role_arn: IAM role ARN for execution
         env_vars: Environment variables to inject
         network_mode: Network mode (PUBLIC or VPC)
+        vpc_subnet_ids: Subnet IDs for VPC network mode
+        vpc_security_group_ids: Security group IDs for VPC network mode
         protocol: Server protocol (HTTP or MCP)
         lifecycle_config: Optional lifecycle configuration
         authorizer_config: Optional authorizer configuration
@@ -224,11 +228,17 @@ def create_runtime(
             }
         },
         "roleArn": role_arn,
-        "networkConfiguration": {"networkMode": network_mode},
         "protocolConfiguration": {"serverProtocol": protocol},
         "environmentVariables": env_vars,
         "tags": _merge_tags(extra=tags),
     }
+
+    network_config: dict[str, Any] = {"networkMode": network_mode}
+    if network_mode == "VPC" and vpc_subnet_ids:
+        network_config["vpcSubnetIds"] = vpc_subnet_ids
+    if network_mode == "VPC" and vpc_security_group_ids:
+        network_config["vpcSecurityGroupIds"] = vpc_security_group_ids
+    params["networkConfiguration"] = network_config
 
     if lifecycle_config is not None:
         params["lifecycleConfiguration"] = lifecycle_config
@@ -353,6 +363,8 @@ def update_runtime(
     artifact_bucket: str | None = None,
     artifact_prefix: str | None = None,
     network_mode: str | None = None,
+    vpc_subnet_ids: list[str] | None = None,
+    vpc_security_group_ids: list[str] | None = None,
     lifecycle_config: dict | None = None,
     region: str = "us-east-1",
 ) -> dict[str, Any]:
@@ -401,7 +413,12 @@ def update_runtime(
             }
         }
     if network_mode is not None:
-        params["networkConfiguration"] = {"networkMode": network_mode}
+        network_config: dict[str, Any] = {"networkMode": network_mode}
+        if network_mode == "VPC" and vpc_subnet_ids:
+            network_config["vpcSubnetIds"] = vpc_subnet_ids
+        if network_mode == "VPC" and vpc_security_group_ids:
+            network_config["vpcSecurityGroupIds"] = vpc_security_group_ids
+        params["networkConfiguration"] = network_config
     if lifecycle_config is not None:
         params["lifecycleConfiguration"] = lifecycle_config
 

--- a/backend/app/services/harness.py
+++ b/backend/app/services/harness.py
@@ -22,9 +22,13 @@ def create_harness(
     max_tokens: int | None = None,
     authorizer_config: dict[str, Any] | None = None,
     network_mode: str = "PUBLIC",
+    vpc_subnet_ids: list[str] | None = None,
+    vpc_security_group_ids: list[str] | None = None,
     idle_timeout: int | None = None,
     max_lifetime: int | None = None,
     tags: dict[str, str] | None = None,
+    memory_arn: str | None = None,
+    memory_retrieval_config: dict[str, Any] | None = None,
     region: str = "us-east-1",
 ) -> dict[str, Any]:
     """Create a new AgentCore Harness (managed agent loop).
@@ -70,8 +74,20 @@ def create_harness(
         if lifecycle_config:
             env_config["lifecycleConfiguration"] = lifecycle_config
         if network_mode != "PUBLIC":
-            env_config["networkConfiguration"] = {"networkMode": network_mode}
+            net_cfg: dict[str, Any] = {"networkMode": network_mode}
+            if network_mode == "VPC" and (vpc_subnet_ids or vpc_security_group_ids):
+                net_cfg["networkModeConfig"] = {
+                    "subnets": vpc_subnet_ids or [],
+                    "securityGroups": vpc_security_group_ids or [],
+                }
+            env_config["networkConfiguration"] = net_cfg
         params["environment"] = {"agentCoreRuntimeEnvironment": env_config}
+
+    if memory_arn:
+        mem_cfg: dict[str, Any] = {"arn": memory_arn}
+        if memory_retrieval_config:
+            mem_cfg["retrievalConfig"] = memory_retrieval_config
+        params["memory"] = {"agentCoreMemoryConfiguration": mem_cfg}
 
     if tags:
         params["tags"] = tags
@@ -102,8 +118,12 @@ def update_harness(
     max_tokens: int | None = None,
     authorizer_config: dict[str, Any] | None = None,
     network_mode: str | None = None,
+    vpc_subnet_ids: list[str] | None = None,
+    vpc_security_group_ids: list[str] | None = None,
     idle_timeout: int | None = None,
     max_lifetime: int | None = None,
+    memory_arn: str | None = None,
+    memory_retrieval_config: dict[str, Any] | None = None,
     region: str = "us-east-1",
 ) -> dict[str, Any]:
     """Update an existing AgentCore Harness."""
@@ -144,8 +164,20 @@ def update_harness(
         if lifecycle_config:
             env_config["lifecycleConfiguration"] = lifecycle_config
         if network_mode and network_mode != "PUBLIC":
-            env_config["networkConfiguration"] = {"networkMode": network_mode}
+            net_cfg: dict[str, Any] = {"networkMode": network_mode}
+            if network_mode == "VPC" and (vpc_subnet_ids or vpc_security_group_ids):
+                net_cfg["networkModeConfig"] = {
+                    "subnets": vpc_subnet_ids or [],
+                    "securityGroups": vpc_security_group_ids or [],
+                }
+            env_config["networkConfiguration"] = net_cfg
         params["environment"] = {"agentCoreRuntimeEnvironment": env_config}
+
+    if memory_arn is not None:
+        mem_cfg: dict[str, Any] = {"arn": memory_arn}
+        if memory_retrieval_config:
+            mem_cfg["retrievalConfig"] = memory_retrieval_config
+        params["memory"] = {"optionalValue": {"agentCoreMemoryConfiguration": mem_cfg}}
 
     response = client.update_harness(**params)
     result = response.get("harness", response)

--- a/backend/tests/test_deployment.py
+++ b/backend/tests/test_deployment.py
@@ -388,15 +388,13 @@ class TestAgentModelVpc(unittest.TestCase):
         agent.set_vpc_security_group_ids(["sg-abc"])
         self.assertEqual(agent.get_vpc_security_group_ids(), ["sg-abc"])
 
-    def test_to_dict_includes_vpc_fields(self) -> None:
+    def test_to_dict_includes_vpc_config_id(self) -> None:
         from app.models.agent import Agent
         agent = Agent(arn="a", runtime_id="r", region="us-east-1", account_id="123",
                       name="test", status="READY", registered_at=None)
-        agent.set_vpc_subnet_ids(["subnet-aaa"])
-        agent.set_vpc_security_group_ids(["sg-bbb"])
+        agent.vpc_config_id = 42
         d = agent.to_dict()
-        self.assertEqual(d["vpc_subnet_ids"], ["subnet-aaa"])
-        self.assertEqual(d["vpc_security_group_ids"], ["sg-bbb"])
+        self.assertEqual(d["vpc_config_id"], 42)
 
 
 class TestUpdateRuntime(unittest.TestCase):

--- a/backend/tests/test_deployment.py
+++ b/backend/tests/test_deployment.py
@@ -221,6 +221,184 @@ class TestDeleteRuntimeEndpoint(unittest.TestCase):
         )
 
 
+class TestCreateRuntimeVpc(unittest.TestCase):
+    """Test VPC configuration in create_runtime."""
+
+    @patch("boto3.client")
+    def test_create_runtime_public_mode_no_vpc_fields(self, mock_boto_client: MagicMock) -> None:
+        """PUBLIC mode should not include vpcSubnetIds or vpcSecurityGroupIds."""
+        mock_client = MagicMock()
+        mock_boto_client.return_value = mock_client
+        mock_client.create_agent_runtime.return_value = {"agentRuntimeId": "rt-pub"}
+
+        create_runtime(
+            name="pub-agent",
+            description="",
+            role_arn="arn:aws:iam::123:role/r",
+            env_vars={},
+            network_mode="PUBLIC",
+            artifact_bucket="b",
+            artifact_prefix="p",
+            region="us-east-1",
+        )
+
+        call_kwargs = mock_client.create_agent_runtime.call_args[1]
+        net = call_kwargs["networkConfiguration"]
+        self.assertEqual(net["networkMode"], "PUBLIC")
+        self.assertNotIn("vpcSubnetIds", net)
+        self.assertNotIn("vpcSecurityGroupIds", net)
+
+    @patch("boto3.client")
+    def test_create_runtime_vpc_mode_passes_subnet_and_sg(self, mock_boto_client: MagicMock) -> None:
+        """VPC mode should include vpcSubnetIds and vpcSecurityGroupIds in networkConfiguration."""
+        mock_client = MagicMock()
+        mock_boto_client.return_value = mock_client
+        mock_client.create_agent_runtime.return_value = {"agentRuntimeId": "rt-vpc"}
+
+        create_runtime(
+            name="vpc-agent",
+            description="",
+            role_arn="arn:aws:iam::123:role/r",
+            env_vars={},
+            network_mode="VPC",
+            vpc_subnet_ids=["subnet-aaa", "subnet-bbb"],
+            vpc_security_group_ids=["sg-ccc"],
+            artifact_bucket="b",
+            artifact_prefix="p",
+            region="us-east-1",
+        )
+
+        call_kwargs = mock_client.create_agent_runtime.call_args[1]
+        net = call_kwargs["networkConfiguration"]
+        self.assertEqual(net["networkMode"], "VPC")
+        self.assertEqual(net["vpcSubnetIds"], ["subnet-aaa", "subnet-bbb"])
+        self.assertEqual(net["vpcSecurityGroupIds"], ["sg-ccc"])
+
+    @patch("boto3.client")
+    def test_create_runtime_vpc_mode_no_subnets(self, mock_boto_client: MagicMock) -> None:
+        """VPC mode without subnet/SG args should set networkMode without subnet fields."""
+        mock_client = MagicMock()
+        mock_boto_client.return_value = mock_client
+        mock_client.create_agent_runtime.return_value = {"agentRuntimeId": "rt-vpc2"}
+
+        create_runtime(
+            name="vpc-agent2",
+            description="",
+            role_arn="arn:aws:iam::123:role/r",
+            env_vars={},
+            network_mode="VPC",
+            artifact_bucket="b",
+            artifact_prefix="p",
+            region="us-east-1",
+        )
+
+        call_kwargs = mock_client.create_agent_runtime.call_args[1]
+        net = call_kwargs["networkConfiguration"]
+        self.assertEqual(net["networkMode"], "VPC")
+        self.assertNotIn("vpcSubnetIds", net)
+        self.assertNotIn("vpcSecurityGroupIds", net)
+
+
+class TestUpdateRuntimeVpc(unittest.TestCase):
+    """Test VPC configuration in update_runtime."""
+
+    @patch("boto3.client")
+    def test_update_runtime_vpc_mode_passes_subnet_and_sg(self, mock_boto_client: MagicMock) -> None:
+        """Updating to VPC mode should include subnet and SG IDs."""
+        mock_client = MagicMock()
+        mock_boto_client.return_value = mock_client
+        mock_client.update_agent_runtime.return_value = {"status": "UPDATING"}
+
+        update_runtime(
+            runtime_id="rt-123",
+            network_mode="VPC",
+            vpc_subnet_ids=["subnet-111", "subnet-222"],
+            vpc_security_group_ids=["sg-333"],
+            region="us-east-1",
+        )
+
+        call_kwargs = mock_client.update_agent_runtime.call_args[1]
+        net = call_kwargs["networkConfiguration"]
+        self.assertEqual(net["networkMode"], "VPC")
+        self.assertEqual(net["vpcSubnetIds"], ["subnet-111", "subnet-222"])
+        self.assertEqual(net["vpcSecurityGroupIds"], ["sg-333"])
+
+    @patch("boto3.client")
+    def test_update_runtime_public_mode_no_vpc_fields(self, mock_boto_client: MagicMock) -> None:
+        """Updating to PUBLIC mode should not include VPC fields."""
+        mock_client = MagicMock()
+        mock_boto_client.return_value = mock_client
+        mock_client.update_agent_runtime.return_value = {"status": "UPDATING"}
+
+        update_runtime(
+            runtime_id="rt-123",
+            network_mode="PUBLIC",
+            region="us-east-1",
+        )
+
+        call_kwargs = mock_client.update_agent_runtime.call_args[1]
+        net = call_kwargs["networkConfiguration"]
+        self.assertEqual(net["networkMode"], "PUBLIC")
+        self.assertNotIn("vpcSubnetIds", net)
+        self.assertNotIn("vpcSecurityGroupIds", net)
+
+    @patch("boto3.client")
+    def test_update_runtime_no_network_mode_omits_network_config(self, mock_boto_client: MagicMock) -> None:
+        """Omitting network_mode should not include networkConfiguration at all."""
+        mock_client = MagicMock()
+        mock_boto_client.return_value = mock_client
+        mock_client.update_agent_runtime.return_value = {"status": "UPDATING"}
+
+        update_runtime(runtime_id="rt-123", region="us-east-1")
+
+        call_kwargs = mock_client.update_agent_runtime.call_args[1]
+        self.assertNotIn("networkConfiguration", call_kwargs)
+
+
+class TestAgentModelVpc(unittest.TestCase):
+    """Test VPC helpers on the Agent model."""
+
+    def test_get_vpc_subnet_ids_empty(self) -> None:
+        from app.models.agent import Agent
+        agent = Agent(arn="a", runtime_id="r", region="us-east-1", account_id="123")
+        self.assertEqual(agent.get_vpc_subnet_ids(), [])
+
+    def test_set_get_vpc_subnet_ids(self) -> None:
+        from app.models.agent import Agent
+        agent = Agent(arn="a", runtime_id="r", region="us-east-1", account_id="123")
+        agent.set_vpc_subnet_ids(["subnet-aaa", "subnet-bbb"])
+        self.assertEqual(agent.get_vpc_subnet_ids(), ["subnet-aaa", "subnet-bbb"])
+
+    def test_set_vpc_subnet_ids_none_clears(self) -> None:
+        from app.models.agent import Agent
+        agent = Agent(arn="a", runtime_id="r", region="us-east-1", account_id="123")
+        agent.set_vpc_subnet_ids(["subnet-aaa"])
+        agent.set_vpc_subnet_ids(None)
+        self.assertIsNone(agent.vpc_subnet_ids)
+        self.assertEqual(agent.get_vpc_subnet_ids(), [])
+
+    def test_get_vpc_security_group_ids_empty(self) -> None:
+        from app.models.agent import Agent
+        agent = Agent(arn="a", runtime_id="r", region="us-east-1", account_id="123")
+        self.assertEqual(agent.get_vpc_security_group_ids(), [])
+
+    def test_set_get_vpc_security_group_ids(self) -> None:
+        from app.models.agent import Agent
+        agent = Agent(arn="a", runtime_id="r", region="us-east-1", account_id="123")
+        agent.set_vpc_security_group_ids(["sg-abc"])
+        self.assertEqual(agent.get_vpc_security_group_ids(), ["sg-abc"])
+
+    def test_to_dict_includes_vpc_fields(self) -> None:
+        from app.models.agent import Agent
+        agent = Agent(arn="a", runtime_id="r", region="us-east-1", account_id="123",
+                      name="test", status="READY", registered_at=None)
+        agent.set_vpc_subnet_ids(["subnet-aaa"])
+        agent.set_vpc_security_group_ids(["sg-bbb"])
+        d = agent.to_dict()
+        self.assertEqual(d["vpc_subnet_ids"], ["subnet-aaa"])
+        self.assertEqual(d["vpc_security_group_ids"], ["sg-bbb"])
+
+
 class TestUpdateRuntime(unittest.TestCase):
     """Test cases for update_runtime function."""
 

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from "./client";
-import type { TagPolicy, TagPolicyCreateRequest, TagPolicyUpdateRequest, TagProfile, TagProfileCreateRequest } from "./types";
+import type { TagPolicy, TagPolicyCreateRequest, TagPolicyUpdateRequest, TagProfile, TagProfileCreateRequest, VpcConfig, VpcConfigCreateRequest, VpcConfigDetail } from "./types";
 
 // Site Settings API
 export interface SiteSetting {
@@ -102,4 +102,33 @@ export function updateEnabledModels(model_ids: string[]): Promise<EnabledModelsC
     method: "PUT",
     body: JSON.stringify({ model_ids }),
   });
+}
+
+// VPC Configuration API
+export function listVpcConfigs(): Promise<VpcConfig[]> {
+  return apiFetch<VpcConfig[]>("/api/settings/vpc-configs");
+}
+
+export function createVpcConfig(request: VpcConfigCreateRequest): Promise<VpcConfig> {
+  return apiFetch<VpcConfig>("/api/settings/vpc-configs", {
+    method: "POST",
+    body: JSON.stringify(request),
+  });
+}
+
+export function updateVpcConfig(id: number, request: VpcConfigCreateRequest): Promise<VpcConfig> {
+  return apiFetch<VpcConfig>(`/api/settings/vpc-configs/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(request),
+  });
+}
+
+export function deleteVpcConfig(id: number): Promise<void> {
+  return apiFetch<void>(`/api/settings/vpc-configs/${id}`, {
+    method: "DELETE",
+  });
+}
+
+export function getVpcConfigDetail(id: number): Promise<VpcConfigDetail> {
+  return apiFetch<VpcConfigDetail>(`/api/settings/vpc-configs/${id}/detail`);
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -44,8 +44,8 @@ export interface AgentResponse {
   registry_status: string | null;
   code_interpreter_id?: string | null;
   code_interpreter_status?: string | null;
-  vpc_subnet_ids: string[];
-  vpc_security_group_ids: string[];
+  vpc_config_id: number | null;
+  status_reason?: string | null;
 }
 
 export interface AgentHarnessDeployRequest {
@@ -59,8 +59,7 @@ export interface AgentHarnessDeployRequest {
   allowed_model_ids?: string[];
   role_arn: string;
   network_mode: string;
-  vpc_subnet_ids: string[];
-  vpc_security_group_ids: string[];
+  vpc_config_id: number | null;
   idle_timeout: number | null;
   max_lifetime: number | null;
   authorizer_type: string | null;
@@ -72,10 +71,15 @@ export interface AgentHarnessDeployRequest {
   authorizer_client_id: string | null;
   authorizer_client_secret: string | null;
   mcp_servers: number[];
+  memory_ids?: number[];
   tags?: Record<string, string>;
   harness_max_iterations: number | null;
   harness_max_tokens: number | null;
   harness_tools?: Record<string, unknown>[];
+  code_interpreter_enabled: boolean;
+  code_interpreter_region: string;
+  code_interpreter_network_mode: string;
+  code_interpreter_role_id: number | null;
 }
 
 export interface AgentRegisterRequest {
@@ -96,8 +100,7 @@ export interface AgentDeployRequest {
   role_arn: string | null;
   protocol: string;
   network_mode: string;
-  vpc_subnet_ids: string[];
-  vpc_security_group_ids: string[];
+  vpc_config_id: number | null;
   idle_timeout: number | null;
   max_lifetime: number | null;
   authorizer_type: string | null;
@@ -692,6 +695,61 @@ export interface TagProfile {
 export interface TagProfileCreateRequest {
   name: string;
   tags: Record<string, string>;
+}
+
+// VPC Configuration types
+export interface VpcConfig {
+  id: number;
+  name: string;
+  description: string | null;
+  vpc_id: string;
+  subnet_ids: string[];
+  sg_ids: string[];
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface VpcConfigCreateRequest {
+  name: string;
+  description?: string;
+  vpc_id: string;
+  subnet_ids: string[];
+  sg_ids: string[];
+}
+
+export interface VpcSubnetDetail {
+  subnet_id: string;
+  availability_zone: string | null;
+  availability_zone_id: string | null;
+  cidr_block: string | null;
+  available_ips: number | null;
+  name: string | null;
+}
+
+export interface VpcSgRuleDetail {
+  protocol: string;
+  from_port: number | null;
+  to_port: number | null;
+  cidr: string | null;
+  source_sg_id: string | null;
+  source_sg_name: string | null;
+  description: string | null;
+}
+
+export interface VpcSgDetail {
+  sg_id: string;
+  name: string | null;
+  ingress: VpcSgRuleDetail[];
+  egress: VpcSgRuleDetail[];
+}
+
+export interface VpcConfigDetail {
+  id: number;
+  name: string;
+  description: string | null;
+  vpc_id: string;
+  subnets: VpcSubnetDetail[];
+  security_groups: VpcSgDetail[];
 }
 
 export interface ConnectorInfo {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -44,6 +44,8 @@ export interface AgentResponse {
   registry_status: string | null;
   code_interpreter_id?: string | null;
   code_interpreter_status?: string | null;
+  vpc_subnet_ids: string[];
+  vpc_security_group_ids: string[];
 }
 
 export interface AgentHarnessDeployRequest {
@@ -57,6 +59,8 @@ export interface AgentHarnessDeployRequest {
   allowed_model_ids?: string[];
   role_arn: string;
   network_mode: string;
+  vpc_subnet_ids: string[];
+  vpc_security_group_ids: string[];
   idle_timeout: number | null;
   max_lifetime: number | null;
   authorizer_type: string | null;
@@ -92,6 +96,8 @@ export interface AgentDeployRequest {
   role_arn: string | null;
   protocol: string;
   network_mode: string;
+  vpc_subnet_ids: string[];
+  vpc_security_group_ids: string[];
   idle_timeout: number | null;
   max_lifetime: number | null;
   authorizer_type: string | null;

--- a/frontend/src/components/AgentCard.tsx
+++ b/frontend/src/components/AgentCard.tsx
@@ -177,6 +177,11 @@ export function AgentCard({ agent, onSelect, onDelete, onEdit, readOnly, showOnC
             )}
           </div>
         )}
+        {agent.status_reason && (agent.status === "CREATE_FAILED" || agent.status === "UPDATE_FAILED" || agent.deployment_status === "failed") && (
+          <div className="text-[10px] text-destructive break-words">
+            {agent.status_reason}
+          </div>
+        )}
       </CardHeader>
       <CardContent className="space-y-3 text-xs text-muted-foreground">
         <div className="rounded border bg-input-bg p-3 space-y-0.5">

--- a/frontend/src/components/AgentRegistrationForm.tsx
+++ b/frontend/src/components/AgentRegistrationForm.tsx
@@ -116,6 +116,8 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
   const [selectedRoleId, setSelectedRoleId] = useState<string>("");
   const [protocol] = useState("HTTP");
   const [networkMode, setNetworkMode] = useState("PUBLIC");
+  const [vpcSubnetIds, setVpcSubnetIds] = useState("");
+  const [vpcSecurityGroupIds, setVpcSecurityGroupIds] = useState("");
 
   // Security config state (pre-configured by Security Admin)
   const [selectedAuthConfigId, setSelectedAuthConfigId] = useState<string>("");
@@ -206,6 +208,11 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
         if (match) setSelectedRoleId(match.id.toString());
       }
       if (parsed.network_mode) setNetworkMode(parsed.network_mode as string);
+      if (parsed.vpc && typeof parsed.vpc === "object") {
+        const vpc = parsed.vpc as Record<string, unknown>;
+        if (Array.isArray(vpc.subnet_ids)) setVpcSubnetIds((vpc.subnet_ids as string[]).join(", "));
+        if (Array.isArray(vpc.security_group_ids)) setVpcSecurityGroupIds((vpc.security_group_ids as string[]).join(", "));
+      }
       if (parsed.authorizer) {
         const match = authConfigs.find((c) => c.name === parsed.authorizer || c.id.toString() === parsed.authorizer);
         if (match) setSelectedAuthConfigId(match.id.toString());
@@ -340,6 +347,8 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
           : undefined,
         role_arn: roleArn,
         network_mode: networkMode,
+        vpc_subnet_ids: networkMode === "VPC" ? vpcSubnetIds.split(",").map(s => s.trim()).filter(Boolean) : [],
+        vpc_security_group_ids: networkMode === "VPC" ? vpcSecurityGroupIds.split(",").map(s => s.trim()).filter(Boolean) : [],
         idle_timeout: idleTimeout ? parseInt(idleTimeout, 10) : null,
         max_lifetime: maxLifetime ? parseInt(maxLifetime, 10) : null,
         authorizer_type: authConfig?.authorizer_type ?? null,
@@ -398,6 +407,8 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
         role_arn: roleArn,
         protocol,
         network_mode: networkMode,
+        vpc_subnet_ids: networkMode === "VPC" ? vpcSubnetIds.split(",").map(s => s.trim()).filter(Boolean) : [],
+        vpc_security_group_ids: networkMode === "VPC" ? vpcSecurityGroupIds.split(",").map(s => s.trim()).filter(Boolean) : [],
         idle_timeout: idleTimeout ? parseInt(idleTimeout, 10) : defaults.idle_timeout_seconds,
         max_lifetime: maxLifetime ? parseInt(maxLifetime, 10) : defaults.max_lifetime_seconds,
         authorizer_type: authConfig?.authorizer_type ?? null,
@@ -512,6 +523,11 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                       if (match) setSelectedRoleId(match.id.toString());
                     }
                     if (parsed.network_mode) setNetworkMode(parsed.network_mode);
+                    if (parsed.vpc && typeof parsed.vpc === "object") {
+                      const vpc = parsed.vpc as Record<string, unknown>;
+                      if (Array.isArray(vpc.subnet_ids)) setVpcSubnetIds((vpc.subnet_ids as string[]).join(", "));
+                      if (Array.isArray(vpc.security_group_ids)) setVpcSecurityGroupIds((vpc.security_group_ids as string[]).join(", "));
+                    }
                     if (parsed.authorizer) {
                       const match = authConfigs.find((c) => c.name === parsed.authorizer || c.id.toString() === parsed.authorizer);
                       if (match) setSelectedAuthConfigId(match.id.toString());
@@ -588,6 +604,12 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                     result.allowed_models = selectedAllowedModelIds;
                   }
                   if (networkMode && networkMode !== "PUBLIC") result.network_mode = networkMode;
+                  if (networkMode === "VPC" && (vpcSubnetIds.trim() || vpcSecurityGroupIds.trim())) {
+                    const vpcObj: Record<string, string[]> = {};
+                    if (vpcSubnetIds.trim()) vpcObj.subnet_ids = vpcSubnetIds.split(",").map(s => s.trim()).filter(Boolean);
+                    if (vpcSecurityGroupIds.trim()) vpcObj.security_group_ids = vpcSecurityGroupIds.split(",").map(s => s.trim()).filter(Boolean);
+                    result.vpc = vpcObj;
+                  }
                   if (selectedRoleId) {
                     const role = managedRoles.find((r) => r.id.toString() === selectedRoleId);
                     if (role) result.role = role.role_name;
@@ -748,7 +770,7 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="PUBLIC">PUBLIC</SelectItem>
-                      <SelectItem value="VPC" disabled>VPC (coming soon)</SelectItem>
+                      <SelectItem value="VPC">VPC</SelectItem>
                     </SelectContent>
                   </Select>
                 </section>
@@ -765,6 +787,34 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                   />
                 </section>
               </div>
+
+              {/* VPC Configuration */}
+              {networkMode === "VPC" && (
+                <div className="grid grid-cols-2 gap-4">
+                  <section className="space-y-2">
+                    <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Subnet IDs</h4>
+                    <input
+                      type="text"
+                      className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+                      placeholder="subnet-abc123, subnet-def456"
+                      value={vpcSubnetIds}
+                      onChange={e => setVpcSubnetIds(e.target.value)}
+                    />
+                    <p className="text-xs text-muted-foreground">Comma-separated private subnet IDs for VPC egress.</p>
+                  </section>
+                  <section className="space-y-2">
+                    <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Security Group IDs</h4>
+                    <input
+                      type="text"
+                      className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+                      placeholder="sg-abc123, sg-def456"
+                      value={vpcSecurityGroupIds}
+                      onChange={e => setVpcSecurityGroupIds(e.target.value)}
+                    />
+                    <p className="text-xs text-muted-foreground">Comma-separated security group IDs for agent egress traffic.</p>
+                  </section>
+                </div>
+              )}
 
               {/* Allowed Models for Runtime Selection */}
               {modelId && models.length > 0 && (

--- a/frontend/src/components/AgentRegistrationForm.tsx
+++ b/frontend/src/components/AgentRegistrationForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
@@ -21,9 +21,95 @@ import { listA2aAgents } from "@/api/a2a";
 import { useAuth } from "@/contexts/AuthContext";
 import { listMemories } from "@/api/memories";
 import { ResourceTagFields } from "@/components/ResourceTagFields";
-import type { AgentDeployRequest, AgentHarnessDeployRequest, ModelOption, ManagedRole, AuthorizerConfigResponse, TagProfile, McpServer, A2aAgent, MemoryResponse } from "@/api/types";
+import type { AgentDeployRequest, AgentHarnessDeployRequest, ModelOption, ManagedRole, AuthorizerConfigResponse, TagProfile, McpServer, A2aAgent, MemoryResponse, VpcConfig, VpcConfigDetail } from "@/api/types";
 import { groupModels } from "@/lib/models";
 import { toast } from "sonner";
+
+function formatSgPort(r: { protocol: string; from_port: number | null; to_port: number | null }): string {
+  if (r.protocol === "All") return "All";
+  if (r.from_port === null && r.to_port === null) return "All";
+  if (r.from_port === r.to_port) return String(r.from_port);
+  return `${r.from_port}–${r.to_port}`;
+}
+
+function VpcDetailTables({ detail }: { detail: VpcConfigDetail }) {
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <p className="text-xs font-medium text-muted-foreground">Subnets ({detail.subnets.length})</p>
+        <table className="text-xs w-full border-collapse border border-border rounded">
+          <thead>
+            <tr className="bg-accent text-muted-foreground">
+              <th className="text-left font-medium px-2 py-1 border border-border">Subnet ID</th>
+              <th className="text-left font-medium px-2 py-1 border border-border">Availability Zone / ID</th>
+              <th className="text-left font-medium px-2 py-1 border border-border">CIDR</th>
+              <th className="text-left font-medium px-2 py-1 border border-border">Available IPs</th>
+            </tr>
+          </thead>
+          <tbody>
+            {detail.subnets.map((s) => (
+              <tr key={s.subnet_id} className="bg-background">
+                <td className="px-2 py-0.5 font-mono border border-border">
+                  {s.subnet_id}{s.name && <span className="ml-1 text-muted-foreground">({s.name})</span>}
+                </td>
+                <td className="px-2 py-0.5 font-mono border border-border">
+                  {s.availability_zone ?? "—"}
+                  {s.availability_zone_id && (
+                    <span className="ml-1 text-muted-foreground">({s.availability_zone_id})</span>
+                  )}
+                </td>
+                <td className="px-2 py-0.5 font-mono border border-border">{s.cidr_block ?? "—"}</td>
+                <td className="px-2 py-0.5 border border-border text-muted-foreground">{s.available_ips ?? "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {detail.security_groups.map((sg) => (
+        <div key={sg.sg_id} className="space-y-2">
+          <p className="text-xs font-medium text-muted-foreground">{sg.sg_id}{sg.name ? ` — ${sg.name}` : ""}</p>
+          {(["ingress", "egress"] as const).map((dir) => (
+            <div key={dir} className="space-y-1">
+              <p className="text-[10px] uppercase tracking-wide text-muted-foreground">{dir === "ingress" ? "Inbound" : "Outbound"} rules</p>
+              <table className="text-xs w-full border-collapse border border-border rounded table-fixed">
+                <colgroup>
+                  <col className="w-20" />
+                  <col className="w-24" />
+                  <col className="w-[25%]" />
+                  <col />
+                </colgroup>
+                <thead>
+                  <tr className="bg-accent text-muted-foreground">
+                    <th className="text-left font-medium px-2 py-1 border border-border">Protocol</th>
+                    <th className="text-left font-medium px-2 py-1 border border-border">Port</th>
+                    <th className="text-left font-medium px-2 py-1 border border-border">Source / Destination</th>
+                    <th className="text-left font-medium px-2 py-1 border border-border">Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sg[dir].length === 0 ? (
+                    <tr className="bg-background">
+                      <td colSpan={4} className="px-2 py-1 border border-border text-muted-foreground italic">No rules</td>
+                    </tr>
+                  ) : sg[dir].map((r, i) => (
+                    <tr key={i} className="bg-background align-top">
+                      <td className="px-2 py-0.5 font-mono border border-border">{r.protocol}</td>
+                      <td className="px-2 py-0.5 font-mono border border-border">{formatSgPort(r)}</td>
+                      <td className="px-2 py-0.5 font-mono border border-border break-all">
+                        {r.cidr ?? (r.source_sg_id ? (r.source_sg_name ? `${r.source_sg_id} (${r.source_sg_name})` : r.source_sg_id) : "—")}
+                      </td>
+                      <td className="px-2 py-0.5 border border-border text-muted-foreground break-words">{r.description ?? ""}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
 
 function TagInput({
   values,
@@ -116,14 +202,16 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
   const [selectedRoleId, setSelectedRoleId] = useState<string>("");
   const [protocol] = useState("HTTP");
   const [networkMode, setNetworkMode] = useState("PUBLIC");
-  const [vpcSubnetIds, setVpcSubnetIds] = useState("");
-  const [vpcSecurityGroupIds, setVpcSecurityGroupIds] = useState("");
+  const [vpcConfigId, setVpcConfigId] = useState<string>("");
+  const [vpcConfigs, setVpcConfigs] = useState<VpcConfig[]>([]);
 
   // Security config state (pre-configured by Security Admin)
   const [selectedAuthConfigId, setSelectedAuthConfigId] = useState<string>("");
 
   // Permission request state
   const [showRolePerms, setShowRolePerms] = useState(false);
+  const [showVpcDetail, setShowVpcDetail] = useState(false);
+  const [vpcDetail, setVpcDetail] = useState<VpcConfigDetail | "loading" | null>(null);
   const [showPermRequest, setShowPermRequest] = useState(false);
   const [permActions, setPermActions] = useState<string[]>([]);
   const [permResources, setPermResources] = useState<string[]>([]);
@@ -173,6 +261,7 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
         securityApi.listManagedRoles().then(setManagedRoles).catch(() => {}),
         securityApi.listAuthorizerConfigs().then(setAuthConfigs).catch(() => {}),
         settingsApi.listTagProfiles().then(setTagProfiles).catch(() => {}),
+        settingsApi.listVpcConfigs().then(setVpcConfigs).catch(() => {}),
         listMcpServers().then(setMcpServers).catch(() => {}),
         listA2aAgents().then(setA2aAgents).catch(() => {}),
         listMemories().then(setMemories).catch(() => {}),
@@ -182,6 +271,7 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
 
   // Auto-populate form when editing an existing agent
   const [loadedAgentId, setLoadedAgentId] = useState<number | undefined>(undefined);
+  const pendingVpcConfigName = useRef<string | null>(null);
   useEffect(() => {
     if (!exportAgentId || !hasScope("admin:write")) return;
     if (exportAgentId === loadedAgentId) return;
@@ -207,11 +297,18 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
         const match = managedRoles.find((r) => r.role_name === parsed.role || r.role_arn === parsed.role);
         if (match) setSelectedRoleId(match.id.toString());
       }
-      if (parsed.network_mode) setNetworkMode(parsed.network_mode as string);
       if (parsed.vpc && typeof parsed.vpc === "object") {
         const vpc = parsed.vpc as Record<string, unknown>;
-        if (Array.isArray(vpc.subnet_ids)) setVpcSubnetIds((vpc.subnet_ids as string[]).join(", "));
-        if (Array.isArray(vpc.security_group_ids)) setVpcSecurityGroupIds((vpc.security_group_ids as string[]).join(", "));
+        if (typeof vpc.mode === "string") setNetworkMode(vpc.mode);
+        if (typeof vpc.config === "string") {
+          const match = vpcConfigs.find((c) => c.name === vpc.config || c.id.toString() === vpc.config);
+          if (match) {
+            setVpcConfigId(match.id.toString());
+          } else {
+            // vpcConfigs may not be loaded yet — store name for deferred resolution
+            pendingVpcConfigName.current = vpc.config;
+          }
+        }
       }
       if (parsed.authorizer) {
         const match = authConfigs.find((c) => c.name === parsed.authorizer || c.id.toString() === parsed.authorizer);
@@ -273,8 +370,20 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [exportAgentId, models.length, dataLoaded]);
 
+  // Deferred VPC config resolution: if vpcConfigs wasn't loaded when the export ran,
+  // resolve the pending name once vpcConfigs becomes available.
+  useEffect(() => {
+    if (!pendingVpcConfigName.current || vpcConfigs.length === 0) return;
+    const match = vpcConfigs.find((c) => c.name === pendingVpcConfigName.current || c.id.toString() === pendingVpcConfigName.current);
+    if (match) {
+      setVpcConfigId(match.id.toString());
+      pendingVpcConfigName.current = null;
+    }
+  }, [vpcConfigs]);
+
   const selectedRole = managedRoles.find((r) => r.id.toString() === selectedRoleId);
   const selectedAuthConfig = authConfigs.find((c) => c.id.toString() === selectedAuthConfigId);
+  const selectedVpcConfig = vpcConfigs.find((c) => c.id.toString() === vpcConfigId);
 
   const validateName = (value: string) => {
     if (!value) {
@@ -347,8 +456,7 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
           : undefined,
         role_arn: roleArn,
         network_mode: networkMode,
-        vpc_subnet_ids: networkMode === "VPC" ? vpcSubnetIds.split(",").map(s => s.trim()).filter(Boolean) : [],
-        vpc_security_group_ids: networkMode === "VPC" ? vpcSecurityGroupIds.split(",").map(s => s.trim()).filter(Boolean) : [],
+        vpc_config_id: networkMode === "VPC" && vpcConfigId ? parseInt(vpcConfigId, 10) : null,
         idle_timeout: idleTimeout ? parseInt(idleTimeout, 10) : null,
         max_lifetime: maxLifetime ? parseInt(maxLifetime, 10) : null,
         authorizer_type: authConfig?.authorizer_type ?? null,
@@ -360,11 +468,16 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
         authorizer_client_id: authConfig?.client_id ?? null,
         authorizer_client_secret: null,
         mcp_servers: selectedMcpServerIds,
+        memory_ids: selectedMemoryIds,
         tags: Object.fromEntries(
           Object.entries(tagValues).filter(([, v]) => v.trim() !== "")
         ),
         harness_max_iterations: harnessMaxIterations ? parseInt(harnessMaxIterations, 10) : null,
         harness_max_tokens: harnessMaxTokens ? parseInt(harnessMaxTokens, 10) : null,
+        code_interpreter_enabled: codeInterpreterEnabled,
+        code_interpreter_region: codeInterpreterRegion,
+        code_interpreter_network_mode: codeInterpreterNetworkMode,
+        code_interpreter_role_id: codeInterpreterRoleId ? parseInt(codeInterpreterRoleId) : null,
         harness_tools: enableHumanConfirmation ? [{
           name: "user_confirmation",
           type: "inline_function",
@@ -407,8 +520,7 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
         role_arn: roleArn,
         protocol,
         network_mode: networkMode,
-        vpc_subnet_ids: networkMode === "VPC" ? vpcSubnetIds.split(",").map(s => s.trim()).filter(Boolean) : [],
-        vpc_security_group_ids: networkMode === "VPC" ? vpcSecurityGroupIds.split(",").map(s => s.trim()).filter(Boolean) : [],
+        vpc_config_id: networkMode === "VPC" && vpcConfigId ? parseInt(vpcConfigId, 10) : null,
         idle_timeout: idleTimeout ? parseInt(idleTimeout, 10) : defaults.idle_timeout_seconds,
         max_lifetime: maxLifetime ? parseInt(maxLifetime, 10) : defaults.max_lifetime_seconds,
         authorizer_type: authConfig?.authorizer_type ?? null,
@@ -522,11 +634,13 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                       const match = managedRoles.find((r) => r.role_name === parsed.role || r.role_arn === parsed.role);
                       if (match) setSelectedRoleId(match.id.toString());
                     }
-                    if (parsed.network_mode) setNetworkMode(parsed.network_mode);
                     if (parsed.vpc && typeof parsed.vpc === "object") {
                       const vpc = parsed.vpc as Record<string, unknown>;
-                      if (Array.isArray(vpc.subnet_ids)) setVpcSubnetIds((vpc.subnet_ids as string[]).join(", "));
-                      if (Array.isArray(vpc.security_group_ids)) setVpcSecurityGroupIds((vpc.security_group_ids as string[]).join(", "));
+                      if (typeof vpc.mode === "string") setNetworkMode(vpc.mode);
+                      if (typeof vpc.config === "string") {
+                        const match = vpcConfigs.find((c) => c.name === vpc.config || c.id.toString() === vpc.config);
+                        if (match) setVpcConfigId(match.id.toString());
+                      }
                     }
                     if (parsed.authorizer) {
                       const match = authConfigs.find((c) => c.name === parsed.authorizer || c.id.toString() === parsed.authorizer);
@@ -603,12 +717,13 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                   if (selectedAllowedModelIds.length > 0) {
                     result.allowed_models = selectedAllowedModelIds;
                   }
-                  if (networkMode && networkMode !== "PUBLIC") result.network_mode = networkMode;
-                  if (networkMode === "VPC" && (vpcSubnetIds.trim() || vpcSecurityGroupIds.trim())) {
-                    const vpcObj: Record<string, string[]> = {};
-                    if (vpcSubnetIds.trim()) vpcObj.subnet_ids = vpcSubnetIds.split(",").map(s => s.trim()).filter(Boolean);
-                    if (vpcSecurityGroupIds.trim()) vpcObj.security_group_ids = vpcSecurityGroupIds.split(",").map(s => s.trim()).filter(Boolean);
-                    result.vpc = vpcObj;
+                  if (networkMode && networkMode !== "PUBLIC") {
+                    const vpcBlock: Record<string, string> = { mode: networkMode };
+                    if (networkMode === "VPC" && vpcConfigId) {
+                      const cfg = vpcConfigs.find((c) => c.id.toString() === vpcConfigId);
+                      if (cfg) vpcBlock.config = cfg.name;
+                    }
+                    result.vpc = vpcBlock;
                   }
                   if (selectedRoleId) {
                     const role = managedRoles.find((r) => r.id.toString() === selectedRoleId);
@@ -788,70 +903,6 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                 </section>
               </div>
 
-              {/* VPC Configuration */}
-              {networkMode === "VPC" && (
-                <div className="grid grid-cols-2 gap-4">
-                  <section className="space-y-2">
-                    <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Subnet IDs</h4>
-                    <input
-                      type="text"
-                      className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
-                      placeholder="subnet-abc123, subnet-def456"
-                      value={vpcSubnetIds}
-                      onChange={e => setVpcSubnetIds(e.target.value)}
-                    />
-                    <p className="text-xs text-muted-foreground">Comma-separated private subnet IDs for VPC egress.</p>
-                  </section>
-                  <section className="space-y-2">
-                    <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Security Group IDs</h4>
-                    <input
-                      type="text"
-                      className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
-                      placeholder="sg-abc123, sg-def456"
-                      value={vpcSecurityGroupIds}
-                      onChange={e => setVpcSecurityGroupIds(e.target.value)}
-                    />
-                    <p className="text-xs text-muted-foreground">Comma-separated security group IDs for agent egress traffic.</p>
-                  </section>
-                </div>
-              )}
-
-              {/* Allowed Models for Runtime Selection */}
-              {modelId && models.length > 0 && (
-                <section className="space-y-2">
-                  <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Allowed Models (runtime selection)</h4>
-                  <p className="text-xs text-muted-foreground">Users can choose from these models when invoking the agent. The deploy model is always included.</p>
-                  <div className="space-y-1.5">
-                    {groupModels(models).map(([group, groupedModels]) => (
-                      <div key={group} className="flex flex-wrap gap-x-4 gap-y-1 items-center">
-                        <span className="text-[10px] font-medium text-muted-foreground w-16 shrink-0">{group}</span>
-                        {groupedModels.map((m) => (
-                          <label key={m.model_id} className="flex items-center gap-2 text-xs cursor-pointer">
-                            <input
-                              type="checkbox"
-                              className="h-3.5 w-3.5 shrink-0"
-                              checked={m.model_id === modelId || selectedAllowedModelIds.includes(m.model_id)}
-                              disabled={m.model_id === modelId}
-                              onChange={(e) => {
-                                if (e.target.checked) {
-                                  setSelectedAllowedModelIds((prev) => [...prev, m.model_id]);
-                                } else {
-                                  setSelectedAllowedModelIds((prev) => prev.filter((id) => id !== m.model_id));
-                                }
-                              }}
-                            />
-                            <span>{m.display_name}</span>
-                            {m.model_id === modelId && (
-                              <span className="text-[10px] text-muted-foreground bg-accent px-1 rounded">default</span>
-                            )}
-                          </label>
-                        ))}
-                      </div>
-                    ))}
-                  </div>
-                </section>
-              )}
-
               {/* IAM Role Permissions (read-only) */}
               {selectedRole && (
                 <section className="space-y-3">
@@ -939,6 +990,97 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                       </Button>
                     </div>
                   )}
+                </section>
+              )}
+
+              {/* VPC Configuration */}
+              {networkMode === "VPC" && (
+                <section className="space-y-2">
+                  <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">VPC Configuration</h4>
+                  <SearchableSelect
+                    options={vpcConfigs.map((c) => ({ value: c.id.toString(), label: c.name, description: `${c.vpc_id} · ${c.subnet_ids.length} subnets · ${c.sg_ids.length} SGs` }))}
+                    value={vpcConfigId}
+                    onValueChange={(v) => {
+                      setVpcConfigId(v);
+                      setShowVpcDetail(false);
+                      setVpcDetail(null);
+                    }}
+                    placeholder="Select VPC configuration..."
+                  />
+                  {vpcConfigs.length === 0 && (
+                    <p className="text-xs text-muted-foreground">No VPC configurations available. Add one in Settings → Networking.</p>
+                  )}
+                  {selectedVpcConfig && (
+                    <div className="space-y-2">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const next = !showVpcDetail;
+                          setShowVpcDetail(next);
+                          if (next && !vpcDetail) {
+                            setVpcDetail("loading");
+                            settingsApi.getVpcConfigDetail(selectedVpcConfig.id)
+                              .then(setVpcDetail)
+                              .catch(() => setVpcDetail(null));
+                          }
+                        }}
+                        className="flex items-center gap-1 text-xs font-medium text-muted-foreground uppercase tracking-wide hover:text-foreground"
+                      >
+                        {showVpcDetail ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+                        VPC Details (read-only)
+                      </button>
+                      {showVpcDetail && (
+                        <div className="rounded border p-3 bg-muted/30 space-y-3">
+                          {vpcDetail === "loading" ? (
+                            <p className="text-xs text-muted-foreground">Loading…</p>
+                          ) : vpcDetail ? (
+                            <>
+                              <p className="text-xs text-muted-foreground font-mono">{vpcDetail.vpc_id}</p>
+                              <VpcDetailTables detail={vpcDetail} />
+                            </>
+                          ) : (
+                            <p className="text-xs text-muted-foreground">Could not load VPC details.</p>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </section>
+              )}
+
+              {/* Allowed Models for Runtime Selection */}
+              {modelId && models.length > 0 && (
+                <section className="space-y-2">
+                  <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Allowed Models (runtime selection)</h4>
+                  <p className="text-xs text-muted-foreground">Users can choose from these models when invoking the agent. The deploy model is always included.</p>
+                  <div className="space-y-1.5">
+                    {groupModels(models).map(([group, groupedModels]) => (
+                      <div key={group} className="flex flex-wrap gap-x-4 gap-y-1 items-center">
+                        <span className="text-[10px] font-medium text-muted-foreground w-16 shrink-0">{group}</span>
+                        {groupedModels.map((m) => (
+                          <label key={m.model_id} className="flex items-center gap-2 text-xs cursor-pointer">
+                            <input
+                              type="checkbox"
+                              className="h-3.5 w-3.5 shrink-0"
+                              checked={m.model_id === modelId || selectedAllowedModelIds.includes(m.model_id)}
+                              disabled={m.model_id === modelId}
+                              onChange={(e) => {
+                                if (e.target.checked) {
+                                  setSelectedAllowedModelIds((prev) => [...prev, m.model_id]);
+                                } else {
+                                  setSelectedAllowedModelIds((prev) => prev.filter((id) => id !== m.model_id));
+                                }
+                              }}
+                            />
+                            <span>{m.display_name}</span>
+                            {m.model_id === modelId && (
+                              <span className="text-[10px] text-muted-foreground bg-accent px-1 rounded">default</span>
+                            )}
+                          </label>
+                        ))}
+                      </div>
+                    ))}
+                  </div>
                 </section>
               )}
 
@@ -1073,8 +1215,7 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
               <ResourceTagFields onChange={setTagValues} profileId={selectedTagProfileId} groupRestriction={groupRestriction} ownerRestriction={ownerRestriction} />
 
               {/* Integrations */}
-              {/* Memory Resources (Custom Agent only) */}
-              {deploymentType === "custom" && (
+              {/* Memory Resources */}
               <section className="space-y-3">
                 <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Memory Resources</h4>
                 <div className="space-y-1.5">
@@ -1106,7 +1247,6 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                   )}
                 </div>
               </section>
-              )}
 
               {/* MCP Servers */}
               <section className="space-y-3">
@@ -1199,7 +1339,6 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
               )}
 
               {/* Code Interpreter (Custom Agent only) */}
-              {deploymentType === "custom" && (
               <section className="space-y-3">
                 <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Code Interpreter</h4>
                 <label className="flex items-center gap-2 text-xs cursor-pointer">
@@ -1246,7 +1385,6 @@ export function AgentRegistrationForm({ mode, onRegister, onDeploy, onDeployHarn
                   </div>
                 )}
               </section>
-              )}
 
               <div className="space-y-1.5">
               <p className="text-[10px] text-muted-foreground italic">

--- a/frontend/src/components/SortableCardGrid.tsx
+++ b/frontend/src/components/SortableCardGrid.tsx
@@ -1,47 +1,5 @@
-import { useState, useEffect, type ReactNode } from "react";
-import {
-  DndContext,
-  closestCenter,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-} from "@dnd-kit/core";
-import {
-  SortableContext,
-  rectSortingStrategy,
-  useSortable,
-} from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
+import { type ReactNode } from "react";
 import { ArrowDownAZ, ArrowUpAZ } from "lucide-react";
-
-interface SortableItemProps {
-  id: string;
-  children: ReactNode;
-}
-
-function SortableItem({ id, children }: SortableItemProps) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.5 : 1,
-  };
-
-  return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-      {children}
-    </div>
-  );
-}
 
 export type SortDirection = "asc" | "desc";
 
@@ -82,18 +40,6 @@ interface SortableCardGridProps<T> {
   className?: string;
 }
 
-function loadOrder(key: string): string[] {
-  try {
-    const raw = localStorage.getItem(`loom-order-${key}`);
-    if (raw) return JSON.parse(raw) as string[];
-  } catch { /* ignore */ }
-  return [];
-}
-
-function saveOrder(key: string, ids: string[]) {
-  localStorage.setItem(`loom-order-${key}`, JSON.stringify(ids));
-}
-
 function alphabeticalCompare(a: string, b: string, direction: SortDirection): number {
   const cmp = a.localeCompare(b, undefined, { sensitivity: "base" });
   return direction === "desc" ? -cmp : cmp;
@@ -103,99 +49,24 @@ export function SortableCardGrid<T>({
   items,
   getId,
   getName,
-  storageKey,
   sortDirection,
-  onSortDirectionChange,
   renderItem,
   prependItems,
   className = "grid gap-4 md:grid-cols-2 lg:grid-cols-3",
 }: SortableCardGridProps<T>) {
-  const [orderedIds, setOrderedIds] = useState<string[]>(() => loadOrder(storageKey));
-  // Track whether the user has a custom drag order active (sort direction was cleared by drag)
-  const [customOrder, setCustomOrder] = useState<boolean>(() => {
-    const raw = localStorage.getItem(`loom-sort-${storageKey}`);
-    // If there's no sort preference saved but there IS a saved order, it's a custom drag order
-    return raw === null && loadOrder(storageKey).length > 0;
-  });
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  const sortedItems = [...items].sort((a, b) =>
+    alphabeticalCompare(getName(a), getName(b), sortDirection)
   );
 
-  // Re-sort items according to custom order or alphabetical
-  const sortedItems = (() => {
-    const itemMap = new Map(items.map((item) => [getId(item), item]));
-
-    // If user has custom drag order active, use it
-    if (customOrder && orderedIds.length > 0) {
-      const result: T[] = [];
-      for (const id of orderedIds) {
-        const item = itemMap.get(id);
-        if (item) {
-          result.push(item);
-          itemMap.delete(id);
-        }
-      }
-      // New items not in saved order — sorted alphabetically among themselves
-      const remaining = [...itemMap.values()];
-      remaining.sort((a, b) => alphabeticalCompare(getName(a), getName(b), "asc"));
-      result.push(...remaining);
-      return result;
-    }
-
-    // Sort alphabetically using the provided direction
-    const all = [...items];
-    all.sort((a, b) => alphabeticalCompare(getName(a), getName(b), sortDirection));
-    return all;
-  })();
-
-  const sortedIds = sortedItems.map(getId);
-
-  // Persist order whenever items change (new items added/removed) and custom order is active
-  useEffect(() => {
-    if (!customOrder) return;
-    const currentIds = items.map(getId);
-    const saved = loadOrder(storageKey);
-    const savedSet = new Set(saved);
-    const hasNew = currentIds.some((id) => !savedSet.has(id));
-    const hasRemoved = saved.some((id) => !currentIds.includes(id));
-    if (hasNew || hasRemoved) {
-      saveOrder(storageKey, sortedIds);
-    }
-  }, [items.map(getId).join(",")]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  function handleDragEnd(event: DragEndEvent) {
-    const { active, over } = event;
-    if (!over || active.id === over.id) return;
-
-    const oldIndex = sortedIds.indexOf(String(active.id));
-    const newIndex = sortedIds.indexOf(String(over.id));
-    if (oldIndex === -1 || newIndex === -1) return;
-
-    const newIds = [...sortedIds];
-    newIds.splice(oldIndex, 1);
-    newIds.splice(newIndex, 0, String(active.id));
-    setOrderedIds(newIds);
-    saveOrder(storageKey, newIds);
-    // Enter custom order mode
-    setCustomOrder(true);
-    localStorage.removeItem(`loom-sort-${storageKey}`);
-    onSortDirectionChange(null);
-  }
-
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-      <SortableContext items={sortedIds} strategy={rectSortingStrategy}>
-        <div className={className}>
-          {prependItems}
-          {sortedItems.map((item) => (
-            <SortableItem key={getId(item)} id={getId(item)}>
-              {renderItem(item)}
-            </SortableItem>
-          ))}
+    <div className={className}>
+      {prependItems}
+      {sortedItems.map((item) => (
+        <div key={getId(item)}>
+          {renderItem(item)}
         </div>
-      </SortableContext>
-    </DndContext>
+      ))}
+    </div>
   );
 }
 

--- a/frontend/src/components/VpcConfigPanel.tsx
+++ b/frontend/src/components/VpcConfigPanel.tsx
@@ -1,0 +1,484 @@
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { SortableCardGrid, SortButton, loadSortDirection, toggleSortDirection, saveSortDirection, type SortDirection } from "@/components/SortableCardGrid";
+import { JsonConfigSection } from "@/components/JsonConfigSection";
+import { ChevronDown, ChevronRight, Trash2, Plus, Pencil, Loader2, Network, Shield, LogIn, LogOut } from "lucide-react";
+import { toast } from "sonner";
+import * as settingsApi from "@/api/settings";
+import type { VpcConfig, VpcConfigCreateRequest, VpcConfigDetail, VpcSgRuleDetail } from "@/api/types";
+
+function parseIds(raw: string): string[] {
+  return raw.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+function joinIds(ids: string[]): string {
+  return ids.join(", ");
+}
+
+interface FormState {
+  name: string;
+  description: string;
+  vpc_id: string;
+  subnet_ids_raw: string;
+  sg_ids_raw: string;
+}
+
+const EMPTY_FORM_STATE: FormState = {
+  name: "",
+  description: "",
+  vpc_id: "",
+  subnet_ids_raw: "",
+  sg_ids_raw: "",
+};
+
+function formToRequest(form: FormState): VpcConfigCreateRequest {
+  return {
+    name: form.name.trim(),
+    description: form.description.trim() || undefined,
+    vpc_id: form.vpc_id.trim(),
+    subnet_ids: parseIds(form.subnet_ids_raw),
+    sg_ids: parseIds(form.sg_ids_raw),
+  };
+}
+
+function configToFormState(cfg: VpcConfig): FormState {
+  return {
+    name: cfg.name,
+    description: cfg.description ?? "",
+    vpc_id: cfg.vpc_id,
+    subnet_ids_raw: joinIds(cfg.subnet_ids),
+    sg_ids_raw: joinIds(cfg.sg_ids),
+  };
+}
+
+function formatPortRange(rule: VpcSgRuleDetail): string {
+  if (rule.protocol === "All") return "All";
+  if (rule.from_port === null && rule.to_port === null) return "All";
+  if (rule.from_port === rule.to_port) return String(rule.from_port);
+  return `${rule.from_port}–${rule.to_port}`;
+}
+
+function SgRulesTable({ rules, label, icon }: { rules: VpcSgRuleDetail[]; label: string; icon: React.ReactNode }) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      <table className="text-xs w-full border-collapse border border-border rounded table-fixed">
+        <colgroup>
+          <col className="w-20" />
+          <col className="w-24" />
+          <col className="w-[25%]" />
+          <col />
+        </colgroup>
+        <thead>
+          <tr className="text-muted-foreground bg-accent">
+            <th className="text-left font-medium px-2 py-1 border border-border">Protocol</th>
+            <th className="text-left font-medium px-2 py-1 border border-border">Port</th>
+            <th className="text-left font-medium px-2 py-1 border border-border">Source / Destination</th>
+            <th className="text-left font-medium px-2 py-1 border border-border">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rules.length === 0 ? (
+            <tr className="bg-background">
+              <td colSpan={4} className="px-2 py-1 border border-border text-muted-foreground italic">No rules</td>
+            </tr>
+          ) : rules.map((r, i) => (
+            <tr key={i} className="bg-background align-top">
+              <td className="px-2 py-0.5 font-mono border border-border">{r.protocol}</td>
+              <td className="px-2 py-0.5 font-mono border border-border">{formatPortRange(r)}</td>
+              <td className="px-2 py-0.5 font-mono border border-border break-all">
+                {r.cidr ?? (r.source_sg_id
+                  ? (r.source_sg_name ? `${r.source_sg_id} (${r.source_sg_name})` : r.source_sg_id)
+                  : "—")}
+              </td>
+              <td className="px-2 py-0.5 border border-border text-muted-foreground break-words">{r.description ?? ""}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function VpcConfigPanel({ readOnly }: { readOnly?: boolean }) {
+  const [configs, setConfigs] = useState<VpcConfig[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM_STATE);
+  const [submitting, setSubmitting] = useState(false);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [detailCache, setDetailCache] = useState<Record<number, VpcConfigDetail | "loading">>({});
+  const [sortDir, setSortDir] = useState<SortDirection>(() => loadSortDirection("settings-vpc-configs"));
+
+  const loadConfigs = () => {
+    setLoading(true);
+    settingsApi.listVpcConfigs()
+      .then(setConfigs)
+      .catch(() => toast.error("Failed to load VPC configurations"))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => { loadConfigs(); }, []);
+
+  const resetForm = () => {
+    setForm(EMPTY_FORM_STATE);
+    setShowAddForm(false);
+    setEditingId(null);
+  };
+
+  const startEdit = (cfg: VpcConfig) => {
+    setEditingId(cfg.id);
+    setForm(configToFormState(cfg));
+    setShowAddForm(false);
+    setExpandedId(null);
+  };
+
+  const handleSave = async () => {
+    if (!form.name.trim() || !form.vpc_id.trim()) return;
+    setSubmitting(true);
+    const request = formToRequest(form);
+    try {
+      if (editingId !== null) {
+        const updated = await settingsApi.updateVpcConfig(editingId, request);
+        setConfigs((prev) => prev.map((c) => c.id === editingId ? updated : c));
+        setDetailCache((prev) => { const next = { ...prev }; delete next[editingId]; return next; });
+        toast.success("VPC configuration updated");
+      } else {
+        const created = await settingsApi.createVpcConfig(request);
+        setConfigs((prev) => [...prev, created]);
+        toast.success("VPC configuration created");
+      }
+      resetForm();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to save");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const toggleExpand = (id: number) => {
+    if (expandedId === id) {
+      setExpandedId(null);
+      return;
+    }
+    setExpandedId(id);
+    if (!detailCache[id]) {
+      setDetailCache((prev) => ({ ...prev, [id]: "loading" }));
+      settingsApi.getVpcConfigDetail(id)
+        .then((d) => setDetailCache((prev) => ({ ...prev, [id]: d })))
+        .catch(() => setDetailCache((prev) => { const next = { ...prev }; delete next[id]; return next; }));
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    setSubmitting(true);
+    try {
+      await settingsApi.deleteVpcConfig(id);
+      setConfigs((prev) => prev.filter((c) => c.id !== id));
+      setConfirmDeleteId(null);
+      toast.success("VPC configuration deleted");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to delete");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleJsonApply = (json: string): string | null => {
+    try {
+      const obj = JSON.parse(json) as Record<string, unknown>;
+      setForm((prev) => ({
+        name: typeof obj.name === "string" ? obj.name : prev.name,
+        description: typeof obj.description === "string" ? obj.description : prev.description,
+        vpc_id: typeof obj.vpc_id === "string" ? obj.vpc_id : prev.vpc_id,
+        subnet_ids_raw: Array.isArray(obj.subnet_ids)
+          ? joinIds(obj.subnet_ids as string[])
+          : typeof obj.subnet_ids === "string"
+          ? obj.subnet_ids
+          : prev.subnet_ids_raw,
+        sg_ids_raw: Array.isArray(obj.sg_ids)
+          ? joinIds(obj.sg_ids as string[])
+          : typeof obj.sg_ids === "string"
+          ? obj.sg_ids
+          : prev.sg_ids_raw,
+      }));
+      return null;
+    } catch {
+      return "Invalid JSON. Expected a VPC configuration object.";
+    }
+  };
+
+  const handleJsonExport = (): string => {
+    // When editing, export the saved record; otherwise export current form state.
+    if (editingId !== null) {
+      const saved = configs.find((c) => c.id === editingId);
+      if (saved) {
+        return JSON.stringify({
+          name: saved.name,
+          description: saved.description || undefined,
+          vpc_id: saved.vpc_id,
+          subnet_ids: saved.subnet_ids,
+          sg_ids: saved.sg_ids,
+        }, null, 2);
+      }
+    }
+    const req = formToRequest(form);
+    return JSON.stringify({
+      name: req.name || undefined,
+      description: req.description || undefined,
+      vpc_id: req.vpc_id || undefined,
+      subnet_ids: req.subnet_ids.length > 0 ? req.subnet_ids : undefined,
+      sg_ids: req.sg_ids.length > 0 ? req.sg_ids : undefined,
+    }, null, 2);
+  };
+
+  if (loading) {
+    return <div className="space-y-3">{Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-12" />)}</div>;
+  }
+
+  const isEditing = editingId !== null;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-medium">VPC Configurations</h3>
+          <p className="text-xs text-muted-foreground mt-1">
+            Named VPC configurations approved for use in Loom.<br />
+            Builders select from these when deploying VPC-enabled agents instead of entering subnet and security group IDs directly.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0 ml-4">
+          <SortButton direction={sortDir} onClick={() => setSortDir(toggleSortDirection("settings-vpc-configs", sortDir))} />
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => { resetForm(); setShowAddForm(!showAddForm); }}
+            disabled={readOnly}
+          >
+            <Plus className="h-3.5 w-3.5 mr-1" />
+            Add Config
+          </Button>
+        </div>
+      </div>
+
+      {(showAddForm || isEditing) && (
+        <Card>
+          <CardContent className="pt-4 space-y-3">
+            <JsonConfigSection
+              onApply={handleJsonApply}
+              onExport={handleJsonExport}
+              placeholder='{"name": "prod-private", "vpc_id": "vpc-xxxxxxxx", "subnet_ids": ["subnet-aaa", "subnet-bbb"], "sg_ids": ["sg-xxx"]}'
+            />
+            <div className="grid grid-cols-2 gap-2">
+              <Input
+                placeholder="Name (e.g. prod-private)"
+                value={form.name}
+                onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+              />
+              <Input
+                placeholder="Description (optional)"
+                value={form.description}
+                onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+              />
+            </div>
+            <Input
+              placeholder="VPC ID (vpc-xxxxxxxx)"
+              value={form.vpc_id}
+              onChange={(e) => setForm((f) => ({ ...f, vpc_id: e.target.value }))}
+              className="font-mono text-xs"
+            />
+            <Input
+              placeholder="Subnet IDs (comma-separated, e.g. subnet-aaa, subnet-bbb)"
+              value={form.subnet_ids_raw}
+              onChange={(e) => setForm((f) => ({ ...f, subnet_ids_raw: e.target.value }))}
+              className="font-mono text-xs"
+            />
+            <Input
+              placeholder="Security group IDs (comma-separated, e.g. sg-xxx, sg-yyy)"
+              value={form.sg_ids_raw}
+              onChange={(e) => setForm((f) => ({ ...f, sg_ids_raw: e.target.value }))}
+              className="font-mono text-xs"
+            />
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                onClick={handleSave}
+                disabled={submitting || !form.name.trim() || !form.vpc_id.trim()}
+              >
+                {submitting ? "Saving..." : isEditing ? "Update" : "Create"}
+              </Button>
+              <Button size="sm" variant="ghost" onClick={resetForm}>
+                Cancel
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {configs.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-8">No VPC configurations yet. Add one above.</p>
+      ) : (
+        <SortableCardGrid
+          items={configs}
+          getId={(c) => c.id.toString()}
+          getName={(c) => c.name}
+          storageKey="settings-vpc-configs"
+          sortDirection={sortDir}
+          onSortDirectionChange={(d) => { if (d) { setSortDir(d); saveSortDirection("settings-vpc-configs", d); } }}
+          className="grid gap-2"
+          renderItem={(cfg) => (
+            <Card className="relative py-3 gap-1 transition-colors hover:bg-accent/50">
+              <CardHeader className="gap-1 pb-2">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <button
+                      type="button"
+                      onClick={() => toggleExpand(cfg.id)}
+                      className="text-muted-foreground hover:text-foreground"
+                    >
+                      {expandedId === cfg.id ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+                    </button>
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium truncate">{cfg.name}</div>
+                      <div className="text-xs text-muted-foreground font-mono truncate">{cfg.vpc_id}</div>
+                    </div>
+                  </div>
+                  {!readOnly && (
+                    <div className="flex items-center gap-1 shrink-0">
+                      <button
+                        type="button"
+                        onClick={() => startEdit(cfg)}
+                        className="text-muted-foreground/50 hover:text-foreground transition-colors"
+                        title="Edit"
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setConfirmDeleteId(cfg.id)}
+                        className="text-muted-foreground/50 hover:text-destructive transition-colors"
+                        title="Delete"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {expandedId === cfg.id && (
+                  <div className="ml-6 space-y-2">
+                    {detailCache[cfg.id] === "loading" ? (
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground py-2">
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        Loading details…
+                      </div>
+                    ) : detailCache[cfg.id] ? (() => {
+                      const detail = detailCache[cfg.id] as import("@/api/types").VpcConfigDetail;
+                      return (
+                        <>
+                          <div className="space-y-1.5">
+                            <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                              <Network className="h-3.5 w-3.5" />
+                              Subnets ({detail.subnets.length})
+                            </div>
+                            <table className="text-xs w-full border-collapse border border-border rounded">
+                              <thead>
+                                <tr className="text-muted-foreground bg-accent">
+                                  <th className="text-left font-medium px-2 py-1 border border-border">Subnet ID</th>
+                                  <th className="text-left font-medium px-2 py-1 border border-border">Availability Zone / ID</th>
+                                  <th className="text-left font-medium px-2 py-1 border border-border">CIDR</th>
+                                  <th className="text-left font-medium px-2 py-1 border border-border">Available IPs</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {detail.subnets.map((s) => (
+                                  <tr key={s.subnet_id} className="bg-background align-top">
+                                    <td className="px-2 py-0.5 font-mono border border-border">
+                                      {s.subnet_id}
+                                      {s.name && <span className="ml-1 text-muted-foreground">({s.name})</span>}
+                                    </td>
+                                    <td className="px-2 py-0.5 font-mono border border-border">
+                                      {s.availability_zone ?? "—"}
+                                      {s.availability_zone_id && (
+                                        <span className="ml-1 text-muted-foreground">({s.availability_zone_id})</span>
+                                      )}
+                                    </td>
+                                    <td className="px-2 py-0.5 font-mono border border-border">{s.cidr_block ?? "—"}</td>
+                                    <td className="px-2 py-0.5 border border-border text-muted-foreground">{s.available_ips ?? "—"}</td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </div>
+                          {detail.security_groups.map((sg) => (
+                            <div key={sg.sg_id} className="space-y-2">
+                              <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                                <Shield className="h-3.5 w-3.5" />
+                                {sg.sg_id}{sg.name ? ` — ${sg.name}` : ""}
+                              </div>
+                              <SgRulesTable rules={sg.ingress} label="Inbound rules" icon={<LogIn className="h-3 w-3" />} />
+                              <SgRulesTable rules={sg.egress} label="Outbound rules" icon={<LogOut className="h-3 w-3" />} />
+                            </div>
+                          ))}
+                        </>
+                      );
+                    })() : (
+                      <div className="space-y-1.5">
+                        <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                          <Network className="h-3.5 w-3.5" />
+                          Subnets ({cfg.subnet_ids.length})
+                        </div>
+                        <table className="text-xs w-full border-collapse border border-border rounded">
+                          <tbody>
+                            {cfg.subnet_ids.map((id) => (
+                              <tr key={id} className="bg-background">
+                                <td className="px-2 py-0.5 font-mono border border-border">{id}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                        <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground pt-1">
+                          <Shield className="h-3.5 w-3.5" />
+                          Security Groups ({cfg.sg_ids.length})
+                        </div>
+                        <table className="text-xs w-full border-collapse border border-border rounded">
+                          <tbody>
+                            {cfg.sg_ids.map((id) => (
+                              <tr key={id} className="bg-background">
+                                <td className="px-2 py-0.5 font-mono border border-border">{id}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    )}
+                  </div>
+                )}
+                {confirmDeleteId === cfg.id && (
+                  <div className="flex items-center justify-end gap-2 pt-1">
+                    <Button size="sm" variant="ghost" className="h-6 text-xs" onClick={() => setConfirmDeleteId(null)}>
+                      Cancel
+                    </Button>
+                    <Button size="sm" variant="destructive" className="h-6 text-xs" onClick={() => handleDelete(cfg.id)} disabled={submitting}>
+                      Confirm
+                    </Button>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -12,10 +12,15 @@ import { Button } from "@/components/ui/button";
 import { listSiteSettings, updateSiteSetting, getRegistryConfig, updateRegistryConfig, getEnabledModels, updateEnabledModels } from "@/api/settings";
 import { groupModels } from "@/lib/models";
 import type { ModelOption } from "@/api/types";
+import { VpcConfigPanel } from "@/components/VpcConfigPanel";
+
+type SettingsTab = "general" | "models" | "networking" | "infrastructure";
 
 export function SettingsPage() {
   const { timezone, setTimezone } = useTimezone();
   const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  const [activeTab, setActiveTab] = useState<SettingsTab>("general");
 
   const [cpuIdleDiscount, setCpuIdleDiscount] = useState("75");
   const [cpuIdleSaved, setCpuIdleSaved] = useState(false);
@@ -108,191 +113,231 @@ export function SettingsPage() {
     }
   };
 
+  const tabs: { key: SettingsTab; label: string }[] = [
+    { key: "general", label: "General" },
+    { key: "models", label: "Models" },
+    { key: "networking", label: "Networking" },
+    { key: "infrastructure", label: "Infrastructure" },
+  ];
+
   return (
     <div className="space-y-6">
       <div>
         <h2 className="text-lg font-semibold">Settings</h2>
-        <p className="text-sm text-muted-foreground">Manage display and cost preferences.</p>
+        <p className="text-sm text-muted-foreground">Manage preferences, models, networking, and infrastructure.</p>
       </div>
 
-      <div className="space-y-4">
-        <div>
-          <h3 className="text-sm font-medium">Preferences</h3>
-          <p className="text-xs text-muted-foreground mt-1">
-            Appearance and display settings.
-          </p>
-        </div>
-        <div className="flex gap-4">
-          <div className="space-y-1">
-            <label className="text-xs text-muted-foreground">Timezone</label>
-            <Select value={timezone} onValueChange={(v) => setTimezone(v as TimezonePreference)}>
-              <SelectTrigger className="h-8 w-[200px] text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="local">{localTz}</SelectItem>
-                <SelectItem value="UTC">UTC</SelectItem>
-              </SelectContent>
-            </Select>
+      <div className="flex rounded-md border text-sm w-fit" role="tablist">
+        {tabs.map((tab, i) => (
+          <button
+            key={tab.key}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.key}
+            className={`px-4 py-1.5 transition-colors ${
+              i === 0 ? "rounded-l-md" : ""
+            } ${
+              i === tabs.length - 1 ? "rounded-r-md" : ""
+            } ${
+              activeTab === tab.key
+                ? "bg-primary text-primary-foreground"
+                : "hover:bg-accent"
+            }`}
+            onClick={() => setActiveTab(tab.key)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === "general" && (
+        <div className="space-y-6">
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-sm font-medium">Preferences</h3>
+              <p className="text-xs text-muted-foreground mt-1">
+                Appearance and display settings.
+              </p>
+            </div>
+            <div className="flex gap-4">
+              <div className="space-y-1">
+                <label className="text-xs text-muted-foreground">Timezone</label>
+                <Select value={timezone} onValueChange={(v) => setTimezone(v as TimezonePreference)}>
+                  <SelectTrigger className="h-8 w-[200px] text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="local">{localTz}</SelectItem>
+                    <SelectItem value="UTC">UTC</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-sm font-medium">Cost Estimation</h3>
+              <p className="text-xs text-muted-foreground mt-1">
+                Configure assumptions for runtime cost calculations.
+              </p>
+            </div>
+            <div className="flex gap-4 items-end">
+              <div className="space-y-1">
+                <label className="text-xs text-muted-foreground">CPU I/O Wait Discount (%)</label>
+                <div className="flex items-center gap-2">
+                  <Input
+                    type="number"
+                    min={0}
+                    max={99}
+                    className="h-8 w-[100px] text-xs font-mono"
+                    value={cpuIdleDiscount}
+                    onChange={(e) => setCpuIdleDiscount(e.target.value)}
+                    onBlur={(e) => void saveCpuIdleDiscount(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === "Enter") void saveCpuIdleDiscount(cpuIdleDiscount); }}
+                  />
+                  {cpuIdleSaved && (
+                    <span className="text-xs text-green-600 dark:text-green-400">Saved</span>
+                  )}
+                </div>
+                <p className="text-[10px] text-muted-foreground">
+                  Assumed % of CPU time spent waiting on I/O (e.g., model API calls). Applied as a discount to runtime CPU cost across estimates and actuals. Range: 0–99.
+                </p>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
-      <div className="space-y-4">
-        <div>
-          <h3 className="text-sm font-medium">Cost Estimation</h3>
-          <p className="text-xs text-muted-foreground mt-1">
-            Configure assumptions for runtime cost calculations.
-          </p>
-        </div>
-        <div className="flex gap-4 items-end">
-          <div className="space-y-1">
-            <label className="text-xs text-muted-foreground">CPU I/O Wait Discount (%)</label>
-            <div className="flex items-center gap-2">
-              <Input
-                type="number"
-                min={0}
-                max={99}
-                className="h-8 w-[100px] text-xs font-mono"
-                value={cpuIdleDiscount}
-                onChange={(e) => setCpuIdleDiscount(e.target.value)}
-                onBlur={(e) => void saveCpuIdleDiscount(e.target.value)}
-                onKeyDown={(e) => { if (e.key === "Enter") void saveCpuIdleDiscount(cpuIdleDiscount); }}
-              />
-              {cpuIdleSaved && (
-                <span className="text-xs text-green-600 dark:text-green-400">Saved</span>
-              )}
-            </div>
-            <p className="text-[10px] text-muted-foreground">
-              Assumed % of CPU time spent waiting on I/O (e.g., model API calls). Applied as a discount to runtime CPU cost across estimates and actuals. Range: 0–99.
+      {activeTab === "models" && (
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-sm font-medium">Enabled Models</h3>
+            <p className="text-xs text-muted-foreground mt-1">
+              Select which models are available for agent deployment and runtime selection. When none are selected, all models are available.
             </p>
           </div>
-        </div>
-      </div>
-
-      {/* Enabled Models */}
-      <div className="space-y-4">
-        <div>
-          <h3 className="text-sm font-medium">Enabled Models</h3>
-          <p className="text-xs text-muted-foreground mt-1">
-            Select which models are available for agent deployment and runtime selection. When none are selected, all models are available.
-          </p>
-        </div>
-        <div className="space-y-2">
-          {groupModels(allModels).map(([group, models]) => (
-            <div key={group} className="flex flex-wrap gap-x-4 gap-y-1 items-center">
-              <span className="text-xs font-medium text-muted-foreground w-20 shrink-0">{group}</span>
-              {models.map((m) => (
-                <label key={m.model_id} className="flex items-center gap-1.5 text-xs cursor-pointer">
-                  <input
-                    type="checkbox"
-                    className="h-3.5 w-3.5 shrink-0"
-                    checked={enabledModelIds.length === 0 || enabledModelIds.includes(m.model_id)}
-                    onChange={(e) => {
-                      setEnabledModelIds((prev) => {
-                        const current = prev.length === 0
-                          ? allModels.map((am) => am.model_id)
-                          : [...prev];
-                        if (e.target.checked) {
-                          return current.includes(m.model_id) ? current : [...current, m.model_id];
-                        }
-                        const next = current.filter((id) => id !== m.model_id);
-                        return next.length === allModels.length ? [] : next;
-                      });
-                    }}
-                  />
-                  <span>{m.display_name}</span>
-                </label>
-              ))}
-            </div>
-          ))}
-          <div className="flex items-center gap-2 pt-1">
-            <Button
-              size="sm"
-              variant="outline"
-              className="h-7 text-xs"
-              disabled={modelsSaving}
-              onClick={async () => {
-                setModelsSaving(true);
-                try {
-                  const idsToSave = enabledModelIds.length === allModels.length ? [] : enabledModelIds;
-                  const config = await updateEnabledModels(idsToSave);
-                  setEnabledModelIds(config.model_ids);
-                  setModelsSaved(true);
-                  setTimeout(() => setModelsSaved(false), 2000);
-                } finally {
-                  setModelsSaving(false);
-                }
-              }}
-            >
-              Save
-            </Button>
-            {modelsSaved && (
-              <span className="text-xs text-green-600 dark:text-green-400">Saved</span>
-            )}
-          </div>
-          <p className="text-[10px] text-muted-foreground">
-            {enabledModelIds.length === 0
-              ? "All models are currently available."
-              : `${enabledModelIds.length} of ${allModels.length} models enabled.`}
-          </p>
-        </div>
-      </div>
-
-      {/* Registry Configuration section */}
-      <div className="space-y-4">
-        <div>
-          <h3 className="text-sm font-medium">Agent Registry</h3>
-          <p className="text-xs text-muted-foreground mt-1">
-            Configure AWS Agent Registry for governance and discovery. When enabled, agents, MCP servers, and A2A agents must be approved in the registry before they can be used by end users.
-          </p>
-        </div>
-        <div className="space-y-3">
-          <div className="space-y-1">
-            <label className="text-xs text-muted-foreground">Registry ARN</label>
-            <div className="flex items-center gap-2">
-              <Input
-                type="text"
-                className="h-8 w-[625px] text-xs font-mono"
-                placeholder="arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/loom-registry"
-                value={registryArn}
-                onChange={(e) => setRegistryArn(e.target.value)}
-                onKeyDown={(e) => { if (e.key === "Enter") void saveRegistryConfig(); }}
-              />
-              <Button size="sm" variant="outline" className="h-8 text-xs" onClick={() => void saveRegistryConfig()}>
+          <div className="space-y-2">
+            {groupModels(allModels).map(([group, models]) => (
+              <div key={group} className="flex flex-wrap gap-x-4 gap-y-1 items-center">
+                <span className="text-xs font-medium text-muted-foreground w-20 shrink-0">{group}</span>
+                {models.map((m) => (
+                  <label key={m.model_id} className="flex items-center gap-1.5 text-xs cursor-pointer">
+                    <input
+                      type="checkbox"
+                      className="h-3.5 w-3.5 shrink-0"
+                      checked={enabledModelIds.length === 0 || enabledModelIds.includes(m.model_id)}
+                      onChange={(e) => {
+                        setEnabledModelIds((prev) => {
+                          const current = prev.length === 0
+                            ? allModels.map((am) => am.model_id)
+                            : [...prev];
+                          if (e.target.checked) {
+                            return current.includes(m.model_id) ? current : [...current, m.model_id];
+                          }
+                          const next = current.filter((id) => id !== m.model_id);
+                          return next.length === allModels.length ? [] : next;
+                        });
+                      }}
+                    />
+                    <span>{m.display_name}</span>
+                  </label>
+                ))}
+              </div>
+            ))}
+            <div className="flex items-center gap-2 pt-1">
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 text-xs"
+                disabled={modelsSaving}
+                onClick={async () => {
+                  setModelsSaving(true);
+                  try {
+                    const idsToSave = enabledModelIds.length === allModels.length ? [] : enabledModelIds;
+                    const config = await updateEnabledModels(idsToSave);
+                    setEnabledModelIds(config.model_ids);
+                    setModelsSaved(true);
+                    setTimeout(() => setModelsSaved(false), 2000);
+                  } finally {
+                    setModelsSaving(false);
+                  }
+                }}
+              >
                 Save
               </Button>
-              {registryEnabled && !confirmingDisable && (
-                <Button size="sm" variant="ghost" className="h-8 text-xs text-destructive" onClick={() => setConfirmingDisable(true)}>
-                  Disable
-                </Button>
-              )}
-              {confirmingDisable && (
-                <>
-                  <span className="text-xs text-destructive">Disable registry?</span>
-                  <Button size="sm" variant="destructive" className="h-6 text-xs" onClick={() => { setConfirmingDisable(false); void disableRegistry(); }}>
-                    Confirm
-                  </Button>
-                  <Button size="sm" variant="ghost" className="h-6 text-xs" onClick={() => setConfirmingDisable(false)}>
-                    Cancel
-                  </Button>
-                </>
-              )}
-              {registrySaved && (
+              {modelsSaved && (
                 <span className="text-xs text-green-600 dark:text-green-400">Saved</span>
               )}
             </div>
-            {registryError && (
-              <p className="text-xs text-destructive">{registryError}</p>
-            )}
             <p className="text-[10px] text-muted-foreground">
-              {registryEnabled
-                ? `Registry enabled (ID: ${registryId}). Governance workflows are active.`
-                : "No registry configured. All resources are available without registry approval."}
+              {enabledModelIds.length === 0
+                ? "All models are currently available."
+                : `${enabledModelIds.length} of ${allModels.length} models enabled.`}
             </p>
           </div>
         </div>
-      </div>
+      )}
+
+      {activeTab === "networking" && (
+        <VpcConfigPanel />
+      )}
+
+      {activeTab === "infrastructure" && (
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-sm font-medium">Agent Registry</h3>
+            <p className="text-xs text-muted-foreground mt-1">
+              Configure AWS Agent Registry for governance and discovery. When enabled, agents, MCP servers, and A2A agents must be approved in the registry before they can be used by end users.
+            </p>
+          </div>
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">Registry ARN</label>
+              <div className="flex items-center gap-2">
+                <Input
+                  type="text"
+                  className="h-8 w-[625px] text-xs font-mono"
+                  placeholder="arn:aws:bedrock-agentcore:us-east-1:123456789012:registry/loom-registry"
+                  value={registryArn}
+                  onChange={(e) => setRegistryArn(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === "Enter") void saveRegistryConfig(); }}
+                />
+                <Button size="sm" variant="outline" className="h-8 text-xs" onClick={() => void saveRegistryConfig()}>
+                  Save
+                </Button>
+                {registryEnabled && !confirmingDisable && (
+                  <Button size="sm" variant="ghost" className="h-8 text-xs text-destructive" onClick={() => setConfirmingDisable(true)}>
+                    Disable
+                  </Button>
+                )}
+                {confirmingDisable && (
+                  <>
+                    <span className="text-xs text-destructive">Disable registry?</span>
+                    <Button size="sm" variant="destructive" className="h-6 text-xs" onClick={() => { setConfirmingDisable(false); void disableRegistry(); }}>
+                      Confirm
+                    </Button>
+                    <Button size="sm" variant="ghost" className="h-6 text-xs" onClick={() => setConfirmingDisable(false)}>
+                      Cancel
+                    </Button>
+                  </>
+                )}
+                {registrySaved && (
+                  <span className="text-xs text-green-600 dark:text-green-400">Saved</span>
+                )}
+              </div>
+              {registryError && (
+                <p className="text-xs text-destructive">{registryError}</p>
+              )}
+              <p className="text-[10px] text-muted-foreground">
+                {registryEnabled
+                  ? `Registry enabled (ID: ${registryId}). Governance workflows are active.`
+                  : "No registry configured. All resources are available without registry approval."}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/shared/etc/environment.sh.example
+++ b/shared/etc/environment.sh.example
@@ -70,6 +70,24 @@ P_ECS_STACK=loom-ecs-cluster
 P_ECS_TEMPLATE=iac/ecs.yaml
 P_ECS_OUTPUT=iac/ecs_output.yaml
 
+# Agent security group stack configuration
+# Deploys a security group for VPC-mode AgentCore Runtime agents.
+# Use the output oSecurityGroupId when creating a VPC configuration in Loom Settings → Networking.
+# Leave ingress parameters empty to omit those rules (only set what you need).
+P_AGENT_SG_STACK=loom-agent-sg
+P_AGENT_SG_TEMPLATE=iac/security_group.yaml
+P_AGENT_SG_OUTPUT=iac/security_group_output.yaml
+# CIDR ingress — one CIDR per port (e.g. 10.0.0.0/8); leave empty to omit
+P_AGENT_SG_HTTPS_CIDR=
+P_AGENT_SG_HTTP_CIDR=
+P_AGENT_SG_MCP_CIDR=
+P_AGENT_SG_A2A_CIDR=
+# Security group ingress — one source SG ID per port; leave empty to omit
+P_AGENT_SG_HTTPS_SOURCE_SG=
+P_AGENT_SG_HTTP_SOURCE_SG=
+P_AGENT_SG_MCP_SOURCE_SG=
+P_AGENT_SG_A2A_SOURCE_SG=
+
 # Loom configurations
 P_LOOM_ARTIFACT_BUCKET=$(LOOM_ARTIFACT_BUCKET)
 

--- a/shared/iac/privatelink.yaml
+++ b/shared/iac/privatelink.yaml
@@ -1,0 +1,124 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  PrivateLink ingress for Loom AgentCore Runtime agents.
+  Creates a Network Load Balancer (NLB) and VPC Endpoint Service so that
+  resources inside a VPC can invoke agents privately without traversing the
+  public internet. Managed separately by the networking team; Loom agents
+  assume the endpoint service already exists.
+
+Parameters:
+  pVpcId:
+    Type: String
+    Description: VPC ID where the NLB will be deployed
+  pPrivateSubnetIds:
+    Type: CommaDelimitedList
+    Description: Comma-separated list of private subnet IDs for the NLB
+  pAgentRuntimePort:
+    Type: Number
+    Default: 443
+    Description: Port that AgentCore Runtime listens on (forwarded by the NLB)
+  pStackName:
+    Type: String
+    Default: loom-privatelink
+    Description: Logical name used for resource naming
+  pTagApplication:
+    Type: String
+    Description: Value for the loom:application tag
+  pTagGroup:
+    Type: String
+    Description: Value for the loom:group tag
+  pTagOwner:
+    Type: String
+    Description: Value for the loom:owner tag
+
+Resources:
+
+  # ---------------------------------------------------------------------------
+  # Network Load Balancer
+  # ---------------------------------------------------------------------------
+  NetworkLoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Sub "${pStackName}-nlb"
+      Type: network
+      Scheme: internal
+      Subnets: !Ref pPrivateSubnetIds
+      LoadBalancerAttributes:
+        - Key: load_balancing.cross_zone.enabled
+          Value: "true"
+      Tags:
+        - Key: Name
+          Value: !Sub "${pStackName}-nlb"
+        - Key: loom:application
+          Value: !Ref pTagApplication
+        - Key: loom:group
+          Value: !Ref pTagGroup
+        - Key: loom:owner
+          Value: !Ref pTagOwner
+
+  NlbTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub "${pStackName}-tg"
+      VpcId: !Ref pVpcId
+      Protocol: TCP
+      Port: !Ref pAgentRuntimePort
+      TargetType: ip
+      HealthCheckProtocol: TCP
+      HealthCheckPort: !Sub "${pAgentRuntimePort}"
+      HealthCheckIntervalSeconds: 30
+      HealthyThresholdCount: 3
+      UnhealthyThresholdCount: 3
+      Tags:
+        - Key: loom:application
+          Value: !Ref pTagApplication
+        - Key: loom:group
+          Value: !Ref pTagGroup
+        - Key: loom:owner
+          Value: !Ref pTagOwner
+
+  NlbListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref NetworkLoadBalancer
+      Protocol: TCP
+      Port: !Ref pAgentRuntimePort
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref NlbTargetGroup
+
+  # ---------------------------------------------------------------------------
+  # VPC Endpoint Service
+  # ---------------------------------------------------------------------------
+  VpcEndpointService:
+    Type: AWS::EC2::VPCEndpointService
+    Properties:
+      NetworkLoadBalancerArns:
+        - !Ref NetworkLoadBalancer
+      AcceptanceRequired: false
+      Tags:
+        - Key: Name
+          Value: !Sub "${pStackName}-endpoint-service"
+        - Key: loom:application
+          Value: !Ref pTagApplication
+        - Key: loom:group
+          Value: !Ref pTagGroup
+        - Key: loom:owner
+          Value: !Ref pTagOwner
+
+Outputs:
+  oNlbArn:
+    Description: ARN of the Network Load Balancer
+    Value: !Ref NetworkLoadBalancer
+  oNlbDnsName:
+    Description: DNS name of the Network Load Balancer
+    Value: !GetAtt NetworkLoadBalancer.DNSName
+  oVpcEndpointServiceId:
+    Description: ID of the VPC Endpoint Service
+    Value: !Ref VpcEndpointService
+  oVpcEndpointServiceName:
+    Description: Service name for consumers to use when creating a VPC endpoint (com.amazonaws.vpce.region.vpce-svc-xxx)
+    Value: !Sub "com.amazonaws.vpce.${AWS::Region}.${VpcEndpointService}"
+  oTargetGroupArn:
+    Description: ARN of the NLB target group (register AgentCore Runtime IPs here)
+    Value: !Ref NlbTargetGroup

--- a/shared/iac/role.yaml
+++ b/shared/iac/role.yaml
@@ -136,6 +136,7 @@ Resources:
                     - bedrock-agentcore:GetMemory
                     - bedrock-agentcore:GetMemoryRecord
                     - bedrock-agentcore:ListActors
+                    - bedrock-agentcore:ListEvents
                     - bedrock-agentcore:ListMemoryRecords
                     - bedrock-agentcore:ListSessions
                     - bedrock-agentcore:RetrieveMemoryRecords

--- a/shared/iac/security_group.yaml
+++ b/shared/iac/security_group.yaml
@@ -1,0 +1,239 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Security group for Loom AgentCore Runtime agents deployed in VPC network mode.
+  Allows inbound traffic on ports agents typically receive (HTTPS 443, HTTP 80,
+  MCP 3000, A2A 8080), with configurable ingress from a CIDR range and/or a
+  peer security group per port family. All outbound traffic is permitted so
+  agents can reach VPC-internal resources (RDS, ElastiCache, internal APIs)
+  and AWS service endpoints. To allow multiple CIDRs for the same port, deploy
+  additional ingress rules against the exported security group ID.
+
+Parameters:
+  pStackName:
+    Type: String
+    Default: loom-agent-sg
+    Description: Logical name used for the security group Name tag and stack exports
+  pVpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: VPC ID where the security group will be created
+
+  # ---------------------------------------------------------------------------
+  # Inbound CIDR — one CIDR string per port family (leave empty to omit)
+  # To allow multiple CIDRs for the same port, add additional rules via the
+  # AWS console or CLI using the exported oSecurityGroupId.
+  # ---------------------------------------------------------------------------
+  pAllowHttpsCidr:
+    Type: String
+    Default: ""
+    Description: >
+      CIDR range allowed to reach agents on port 443 (HTTPS / AgentCore Runtime
+      TLS endpoint). Example: 10.0.0.0/8. Leave empty to omit.
+  pAllowHttpCidr:
+    Type: String
+    Default: ""
+    Description: >
+      CIDR range allowed to reach agents on port 80 (HTTP health-check probes,
+      e.g. from an NLB). Leave empty to omit.
+  pAllowMcpCidr:
+    Type: String
+    Default: ""
+    Description: >
+      CIDR range allowed to reach agents on port 3000 (MCP Streamable HTTP /
+      SSE transport). Leave empty to omit.
+  pAllowA2aCidr:
+    Type: String
+    Default: ""
+    Description: >
+      CIDR range allowed to reach agents on port 8080 (A2A JSON-RPC over HTTP).
+      Leave empty to omit.
+
+  # ---------------------------------------------------------------------------
+  # Inbound peer security groups — one source SG per port family
+  # ---------------------------------------------------------------------------
+  pAllowHttpsFromSg:
+    Type: String
+    Default: ""
+    Description: >
+      Security group ID whose members may reach agents on port 443.
+      Typical sources: NLB ENIs, bastion hosts, peered service SGs.
+      Leave empty to omit.
+  pAllowHttpFromSg:
+    Type: String
+    Default: ""
+    Description: >
+      Security group ID whose members may reach agents on port 80 (health checks).
+      Leave empty to omit.
+  pAllowMcpFromSg:
+    Type: String
+    Default: ""
+    Description: >
+      Security group ID whose members may reach agents on port 3000 (MCP).
+      Leave empty to omit.
+  pAllowA2aFromSg:
+    Type: String
+    Default: ""
+    Description: >
+      Security group ID whose members may reach agents on port 8080 (A2A).
+      Leave empty to omit.
+
+  # ---------------------------------------------------------------------------
+  # Tags
+  # ---------------------------------------------------------------------------
+  pTagApplication:
+    Type: String
+    Description: Value for the loom:application tag
+
+  pTagGroup:
+    Type: String
+    Description: Value for the loom:group tag
+
+  pTagOwner:
+    Type: String
+    Description: Value for the loom:owner tag
+
+Conditions:
+  HasHttpsCidr:   !Not [!Equals [!Ref pAllowHttpsCidr, ""]]
+  HasHttpCidr:    !Not [!Equals [!Ref pAllowHttpCidr, ""]]
+  HasMcpCidr:     !Not [!Equals [!Ref pAllowMcpCidr, ""]]
+  HasA2aCidr:     !Not [!Equals [!Ref pAllowA2aCidr, ""]]
+  HasHttpsSg:     !Not [!Equals [!Ref pAllowHttpsFromSg, ""]]
+  HasHttpSg:      !Not [!Equals [!Ref pAllowHttpFromSg, ""]]
+  HasMcpSg:       !Not [!Equals [!Ref pAllowMcpFromSg, ""]]
+  HasA2aSg:       !Not [!Equals [!Ref pAllowA2aFromSg, ""]]
+
+Resources:
+  # ---------------------------------------------------------------------------
+  # Security group — no inline ingress rules; each is a separate conditional
+  # resource so only enabled rules are created.
+  # ---------------------------------------------------------------------------
+  AgentSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: !Sub "${pStackName}"
+      GroupDescription: "Loom AgentCore Runtime agents - inbound HTTPS 443, HTTP 80, MCP 3000, A2A 8080"
+      VpcId: !Ref pVpcId
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          CidrIp: "0.0.0.0/0"
+          Description: Allow all outbound (agents reach VPC resources and AWS endpoints)
+      Tags:
+        - Key: Name
+          Value: !Sub "${pStackName}"
+        - Key: loom:application
+          Value: !Ref pTagApplication
+        - Key: loom:group
+          Value: !Ref pTagGroup
+        - Key: loom:owner
+          Value: !Ref pTagOwner
+
+  # ---------------------------------------------------------------------------
+  # HTTPS (443) — AgentCore Runtime TLS / HTTP invocation endpoint
+  # ---------------------------------------------------------------------------
+  IngressHttpsCidr:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: HasHttpsCidr
+    Properties:
+      GroupId: !Ref AgentSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      CidrIp: !Ref pAllowHttpsCidr
+      Description: !Sub "HTTPS ingress from ${pAllowHttpsCidr}"
+  IngressHttpsSg:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: HasHttpsSg
+    Properties:
+      GroupId: !Ref AgentSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      SourceSecurityGroupId: !Ref pAllowHttpsFromSg
+      Description: !Sub "HTTPS ingress from security group ${pAllowHttpsFromSg}"
+
+  # ---------------------------------------------------------------------------
+  # HTTP (80) — health-check probes (e.g. NLB target health, ALB /health)
+  # ---------------------------------------------------------------------------
+  IngressHttpCidr:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: HasHttpCidr
+    Properties:
+      GroupId: !Ref AgentSecurityGroup
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+      CidrIp: !Ref pAllowHttpCidr
+      Description: !Sub "HTTP ingress from ${pAllowHttpCidr} (health checks)"
+  IngressHttpSg:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: HasHttpSg
+    Properties:
+      GroupId: !Ref AgentSecurityGroup
+      IpProtocol: tcp
+      FromPort: 80
+      ToPort: 80
+      SourceSecurityGroupId: !Ref pAllowHttpFromSg
+      Description: !Sub "HTTP ingress from security group ${pAllowHttpFromSg}"
+
+  # ---------------------------------------------------------------------------
+  # MCP (3000) — Model Context Protocol Streamable HTTP / SSE transport
+  # ---------------------------------------------------------------------------
+  IngressMcpCidr:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: HasMcpCidr
+    Properties:
+      GroupId: !Ref AgentSecurityGroup
+      IpProtocol: tcp
+      FromPort: 3000
+      ToPort: 3000
+      CidrIp: !Ref pAllowMcpCidr
+      Description: !Sub "MCP (port 3000) ingress from ${pAllowMcpCidr}"
+
+  IngressMcpSg:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: HasMcpSg
+    Properties:
+      GroupId: !Ref AgentSecurityGroup
+      IpProtocol: tcp
+      FromPort: 3000
+      ToPort: 3000
+      SourceSecurityGroupId: !Ref pAllowMcpFromSg
+      Description: !Sub "MCP ingress from security group ${pAllowMcpFromSg}"
+
+  # ---------------------------------------------------------------------------
+  # A2A (8080) — Agent-to-Agent JSON-RPC over HTTP
+  # ---------------------------------------------------------------------------
+  IngressA2aCidr:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: HasA2aCidr
+    Properties:
+      GroupId: !Ref AgentSecurityGroup
+      IpProtocol: tcp
+      FromPort: 8080
+      ToPort: 8080
+      CidrIp: !Ref pAllowA2aCidr
+      Description: !Sub "A2A (port 8080) ingress from ${pAllowA2aCidr}"
+  IngressA2aSg:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: HasA2aSg
+    Properties:
+      GroupId: !Ref AgentSecurityGroup
+      IpProtocol: tcp
+      FromPort: 8080
+      ToPort: 8080
+      SourceSecurityGroupId: !Ref pAllowA2aFromSg
+      Description: !Sub "A2A ingress from security group ${pAllowA2aFromSg}"
+
+Outputs:
+  oSecurityGroupId:
+    Description: >
+      Security group ID — use this value when creating a VPC configuration in
+      Loom Settings → Networking. Also use it as a source SG for other stacks
+      that need to accept traffic from these agents.
+    Value: !Ref AgentSecurityGroup
+    Export:
+      Name: !Sub "${pStackName}-sg-id"
+  oVpcId:
+    Description: VPC ID the security group belongs to
+    Value: !Ref pVpcId
+    Export:
+      Name: !Sub "${pStackName}-vpc-id"

--- a/shared/makefile
+++ b/shared/makefile
@@ -256,6 +256,50 @@ infra.delete:
 		--stack-name $(P_INFRA_STACK) \
 		--no-prompts
 
+# PrivateLink ingress (NLB + VPC Endpoint Service — deployed separately by networking team)
+privatelink: privatelink.package privatelink.deploy
+
+privatelink.package:
+	sam package \
+		--profile $(PROFILE) \
+		--region $(REGION) \
+		--template-file $(P_PRIVATELINK_TEMPLATE) \
+		--output-template-file $(P_PRIVATELINK_OUTPUT) \
+		--s3-bucket $(BUCKET) \
+		--s3-prefix $(P_PRIVATELINK_STACK)
+
+privatelink.deploy:
+	sam deploy \
+		--profile $(PROFILE) \
+		--region $(REGION) \
+		--template-file $(P_PRIVATELINK_OUTPUT) \
+		--stack-name $(P_PRIVATELINK_STACK) \
+		--s3-bucket $(BUCKET) \
+		--s3-prefix $(P_PRIVATELINK_STACK) \
+		--parameter-overrides \
+			pVpcId=$(P_INFRA_VPC_ID) \
+			pPrivateSubnetIds=$(P_PRIVATELINK_PRIVATE_SUBNET_IDS) \
+			pStackName=$(P_PRIVATELINK_STACK) \
+			pTagApplication=$(P_TAG_APPLICATION) \
+			pTagGroup=$(P_TAG_GROUP) \
+			pTagOwner=$(P_TAG_OWNER) \
+		--no-confirm-changeset
+
+privatelink.outputs:
+	@aws cloudformation describe-stacks \
+		--profile $(PROFILE) \
+		--region $(REGION) \
+		--stack-name $(P_PRIVATELINK_STACK) \
+		--query 'Stacks[0].Outputs' \
+		--output json | jq .
+
+privatelink.delete:
+	sam delete \
+		--profile $(PROFILE) \
+		--region $(REGION) \
+		--stack-name $(P_PRIVATELINK_STACK) \
+		--no-prompts
+
 # Bedrock AgentCore service-linked role (run once per account before first agent deployment)
 agentcore.init:
 	aws iam create-service-linked-role \

--- a/shared/makefile
+++ b/shared/makefile
@@ -300,6 +300,57 @@ privatelink.delete:
 		--stack-name $(P_PRIVATELINK_STACK) \
 		--no-prompts
 
+# Agent security group (ingress rules for VPC-deployed AgentCore Runtime agents)
+security-group: security-group.package security-group.deploy
+
+security-group.package:
+	sam package \
+		--profile $(PROFILE) \
+		--region $(REGION) \
+		--template-file $(P_AGENT_SG_TEMPLATE) \
+		--output-template-file $(P_AGENT_SG_OUTPUT) \
+		--s3-bucket $(BUCKET) \
+		--s3-prefix $(P_AGENT_SG_STACK)
+
+security-group.deploy:
+	sam deploy \
+		--profile $(PROFILE) \
+		--region $(REGION) \
+		--template-file $(P_AGENT_SG_OUTPUT) \
+		--stack-name $(P_AGENT_SG_STACK) \
+		--s3-bucket $(BUCKET) \
+		--s3-prefix $(P_AGENT_SG_STACK) \
+		--parameter-overrides \
+			pVpcId=$(P_INFRA_VPC_ID) \
+			pStackName=$(P_AGENT_SG_STACK) \
+			$(if $(P_AGENT_SG_HTTPS_CIDR),pAllowHttpsCidr=$(P_AGENT_SG_HTTPS_CIDR)) \
+			$(if $(P_AGENT_SG_HTTP_CIDR),pAllowHttpCidr=$(P_AGENT_SG_HTTP_CIDR)) \
+			$(if $(P_AGENT_SG_MCP_CIDR),pAllowMcpCidr=$(P_AGENT_SG_MCP_CIDR)) \
+			$(if $(P_AGENT_SG_A2A_CIDR),pAllowA2aCidr=$(P_AGENT_SG_A2A_CIDR)) \
+			$(if $(P_AGENT_SG_HTTPS_SOURCE_SG),pAllowHttpsFromSg=$(P_AGENT_SG_HTTPS_SOURCE_SG)) \
+			$(if $(P_AGENT_SG_HTTP_SOURCE_SG),pAllowHttpFromSg=$(P_AGENT_SG_HTTP_SOURCE_SG)) \
+			$(if $(P_AGENT_SG_MCP_SOURCE_SG),pAllowMcpFromSg=$(P_AGENT_SG_MCP_SOURCE_SG)) \
+			$(if $(P_AGENT_SG_A2A_SOURCE_SG),pAllowA2aFromSg=$(P_AGENT_SG_A2A_SOURCE_SG)) \
+			pTagApplication=$(P_TAG_APPLICATION) \
+			pTagGroup=$(P_TAG_GROUP) \
+			pTagOwner=$(P_TAG_OWNER) \
+		--no-confirm-changeset
+
+security-group.outputs:
+	@aws cloudformation describe-stacks \
+		--profile $(PROFILE) \
+		--region $(REGION) \
+		--stack-name $(P_AGENT_SG_STACK) \
+		--query 'Stacks[0].Outputs' \
+		--output json | jq .
+
+security-group.delete:
+	sam delete \
+		--profile $(PROFILE) \
+		--region $(REGION) \
+		--stack-name $(P_AGENT_SG_STACK) \
+		--no-prompts
+
 # Bedrock AgentCore service-linked role (run once per account before first agent deployment)
 agentcore.init:
 	aws iam create-service-linked-role \


### PR DESCRIPTION
## Summary
- Add VPC egress support for both custom (deploy-type) and managed (harness) agents — configure subnets and security groups via named VPC config profiles
- Add PrivateLink ingress IaC (`shared/iac/privatelink.yaml`) that provisions an NLB and VPC Endpoint Service for invoking agents from within a VPC
- Harden harness deployment: OAuth2 MCP tokens injected at invocation time, CI resource conflict handling, memory `retrievalConfig` from active strategies, actor ID sanitization for Okta email subs, registry auto-registration for harness agents on READY

## Test Plan
- Deployed custom (deploy-type) agent with `network_mode=VPC` and confirmed runtime created with VPC configuration
- Deployed managed (harness) agent with `network_mode=VPC` and confirmed harness created with subnet/SG parameters
- Verified VPC config pre-populates correctly on agent edit form
- Verified Code Interpreter `ConflictException` handled by reusing existing resource
- Verified memory configuration with `retrievalConfig` built from active strategies
- Verified actor ID sanitization for Okta email-format subs (containing `@` and `.`)
- Verified harness agents auto-register in DRAFT status when registry is configured

Closes #73

Co-Authored-By: Claude <noreply@anthropic.com>